### PR TITLE
[Rewrite] sqrt(x**2) -> abs(x)  (#59)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from stratum.optimizer._numeric_rewrites import eliminate_log_exp, eliminate_exp_log
+from stratum.optimizer._numeric_rewrites import eliminate_log_exp, eliminate_exp_log, eliminate_sqrt_square
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
 import logging
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 class AlgebraicRewritesConfig:
     log_exp: bool = True
     exp_log: bool = True
+    sqrt_square: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -20,5 +21,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_log_exp(root)
     if config.exp_log:
         root = eliminate_exp_log(root)
+    if config.sqrt_square:
+        root = eliminate_sqrt_square(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -34,6 +34,28 @@ def eliminate_two_op_chain_root_safe(op1: Op, op2: Op, root: Op) -> Op:
     return root
 
 
+def replace_two_op_chain(op1: Op, op2: Op, replacement: Op):
+    """Replace op1 -> op2 with replacement: x -> replacement -> downstream."""
+    x = op1.inputs[0]
+    x.replace_output(op1, replacement)
+    replacement.add_input(x)
+    for downstream in op2.outputs:
+        replacement.add_output(downstream)
+        downstream.replace_input(op2, replacement)
+
+
+def make_replace_two_op_chain_root_safe(make_replacement):
+    """Action factory: replace a two-op chain with a new op from make_replacement()."""
+    def action(op1: Op, op2: Op, root: Op) -> Op:
+        replacement = make_replacement()
+        replace_two_op_chain(op1, op2, replacement)
+        if op2 is root:
+            root = replacement
+        return root
+    return action
+
+
+
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -43,3 +65,14 @@ eliminate_exp_log = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.EXP, NumericOpType.LOG),
     eliminate_two_op_chain_root_safe,
 )
+
+def make_abs_op():
+    return NumericOp(inputs=[], outputs=[], type=NumericOpType.ABS)
+
+_replace_with_abs = make_replace_two_op_chain_root_safe(make_abs_op)
+
+eliminate_sqrt_square = rewrite_pass(
+    match_two_op_chain(NumericOp, NumericOpType.SQUARE, NumericOpType.SQRT),
+    _replace_with_abs,
+)
+

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -66,10 +66,7 @@ eliminate_exp_log = rewrite_pass(
     eliminate_two_op_chain_root_safe,
 )
 
-def make_abs_op():
-    return NumericOp(inputs=[], outputs=[], type=NumericOpType.ABS)
-
-_replace_with_abs = make_replace_two_op_chain_root_safe(make_abs_op)
+_replace_with_abs = make_replace_two_op_chain_root_safe(lambda : NumericOp(inputs=[], outputs=[], type=NumericOpType.ABS))
 
 eliminate_sqrt_square = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.SQUARE, NumericOpType.SQRT),

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -1,4 +1,5 @@
-from stratum.optimizer.ir._ops import CallOp, Op
+from stratum.optimizer.ir._ops import BinOp, CallOp, Op
+import operator
 import numpy as np
 from enum import Enum
 
@@ -6,25 +7,46 @@ class NumericOpType(Enum):
     GENERIC = "generic"
     LOG = "log"
     EXP = "exp"
+    SQRT = "sqrt"
+    ABS = "abs"
+    SQUARE = "square"
+
 class NumericOp(Op):
     fields = ["func", "args", "kwargs", "type"]
     func = None
 
-    def __init__(self, func, args, kwargs, inputs, outputs):
-        if func is np.log:
-            self.type = NumericOpType.LOG
-            name = "log"
-        elif func is np.exp:
-            self.type = NumericOpType.EXP
-            name = "exp"
+    def __init__(self, inputs, outputs, func=None, args=(), kwargs=None, type: NumericOpType = None):
+        if func is not None:
+            if func is np.log:
+                self.type = NumericOpType.LOG
+                name = "log"
+            elif func is np.exp:
+                self.type = NumericOpType.EXP
+                name = "exp"
+            elif func is np.sqrt:
+                self.type = NumericOpType.SQRT
+                name = "sqrt"
+            elif func is np.abs:
+                self.type = NumericOpType.ABS
+                name = "abs"
+            elif func is np.square:
+                self.type = NumericOpType.SQUARE
+                name = "square"
+            else:
+                self.type = NumericOpType.GENERIC
+                self.func = func
+                name = func.__name__
+        elif type is not None:
+            if type == NumericOpType.GENERIC:
+                raise ValueError("GENERIC type requires a func")
+            self.type = type
+            name = type.value
         else:
-            self.type = NumericOpType.GENERIC
-            self.func = func
-            name = func.__name__
-        super().__init__(name=name, inputs=inputs, outputs=outputs)
+            raise ValueError("Either func or type must be provided")
 
+        super().__init__(name=name, inputs=inputs, outputs=outputs)
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = kwargs or {}
 
     def process(self, mode: str, environment: dict, inputs: list):
         if self.type == NumericOpType.GENERIC:
@@ -33,6 +55,12 @@ class NumericOp(Op):
             return np.log(inputs[0])
         elif self.type == NumericOpType.EXP:
             return np.exp(inputs[0])
+        elif self.type == NumericOpType.SQRT:
+            return np.sqrt(inputs[0])
+        elif self.type == NumericOpType.ABS:
+            return np.abs(inputs[0])
+        elif self.type == NumericOpType.SQUARE:
+            return np.square(inputs[0])
         else:
             raise ValueError(f"Unsupported numeric operation type: {self.type}")
 
@@ -44,7 +72,9 @@ def make_numeric_op(op: CallOp) -> NumericOp:
 
 def extract_numeric_op(op: Op, root: Op) -> tuple[Op, bool]:
     new_op = None
-    if isinstance(op, CallOp):
+    if isinstance(op, BinOp) and op.op is operator.pow and op.right == 2:
+        new_op = NumericOp(func=np.square, args=(), kwargs={}, inputs=op.inputs, outputs=op.outputs)
+    elif isinstance(op, CallOp):
         if op.func is np.log:
             new_op = make_numeric_op(op)
         elif op.func is np.exp:

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -4,6 +4,7 @@ import numpy as np
 from stratum.optimizer._optimize import  optimize
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
+from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 
 class TestCSE(unittest.TestCase):
 
@@ -92,6 +93,115 @@ class TestCSE(unittest.TestCase):
         config = OptConfig(
             algebraic_rewrites=True,
             algebraic_rewrite_config=AlgebraicRewritesConfig(exp_log=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)
+
+    def test_sqrt_square_via_np_square(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.square)
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        # abs(4) = 4
+        self.assertEqual(out[0].value, 4)
+
+    def test_sqrt_pow2(self):
+        df = st.as_data_op(-3)
+        t1 = df ** 2
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        # abs(-3) = 3
+        self.assertEqual(out[0].value, -3)
+
+    def test_sqrt_square_with_trailing_op(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.square)
+        t2 = t1.skb.apply_func(np.sqrt)
+        t3 = t2.skb.apply_func(np.log1p)
+
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[0].value, 4)
+
+    def test_disable_sqrt_square_rewrite(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.square)
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_sqrt_only(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_sqrt_square_produces_abs_op(self):
+        """Rewrite must insert an abs op, not identity — critical for negative inputs."""
+        df = st.as_data_op(-5)
+        t1 = df.skb.apply_func(np.square)
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.ABS)
+
+    def test_sqrt_pow2_produces_abs_op(self):
+        """BinOp(**2) → sqrt rewrite must also produce abs, not identity."""
+        df = st.as_data_op(-5)
+        t1 = df ** 2
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.ABS)
+
+    def test_no_rewrite_square_log(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.square)
+        t2 = t1.skb.apply_func(np.log)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_sqrt_exp(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.sqrt)
+        t2 = t1.skb.apply_func(np.exp)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_pow3_sqrt(self):
+        """x**3 → sqrt should not rewrite; only x**2 qualifies."""
+        df = st.as_data_op(4)
+        t1 = df ** 3
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+
+    def test_disable_sqrt_square_does_not_affect_log_exp(self):
+        """Disabling sqrt_square must not suppress other algebraic rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -24,6 +24,41 @@ class TestNumericOps(unittest.TestCase):
         with st.config(scheduler=True):
             pred.skb.make_grid_search(cv=3)
 
+    def test_to_numeric_op_abs(self):
+        data = st.as_data_op(self.df)
+        X = data[["x"]].skb.mark_as_X()
+        y = data["y"].skb.mark_as_y()
+        t1 = X.skb.apply_func(np.abs)
+        pred = t1.skb.apply(DummyRegressor(), y=y)
+
+        with st.config(scheduler=True):
+            pred.skb.make_grid_search(cv=3)
+
+    def test_process_log(self):
+        op = NumericOp(inputs=[], outputs=None, func=np.log)
+        result = op.process("fit", {}, [np.array([1.0, np.e, np.e**2])])
+        np.testing.assert_array_almost_equal(result, np.array([0.0, 1.0, 2.0]))
+
+    def test_process_exp(self):
+        op = NumericOp(inputs=[], outputs=None, func=np.exp)
+        result = op.process("fit", {}, [np.array([0.0, 1.0, 2.0])])
+        np.testing.assert_array_almost_equal(result, np.array([1.0, np.e, np.e**2]))
+
+    def test_process_sqrt(self):
+        op = NumericOp(inputs=[], outputs=None, func=np.sqrt)
+        result = op.process("fit", {}, [np.array([4.0, 9.0, 16.0])])
+        np.testing.assert_array_almost_equal(result, np.array([2.0, 3.0, 4.0]))
+
+    def test_process_abs(self):
+        op = NumericOp(inputs=[], outputs=None, func=np.abs)
+        result = op.process("fit", {}, [np.array([-3.0, 0.0, 5.0])])
+        np.testing.assert_array_almost_equal(result, np.array([3.0, 0.0, 5.0]))
+
+    def test_process_square(self):
+        op = NumericOp(inputs=[], outputs=None, func=np.square)
+        result = op.process("fit", {}, [np.array([2.0, 3.0, 4.0])])
+        np.testing.assert_array_almost_equal(result, np.array([4.0, 9.0, 16.0]))
+
     def test_unsupported_numeric_op(self):
         op = NumericOp(inputs=[], outputs=None, func=np.cos)
         op.type = "unsupported"

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -25,7 +25,7 @@ class TestNumericOps(unittest.TestCase):
             pred.skb.make_grid_search(cv=3)
 
     def test_unsupported_numeric_op(self):
-        op = NumericOp(np.cos, None, None, [], [])
+        op = NumericOp(inputs=[], outputs=None, func=np.cos)
         op.type = "unsupported"
         with self.assertRaises(ValueError):
             op.process("fit", {}, [])


### PR DESCRIPTION
Closes #59  
- New ops: SQRT, ABS, SQUARE added to NumericOpType + dispatch
 - Constructor refactor: NumericOp now accepts either a func or a type directly, enabling synthetic nodes (e.g. the replacement ABS op)
 - x**2 support: BinOp(**2) now canonicalizes to SQUARE, making it rewrite-eligible
 - New rewrite pass: eliminate_sqrt_square replaces SQUARE → SQRT chains with ABS
 - Config toggle: AlgebraicRewritesConfig.sqrt_square (default on)
 - 11 new tests