### PR TITLE
[BufferPool] Add to disk serialization with LRU eviction (#72, #73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,13 +90,18 @@ stratum/_rust_backend_native.abi3.so
 
 # Ignore input folders in benchmarks
 benchmarks/**/input/
+benchmarks-staging
 
 # Ignore any data files
 *.zip
 *.csv
 *.pdf
 *.ipynb
+*.npy
 
 # coding agents
 .cursor
 .claude
+
+# buffer pool spill directory
+**/.stratum/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "xgboost>=3.1.1",
 ]
 benchmark = [
+    "psutil>=7.2"
 ]
 dev = [
     "ipykernel>=7.3.0",

--- a/stratum/_api.py
+++ b/stratum/_api.py
@@ -49,4 +49,8 @@ def stats_printer(sched: SequentialScheduler):
         print("\n" + "=" * 80)
         print(f"Heavy hitters (sorted by time spent in DataOp evaluation):\n")
         print(table.head(FLAGS.stats_top_k).to_string(index=False))
+        print("=" * 80)
+        print("Total BufferPool overhead during execution:", sched.buffer_pool_overhead)
+        print("=" * 80 + "\n")
+        print(sched.pool.stats)
         print("=" * 80 + "\n")

--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
+import logging
 
 def _env_bool(name, default=False):
     val = os.getenv(name)
@@ -44,6 +45,7 @@ class _Flags:
     force_polars: bool = _env_bool("STRATUM_FORCE_POLARS", False)
     fast_dataops_convert: bool = True
     validate_dag: bool = True
+    buffer_pool_memory_budget: int = 0
 
 FLAGS = _Flags()
 
@@ -61,7 +63,8 @@ def set_config(rust_backend: bool | None = None,
     force_polars: bool = False,
     cse: bool = True,
     fast_dataops_convert: bool = True,
-    validate_dag: bool = True) -> None:
+    validate_dag: bool = True,
+    buffer_pool_memory_budget: int = 0) -> None:
     """Runtime toggles (synced env for Rust to read).
 
     Parameter:
@@ -135,6 +138,7 @@ def set_config(rust_backend: bool | None = None,
     FLAGS.open_graph = bool(open_graph)
     FLAGS.explain_linear_plan = bool(explain_linear_plan)
 
+    FLAGS.buffer_pool_memory_budget = int(buffer_pool_memory_budget)
     #FIXME: This should be the default. No need to set it. Remove.
     FLAGS.fast_dataops_convert = bool(fast_dataops_convert)
     FLAGS.validate_dag = bool(validate_dag)
@@ -158,6 +162,7 @@ def get_config() -> dict:
         "cse": FLAGS.cse,
         "fast_dataops_convert": FLAGS.fast_dataops_convert,
         "validate_dag": FLAGS.validate_dag,
+        "buffer_pool_memory_budget": FLAGS.buffer_pool_memory_budget,
     }
 
 @contextmanager
@@ -165,7 +170,15 @@ def config(**kwargs):
     """Temporarily override runtime config inside a context."""
     original = get_config()
     set_config(**kwargs)
+    stratum_logger = logging.getLogger("stratum")
+    prev_level = stratum_logger.level
+    if kwargs.get("DEBUG", False):
+        # set for this module stratum only
+        print("DEBUG MODE ENABLED")
+        logging.basicConfig(level=logging.INFO)
+        stratum_logger.setLevel(logging.DEBUG)
     try:
         yield
     finally:
         set_config(**original)
+        stratum_logger.setLevel(prev_level)

--- a/stratum/optimizer/ir/_ops.py
+++ b/stratum/optimizer/ir/_ops.py
@@ -640,7 +640,9 @@ class ValueOp(Op):
         raise ValueError(f"We should not clone ValueOp objects.")
 
     def process(self, mode: str, inputs: list):
-        return self.value
+        out = self.value
+        self.value = None
+        return out
 
 class MethodCallOp(Op):
     fields = ["method_name", "args", "kwargs"]

--- a/stratum/runtime/_buffer_pool.py
+++ b/stratum/runtime/_buffer_pool.py
@@ -1,51 +1,166 @@
 from __future__ import annotations
-
 import logging
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
 from typing import Any, Hashable
+
+from stratum._config import FLAGS
+from stratum.runtime._object_serialization import (
+    SpilledObject,
+    delete_object,
+    deserialize_object,
+    serialize_object,
+)
+from stratum.runtime._object_size import get_size, prettify_bytes
+
 logger = logging.getLogger(__name__)
-from stratum.runtime._object_size import get_size
+
+_DEFAULT_SPILL_ROOT = Path(".stratum/bufferpool")
+
+
+@dataclass
+class _Entry:
+    """Internal record. `data` is None iff the entry has been spilled to disk."""
+    size: int  # in-memory cost; constant after put
+    data: Any = None
+    handle: SpilledObject | None = None
+    pin_count: int = 0
+
+    @property
+    def is_spilled(self) -> bool:
+        return self.handle is not None
+
+
+@dataclass
+class BufferPoolStats:
+    """Counters/timers maintained over a BufferPool's lifetime.
+
+    Hit = `pin` served the entry directly from memory.
+    Miss = `pin` had to deserialize the entry back from disk.
+    """
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    serialize_time: float = 0.0  # cumulative seconds spent spilling
+    deserialize_time: float = 0.0  # cumulative seconds spent reloading
+    bytes_spilled: int = 0
+    bytes_loaded: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total else 0.0
+
+    def __str__(self) -> str:
+        return (
+            "BufferPool stats:\n"
+            f"  Hits:             {self.hits}\n"
+            f"  Misses:           {self.misses}\n"
+            f"  Hit rate:         {self.hit_rate * 100:.1f}%\n"
+            f"  Evictions:        {self.evictions}\n"
+            f"  Serialize time:   {self.serialize_time:.3f}s\n"
+            f"  Deserialize time: {self.deserialize_time:.3f}s\n"
+            f"  Bytes spilled:    {prettify_bytes(self.bytes_spilled)}\n"
+            f"  Bytes loaded:     {prettify_bytes(self.bytes_loaded)}"
+        )
+
 
 class BufferPool:
-    """Simple cache for intermediate buffers, will be replaced by a proper buffer in future. """
+    """Cache for intermediate buffers with LRU spill-to-disk eviction.
 
-    def __init__(self):
+    When `memory_usage` exceeds `memory_budget` (and budget > 0), the
+    least-recently-pinned unpinned entries are spilled to disk under
+    `spill_root`. A spilled entry stays in `live_variable_map` so subsequent
+    `pin` calls can transparently re-load it; only the in-memory bytes are
+    released.
+
+    `memory_budget` is sourced from `FLAGS.buffer_pool_memory_budget` at
+    construction time; a value of 0 disables eviction.
+    """
+
+    def __init__(self, spill_root: Path | str = _DEFAULT_SPILL_ROOT):
         # TODO:
         # right now our buffer pool is basically a symbol table and (main memory) puffer pool in one thing
         # once we have multiple backends, we will have to separate both
-        self.live_variable_map: dict[Hashable, Any] = {}  # key -> data
+        self.live_variable_map: OrderedDict[Hashable, _Entry] = OrderedDict()
         self._removed_count: int = 0
         self.memory_usage = 0
+        # The spill root is created lazily on the first eviction. Each spill
+        # gets a uuid4 filename prefix, so files never collide across entries,
+        # BufferPool instances, or processes sharing the same root.
+        # TODO: stale spill files from a crashed run are never reclaimed; add
+        # startup/teardown cleanup of the spill root.
+        self._spill_root = Path(spill_root)
+        self.memory_budget = FLAGS.buffer_pool_memory_budget
+        self.stats = BufferPoolStats()
 
     def put(self, key: Hashable, data: Any):
         """Store data for a key. Overwrites any existing entry."""
+        if key in self.live_variable_map:
+            self._drop(key)
         size = get_size(data)
-        self.live_variable_map[key] = (size, data)
-        # TODO we need to add a check if eviction is needed
+        self.live_variable_map[key] = _Entry(size=size, data=data)
         self.memory_usage += size
+        self.check_for_eviction()
 
     def pin(self, key: Hashable) -> Any:
-        """Retrieve stored data for a key, or None if not present and lock s.t. the intermediate is not evicted"""
-        entry = self.live_variable_map.get(key)
-        if entry:
-            return entry[1]
-        return entry
+        """Retrieve stored data for a key, or None if absent.
 
+        Locks the entry against eviction (refcounted; balance every `pin` with
+        an `unpin`). If the entry was previously spilled to disk, it is
+        deserialized back into memory.
+
+        TODO: `pin`/`unpin` (and the pin_count mutation) are not thread-safe;
+        guard the refcount and the spill/reload transition with a lock before
+        the pool is accessed from multiple threads.
+        """
+        entry = self.live_variable_map.get(key)
+        if entry is None:
+            return None
+        if entry.is_spilled:
+            logger.debug(f"Deserializing {key} into memory: {prettify_bytes(entry.size)}")
+            t0 = perf_counter()
+            entry.data = deserialize_object(entry.handle)
+            delete_object(entry.handle)
+            self.stats.deserialize_time += perf_counter() - t0
+            self.stats.misses += 1
+            self.stats.bytes_loaded += entry.size
+            entry.handle = None
+            self.memory_usage += entry.size
+        else:
+            self.stats.hits += 1
+        entry.pin_count += 1
+        self.live_variable_map.move_to_end(key)
+        return entry.data
 
     def unpin(self, key: Hashable) -> None:
         """Release a pinned buffer, allowing it to be evicted."""
-        return
+        entry = self.live_variable_map.get(key)
+        if entry is None:
+            return
+        if entry.pin_count > 0:
+            entry.pin_count -= 1
 
     def remove(self, key: Hashable) -> bool:
-        """Remove a single buffer, dropping its data."""
-        entry = self.live_variable_map.pop(key, None)
-        if entry is not None:
-            size, _ = entry
-            logger.debug(f"Removing buffer for {key}")
-            self._removed_count += 1
-            self.memory_usage -= size
-            assert self.memory_usage >= 0, "Memory usage is negative"
-            return True
-        return False
+        """Remove a single buffer, dropping its data (and any spilled file)."""
+        if key not in self.live_variable_map:
+            return False
+        self._drop(key)
+        self._removed_count += 1
+        logger.debug(f"Removing buffer for {key}")
+        assert self.memory_usage >= 0, "Memory usage is negative"
+        return True
+
+    def _drop(self, key: Hashable) -> None:
+        """Internal: free in-memory bytes and any spilled file, then unlink the entry."""
+        entry = self.live_variable_map.pop(key)
+        if entry.is_spilled:
+            delete_object(entry.handle)
+        else:
+            self.memory_usage -= entry.size
 
     def remove_all(self) -> list:
         """Remove everything, including pinned. Used at end of execution.
@@ -55,7 +170,6 @@ class BufferPool:
         removed = list(self.live_variable_map.keys())
         for key in removed:
             self.remove(key)
-        self.live_variable_map.clear()
         return removed
 
     @property
@@ -69,11 +183,45 @@ class BufferPool:
     @property
     def total_size(self) -> str:
         """Pretty print the total size of the buffer pool."""
-        units = ["B", "KB", "MB", "GB"]
-        memory_usage = self.memory_usage
-        unit = "B"
-        for unit in units:
-            if memory_usage < 1024:
-                return f"{memory_usage:.2f} {unit}"
-            memory_usage /= 1024
-        return f"{memory_usage:.2f} {unit}"
+        return prettify_bytes(self.memory_usage)
+
+    def check_for_eviction(self) -> bool:
+        """Spill LRU unpinned entries until under budget. Returns True if any evicted."""
+        if self.memory_budget <= 0 or self.memory_usage <= self.memory_budget:
+            return False
+        evicted = False
+        # OrderedDict iterates oldest → newest; oldest = LRU.
+        # FIXME(perf): `list(...)` snapshots every key up front, allocating O(n)
+        # even when only a few LRU entries need spilling. With thousands of live
+        # entries this is wasteful. Iterate in bounded chunks (e.g. 64 keys) and
+        # stop once back under budget, re-snapshotting only if more are needed.
+        for key in list(self.live_variable_map.keys()):
+            if self.memory_usage <= self.memory_budget:
+                break
+            entry = self.live_variable_map[key]
+            if entry.pin_count > 0 or entry.is_spilled:
+                continue
+            self._evict(key, entry)
+            evicted = True
+        if self.memory_usage > self.memory_budget:
+            logger.warning(
+                f"Budget {prettify_bytes(self.memory_budget)} still exceeded after eviction "
+                f"(usage {prettify_bytes(self.memory_usage)}); all remaining entries are pinned."
+            )
+        return evicted
+
+    def _evict(self, key: Hashable, entry: _Entry) -> None:
+        self._spill_root.mkdir(parents=True, exist_ok=True)
+        stem = self._spill_root / uuid.uuid4().hex
+        t0 = perf_counter()
+        handle = serialize_object(entry.data, stem)
+        self.stats.serialize_time += perf_counter() - t0
+        self.stats.evictions += 1
+        self.stats.bytes_spilled += handle.size_on_disk
+        self.memory_usage -= entry.size
+        entry.data = None
+        entry.handle = handle
+        logger.debug(
+            f"Evicted {key}: freed {prettify_bytes(entry.size)} "
+            f"(spilled {prettify_bytes(handle.size_on_disk)} to disk)"
+        )

--- a/stratum/runtime/_object_serialization.py
+++ b/stratum/runtime/_object_serialization.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import os
+import pickle
+from dataclasses import dataclass
+from itertools import count
+from logging import getLogger
+from pathlib import Path
+from typing import Any
+
+from numpy import ndarray, load as np_load, save as np_save
+from pandas import DataFrame, Series, read_parquet
+from polars import DataFrame as PolarsDataFrame, Series as PolarsSeries, read_parquet as pl_read_parquet
+
+logger = getLogger(__name__)
+
+_FORMAT_EXT = {
+    "pandas_dataframe": ".parquet",
+    "pandas_series": ".parquet",
+    "polars_dataframe": ".parquet",
+    "polars_series": ".parquet",
+    "numpy_ndarray": ".npy",
+}
+
+# Structured leaves are the only objects that get their own portable file
+# (parquet / .npy), so a spilled intermediate can be read by other tools
+# (polars, arrow, rust, gpu, ...) without a Python round-trip. Everything else
+# — primitives and the container glue — is folded into a single skeleton file.
+_STRUCTURED_FORMAT: list[tuple[type, str]] = [
+    (DataFrame, "pandas_dataframe"),
+    (Series, "pandas_series"),
+    (PolarsDataFrame, "polars_dataframe"),
+    (PolarsSeries, "polars_series"),
+    (ndarray, "numpy_ndarray"),
+]
+
+
+# Non-structured leaves we know how to pickle. Mirrors the types `get_size`
+# accepts, so anything the buffer pool admits can also be spilled (and we reject
+# the same unsupported types here, rather than silently pickling them).
+_PICKLABLE_PRIMITIVE = (str, int, float, bool, bytes)
+
+
+def _native_format(obj: Any) -> str | None:
+    """Return the portable file format for a structured leaf, else None."""
+    for typ, fmt in _STRUCTURED_FORMAT:
+        if isinstance(obj, typ):
+            return fmt
+    return None
+
+
+@dataclass(frozen=True)
+class _LeafRef:
+    """Placeholder left in a skeleton where a structured leaf was extracted.
+
+    Points at the leaf's own portable file. Kept minimal (just path + format)
+    so the skeleton stays a plain tree of containers, primitives and refs.
+    """
+    path: str
+    format: str
+
+
+@dataclass(frozen=True)
+class SpilledObject:
+    """Reference to a single spilled object (the handle the buffer pool holds).
+
+    Two shapes:
+      * a *bare* structured object → `path` is its native file, `format` is a
+        native format, `leaves` is empty;
+      * anything else (a primitive, or any list/tuple/dict) → `path` is the
+        skeleton pickle, `format` is ``"skeleton"``, and `leaves` lists the
+        native files that the skeleton's `_LeafRef`s point at.
+    """
+    path: Path
+    format: str
+    leaves: tuple[_LeafRef, ...]
+    size_on_disk: int
+
+
+def serialize_object(obj: Any, stem: Path) -> SpilledObject:
+    """Spill a single object. `stem` is the target path prefix without extension.
+
+    A bare frame/array/series is written straight to its native file. Any
+    container is walked once: each structured leaf is peeled out to its own
+    native file and replaced by a `_LeafRef`; primitives stay inline; the
+    resulting skeleton is pickled to a single file.
+    """
+    fmt = _native_format(obj)
+    if fmt is not None:
+        path = _write_native(obj, stem, fmt)
+        return SpilledObject(path=path, format=fmt, leaves=(), size_on_disk=path.stat().st_size)
+
+    leaves: list[_LeafRef] = []
+    ids = count()
+
+    # Note: a container of *many small* structured objects (e.g. thousands of
+    # tiny frames) still fans out to one native file each. That is a pathological
+    # shape we have no real use for — normal structured leaves are large and few
+    # — so we don't special-case it. If it ever matters, fold sub-threshold
+    # leaves into the skeleton pickle instead of giving them their own file.
+    def build(node: Any) -> Any:
+        leaf_fmt = _native_format(node)
+        if leaf_fmt is not None:
+            leaf_path = _write_native(node, Path(f"{stem}_{next(ids)}"), leaf_fmt)
+            ref = _LeafRef(path=str(leaf_path), format=leaf_fmt)
+            leaves.append(ref)
+            return ref
+        if isinstance(node, list):
+            return [build(x) for x in node]
+        if isinstance(node, tuple):
+            return tuple(build(x) for x in node)
+        if isinstance(node, dict):
+            return {k: build(v) for k, v in node.items()}
+        if isinstance(node, _PICKLABLE_PRIMITIVE) or node is None:
+            return node  # primitive: inline in the skeleton
+        raise ValueError(f"Unsupported type for serialization: {type(node)}")
+
+    skeleton = build(obj)
+    # The skeleton is pickled, so it is Python-only. That is a deliberate
+    # trade-off: the heavy data (frames/arrays) lives in portable native files
+    # above, which is what another language would actually consume. If a
+    # non-Python reader ever needs the *structure* too, swap this for a tagged
+    # JSON encoding (tuples/bytes/non-str dict keys need tagging) and record
+    # `format="json"` — the buffer pool is agnostic to the value.
+    skel_path = _write_pickle(skeleton, stem)
+    size = skel_path.stat().st_size + sum(Path(r.path).stat().st_size for r in leaves)
+    return SpilledObject(path=skel_path, format="skeleton", leaves=tuple(leaves), size_on_disk=size)
+
+
+def deserialize_object(spilled: SpilledObject) -> Any:
+    if spilled.format != "skeleton":
+        return _read_native(spilled.path, spilled.format)
+    # Only ever loads a pickle we wrote ourselves; never an untrusted one.
+    with open(spilled.path, "rb") as f:
+        return _rehydrate(pickle.load(f))
+
+
+def delete_object(spilled: SpilledObject) -> None:
+    for path in (spilled.path, *(Path(r.path) for r in spilled.leaves)):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _rehydrate(node: Any) -> Any:
+    if isinstance(node, _LeafRef):
+        return _read_native(Path(node.path), node.format)
+    if isinstance(node, list):
+        return [_rehydrate(x) for x in node]
+    if isinstance(node, tuple):
+        return tuple(_rehydrate(x) for x in node)
+    if isinstance(node, dict):
+        return {k: _rehydrate(v) for k, v in node.items()}
+    return node
+
+
+def _write_native(obj: Any, stem: Path, fmt: str) -> Path:
+    """Write one structured object to `stem` + its native extension, atomically."""
+    path = Path(f"{stem}{_FORMAT_EXT[fmt]}")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    if fmt == "pandas_dataframe":
+        obj.to_parquet(tmp)
+    elif fmt == "pandas_series":
+        obj.to_frame().to_parquet(tmp)
+    elif fmt == "polars_dataframe":
+        obj.write_parquet(tmp)
+    elif fmt == "polars_series":
+        obj.to_frame().write_parquet(tmp)
+    elif fmt == "numpy_ndarray":
+        with open(tmp, "wb") as f:
+            np_save(f, obj, allow_pickle=False)
+    else:
+        raise ValueError(f"Unknown native format: {fmt}")
+    os.replace(tmp, path)
+    return path
+
+
+def _write_pickle(obj: Any, stem: Path) -> Path:
+    path = Path(f"{stem}.pkl")
+    tmp = path.with_suffix(".pkl.tmp")
+    with open(tmp, "wb") as f:
+        pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(tmp, path)
+    return path
+
+
+def _read_native(path: Path, fmt: str) -> Any:
+    if fmt == "pandas_dataframe":
+        return read_parquet(path)
+    if fmt == "pandas_series":
+        return read_parquet(path).iloc[:, 0]
+    if fmt == "polars_dataframe":
+        return pl_read_parquet(path)
+    if fmt == "polars_series":
+        return pl_read_parquet(path).to_series(0)
+    if fmt == "numpy_ndarray":
+        with open(path, "rb") as f:
+            return np_load(f, allow_pickle=False)
+    raise ValueError(f"Unknown native format: {fmt}")

--- a/stratum/runtime/_object_size.py
+++ b/stratum/runtime/_object_size.py
@@ -52,3 +52,15 @@ def get_size_numpy(obj):
         return obj.itemsize
     else:
         raise ValueError(f"Unsupported numpy type for memory estimation: {type(obj)}")
+
+def prettify_bytes(num_bytes: float) -> str:
+    """Format a byte count as a human-readable string (e.g. ``"1.50 MB"``)."""
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    size = float(num_bytes)
+    for unit in units:
+        # Stop at the last unit even if `size` is still >= 1024, so the number
+        # and unit always stay paired (values > 1024 PB report as "N.NN PB").
+        if abs(size) < 1024 or unit == units[-1]:
+            return f"{size:.2f} {unit}"
+        size /= 1024
+    return f"{size:.2f} {units[-1]}"

--- a/stratum/runtime/_scheduler.py
+++ b/stratum/runtime/_scheduler.py
@@ -39,6 +39,7 @@ class Scheduler:
         self.pool = BufferPool()
         self.t0 = t0 if t0 is not None else perf_counter()
         self._pinned_ops: set[Op] = set()
+        self.buffer_pool_overhead = 0
 
     def _finish(self):
         """End of execution. Remove all buffers."""
@@ -86,15 +87,30 @@ class Scheduler:
         scoring_func, greater_is_better = get_scoring_func(scoring)
 
         x_data = self.pool.pin(split_op.inputs[0])
+        splits = []
         for i, (train_index, test_index) in enumerate(cv.split(x_data)):
+            train_key = ("__cv_split", "train", i)
+            test_key = ("__cv_split", "test", i)
+            splits.append((i, train_key, test_key))
+            self.pool.put(test_key, test_index)
+            self.pool.put(train_key, train_index)
+            self.log_memory_usage()
+        self.pool.unpin(split_op.inputs[0])
+
+        for i, train_ids_handle, test_ids_handle in splits:
             self.cv_id = i
             logger.debug(f"CV Fold Nr. {i + 1}")
 
-            split_op.indices = train_index
+            split_op.indices = self.pool.pin(train_ids_handle)
             self.compute(self.pos_split_op)
+            self.pool.unpin(train_ids_handle)
+            self.pool.remove(train_ids_handle)
             logger.debug("\n" + "="*100 + "\n" + "Training done for fold " + str(i+1) + "\n" + "="*100 + "\n")
-            split_op.indices = test_index
+
+            split_op.indices = self.pool.pin(test_ids_handle)
             df, y_test = self.compute(self.pos_split_op, mode="predict")
+            self.pool.unpin(test_ids_handle)
+            self.pool.remove(test_ids_handle)
             logger.debug("\n" + "="*100 + "\n" + "Predicting done for fold " + str(i+1) + "\n" + "="*100 + "\n")
             if return_predictions:
                 predictions.append(df)
@@ -115,13 +131,15 @@ class Scheduler:
         logger.debug(f"[{perf_counter() - self.t0:.2f}s] Processing op: {op}")
 
         try:
-            t0 = perf_counter() if self.timings is not None else 0
+            t0 = perf_counter()
 
             # 1. pin all inputs
             inputs = [self.pool.pin(in_op) for in_op in op.inputs]
 
             # 2. process operator
+            t1 = perf_counter()
             result = op.process(mode=self.mode, inputs=inputs)
+            t2 = perf_counter()
 
             # 3. unpin inputs
             for in_op in op.inputs:
@@ -135,9 +153,14 @@ class Scheduler:
             self.pool.put(op, result)
             self.log_memory_usage()
 
+            t3 = perf_counter()
+            process_duration = t2 - t1
+            buffer_overhead = t3 - t0 - process_duration
+            self.buffer_pool_overhead += buffer_overhead
+
             if self.timings is not None:
-                duration = perf_counter() - t0
-                self.timings.append((str(op), duration))
+                duration = t2 - t1
+                self.timings.append((str(op), process_duration))
 
         except Exception as e:
             raise RuntimeError(f"[{self.mode}] Error processing '{op}': {e}")

--- a/stratum/tests/runtime/runtime_test_utils.py
+++ b/stratum/tests/runtime/runtime_test_utils.py
@@ -79,6 +79,11 @@ def _make_op(name="op"):
     return Op(name=name)
 
 
+def _arr(n: int) -> np.ndarray:
+    """float64 array of length n — 8 bytes per element for predictable in-memory size."""
+    return np.arange(n, dtype=np.float64)
+
+
 def _make_linear_dag():
     """A -> B -> C (linear chain)."""
     a = _make_op("A")

--- a/stratum/tests/runtime/test_buffer_pool.py
+++ b/stratum/tests/runtime/test_buffer_pool.py
@@ -1,11 +1,21 @@
+import shutil
+import tempfile
 import unittest
-from stratum.runtime._buffer_pool import BufferPool
-from stratum.runtime._object_size import get_size
-from stratum.tests.runtime.runtime_test_utils import RuntimeTest, simple_pipeline, _make_op
-from stratum._api import grid_search
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import polars as pl
+
+from stratum._api import grid_search
+from stratum._config import config
+from stratum.runtime._buffer_pool import BufferPool
+from stratum.runtime._object_size import get_size
+from stratum.tests.runtime.runtime_test_utils import RuntimeTest, _arr, _make_op, simple_pipeline
+import skrub
+from sklearn.dummy import DummyRegressor
+
+
 class TestBufferPool(unittest.TestCase):
     """Tests for BufferPool as a pure cache."""
 
@@ -62,7 +72,7 @@ class TestBufferPool(unittest.TestCase):
         pool.remove(op)
         self.assertEqual(pool.memory_usage, 0)
         pool.memory_usage = 2*1024**5
-        self.assertEqual(pool.total_size, "2048.00 GB")
+        self.assertEqual(pool.total_size, "2.00 PB")
 
     def test_unknown_object_sizes(self):
         class Foo:
@@ -97,6 +107,130 @@ class TestBufferPoolIntegration(RuntimeTest):
         pred_opt = simple_pipeline()
         results = grid_search(pred_opt, cv=2)
         self.assertIsNotNone(results)
+        
+    def test_buffer_pool_evictions(self):
+        arr = skrub.as_data_op(_arr(1000)).skb.mark_as_X()
+        y = skrub.as_data_op(_arr(1000)).skb.mark_as_y()
+        def dummy_op(x):
+            return x + 1
+
+        arr2 = arr.skb.apply_func(lambda x: dummy_op(x)).reshape(-1, 1)
+        arr3 = arr.skb.apply_func(lambda x: dummy_op(x)).reshape(-1, 1)
+        arr4 = arr.skb.apply_func(lambda x: dummy_op(x)).reshape(-1, 1)
+        arr_out = arr2.skb.apply_func(lambda a, b, c: np.hstack([a, b, c]), arr3, arr4)
+        pred = arr_out.skb.apply(DummyRegressor(), y=y)
+
+        with self.assertLogs("stratum", level="DEBUG") as logs:
+            with config(scheduler=True, buffer_pool_memory_budget=24000, DEBUG=True):
+                search = pred.skb.make_grid_search(cv=2)
+        self.assertIsNotNone(search)
+        evictions = [line for line in logs.output if "Evicted" in line]
+        self.assertEqual(len(evictions), 12, msg="\n".join(logs.output))
+
+
+class TestLRUEviction(unittest.TestCase):
+    """LRU spill-to-disk eviction in BufferPool."""
+
+    def setUp(self):
+        self.spill_root = Path(tempfile.mkdtemp())
+        self.pool = BufferPool(spill_root=self.spill_root)
+        self.pool.memory_budget = 10_000  # ~10 KB
+
+    def tearDown(self):
+        shutil.rmtree(self.spill_root, ignore_errors=True)
+
+    def test_no_eviction_when_budget_zero(self):
+        self.pool.memory_budget = 0  # override the setUp budget for this test
+        a, b = _make_op("a"), _make_op("b")
+        self.pool.put(a, _arr(1000))
+        self.pool.put(b, _arr(1000))
+        self.assertEqual(list(self.spill_root.iterdir()), [])
+        self.assertEqual(self.pool.memory_usage, 16_000)
+
+    def test_eviction_spills_lru(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        self.pool.put(a, _arr(500))  # 4_000 B; touches a
+        self.pool.put(b, _arr(500))  # 4_000 B; touches b
+        self.pool.put(c, _arr(500))  # 4_000 B → 12_000 total, over budget
+        # `a` is LRU → should be the one spilled.
+        self.assertTrue(self.pool.live_variable_map[a].is_spilled)
+        self.assertFalse(self.pool.live_variable_map[b].is_spilled)
+        self.assertFalse(self.pool.live_variable_map[c].is_spilled)
+        self.assertEqual(self.pool.memory_usage, 8_000)
+
+    def test_pin_reloads_evicted_entry(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        original = _arr(500)
+        self.pool.put(a, original)
+        self.pool.put(b, _arr(500))
+        self.pool.put(c, _arr(500))  # evicts a
+        self.assertTrue(self.pool.live_variable_map[a].is_spilled)
+
+        out = self.pool.pin(a)
+        np.testing.assert_array_equal(out, original)
+        self.assertFalse(self.pool.live_variable_map[a].is_spilled)
+
+    def test_pinned_entries_not_evicted(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        self.pool.put(a, _arr(500))
+        self.pool.pin(a)  # protect a
+        self.pool.put(b, _arr(500))
+        self.pool.put(c, _arr(500))  # would normally evict a (LRU)
+        self.assertFalse(self.pool.live_variable_map[a].is_spilled)
+        # b is next LRU among unpinned, so b should have been spilled instead.
+        self.assertTrue(self.pool.live_variable_map[b].is_spilled)
+
+    def test_pin_refcount(self):
+        a = _make_op("a")
+        self.pool.put(a, "data")
+        self.pool.pin(a)
+        self.pool.pin(a)
+        self.assertEqual(self.pool.live_variable_map[a].pin_count, 2)
+        self.pool.unpin(a)
+        self.assertEqual(self.pool.live_variable_map[a].pin_count, 1)
+        self.pool.unpin(a)
+        self.assertEqual(self.pool.live_variable_map[a].pin_count, 0)
+        self.pool.unpin(a)  # extra unpin clamps at 0
+        self.assertEqual(self.pool.live_variable_map[a].pin_count, 0)
+
+    def test_pin_moves_to_mru(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        self.pool.put(a, _arr(500))
+        self.pool.put(b, _arr(500))
+        self.pool.pin(a)  # makes a the MRU
+        self.pool.unpin(a)
+        self.pool.put(c, _arr(500))  # over budget → evict LRU = b now, not a
+        self.assertFalse(self.pool.live_variable_map[a].is_spilled)
+        self.assertTrue(self.pool.live_variable_map[b].is_spilled)
+
+    def test_remove_evicted_cleans_disk(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        self.pool.put(a, _arr(500))
+        self.pool.put(b, _arr(500))
+        self.pool.put(c, _arr(500))
+        self.assertTrue(self.pool.live_variable_map[a].is_spilled)
+        self.assertEqual(len(list(self.spill_root.iterdir())), 1)
+        self.assertTrue(self.pool.remove(a))
+        self.assertEqual(list(self.spill_root.iterdir()), [])
+
+    def test_remove_all_cleans_disk(self):
+        self.pool.memory_budget = 10_000
+        for name in ("a", "b", "c"):
+            self.pool.put(_make_op(name), _arr(500))
+        self.assertGreater(len(list(self.spill_root.iterdir())), 0)
+        self.pool.remove_all()
+        self.assertEqual(self.pool.memory_usage, 0)
+        self.assertEqual(list(self.spill_root.iterdir()), [])
+
+    def test_put_overwrites_evicted(self):
+        a, b, c = _make_op("a"), _make_op("b"), _make_op("c")
+        self.pool.put(a, _arr(500))
+        self.pool.put(b, _arr(500))
+        self.pool.put(c, _arr(500))  # a now spilled
+        self.assertTrue(self.pool.live_variable_map[a].is_spilled)
+        self.pool.put(a, _arr(100))  # overwrite spilled entry
+        self.assertFalse(self.pool.live_variable_map[a].is_spilled)
+        self.assertEqual(self.pool.live_variable_map[a].size, 800)
 
 
 if __name__ == "__main__":

--- a/stratum/tests/runtime/test_object_serialization.py
+++ b/stratum/tests/runtime/test_object_serialization.py
@@ -1,0 +1,171 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from polars.testing import assert_frame_equal as pl_assert_frame_equal
+from polars.testing import assert_series_equal as pl_assert_series_equal
+
+from stratum.runtime._object_serialization import (
+    _LeafRef,
+    delete_object,
+    deserialize_object,
+    serialize_object,
+)
+
+
+class TestBareObjects(unittest.TestCase):
+    """A single structured object is written straight to its native file."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _stem(self, name: str = "x") -> Path:
+        return self.root / name
+
+    def test_pandas_dataframe(self):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+        h = serialize_object(df, self._stem())
+        self.assertEqual(h.format, "pandas_dataframe")
+        self.assertEqual(h.leaves, ())
+        self.assertEqual(h.path.suffix, ".parquet")
+        self.assertGreater(h.size_on_disk, 0)
+        pd.testing.assert_frame_equal(deserialize_object(h), df)
+
+    def test_pandas_series(self):
+        ser = pd.Series([1, 2, 3], name="x")
+        h = serialize_object(ser, self._stem())
+        pd.testing.assert_series_equal(deserialize_object(h), ser)
+
+    def test_polars_dataframe(self):
+        df = pl.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+        h = serialize_object(df, self._stem())
+        pl_assert_frame_equal(deserialize_object(h), df)
+
+    def test_polars_series(self):
+        ser = pl.Series("x", [1, 2, 3])
+        h = serialize_object(ser, self._stem())
+        pl_assert_series_equal(deserialize_object(h), ser)
+
+    def test_numpy(self):
+        arr = np.arange(12, dtype=np.float64).reshape(3, 4)
+        h = serialize_object(arr, self._stem())
+        self.assertEqual(h.path.suffix, ".npy")
+        np.testing.assert_array_equal(deserialize_object(h), arr)
+
+    def test_bare_primitive(self):
+        # A lone primitive has no native format, so it lands in a skeleton pickle.
+        for i, val in enumerate(["hello", 42, 3.14, True, b"raw", None]):
+            h = serialize_object(val, self._stem(f"p{i}"))
+            self.assertEqual(h.format, "skeleton")
+            self.assertEqual(h.leaves, ())
+            self.assertEqual(deserialize_object(h), val)
+
+    def test_unsupported_type_raises(self):
+        class Foo:
+            pass
+
+        with self.assertRaises(ValueError):
+            serialize_object(Foo(), self._stem())
+
+    def test_no_tmp_after_serialize(self):
+        serialize_object(np.arange(10), self._stem())
+        self.assertEqual(list(self.root.glob("*.tmp")), [])
+
+    def test_delete_bare(self):
+        h = serialize_object("hello", self._stem())
+        self.assertTrue(h.path.exists())
+        delete_object(h)
+        self.assertFalse(h.path.exists())
+        delete_object(h)  # idempotent
+
+
+class TestSkeleton(unittest.TestCase):
+    """Containers keep structured leaves in native files and pickle the rest."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self._n = 0
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _stem(self) -> Path:
+        self._n += 1
+        return self.root / f"obj{self._n}"
+
+    def test_tuple_of_structured_uses_native_leaves(self):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        arr = np.arange(5, dtype=np.float64)
+        h = serialize_object((df, arr), self._stem())
+        self.assertEqual(h.format, "skeleton")
+        self.assertEqual(h.path.suffix, ".pkl")
+        self.assertEqual(len(h.leaves), 2)
+        self.assertTrue(all(isinstance(l, _LeafRef) for l in h.leaves))
+        # frames/arrays stay portable
+        self.assertEqual({Path(l.path).suffix for l in h.leaves}, {".parquet", ".npy"})
+        out_df, out_arr = deserialize_object(h)
+        pd.testing.assert_frame_equal(out_df, df)
+        np.testing.assert_array_equal(out_arr, arr)
+
+    def test_nested_dict_with_list(self):
+        obj = {
+            "df": pd.DataFrame({"a": [1, 2]}),
+            "arrs": [np.array([1.0, 2.0]), np.array([3.0, 4.0])],
+            "label": "train",
+            "n": 3,
+        }
+        h = serialize_object(obj, self._stem())
+        self.assertEqual(len(h.leaves), 3)  # 1 frame + 2 arrays; primitives inline
+        out = deserialize_object(h)
+        pd.testing.assert_frame_equal(out["df"], obj["df"])
+        for a, b in zip(out["arrs"], obj["arrs"]):
+            np.testing.assert_array_equal(a, b)
+        self.assertEqual(out["label"], "train")
+        self.assertEqual(out["n"], 3)
+
+    def test_list_of_primitives_is_single_file(self):
+        # The reviewer's case: many small objects must not fan out to N files.
+        data = [f"item_{i}" for i in range(1000)]
+        h = serialize_object(data, self._stem())
+        self.assertEqual(h.leaves, ())
+        self.assertEqual(len(list(self.root.iterdir())), 1)  # one skeleton pickle
+        self.assertEqual(deserialize_object(h), data)
+
+    def test_non_string_dict_keys_roundtrip(self):
+        obj = {1: np.arange(3), (2, 3): "pair", None: 4}
+        h = serialize_object(obj, self._stem())
+        out = deserialize_object(h)
+        np.testing.assert_array_equal(out[1], np.arange(3))
+        self.assertEqual(out[(2, 3)], "pair")
+        self.assertEqual(out[None], 4)
+
+    def test_unsupported_leaf_raises(self):
+        class Foo:
+            pass
+
+        with self.assertRaises(ValueError):
+            serialize_object([pd.DataFrame({"a": [1]}), Foo()], self._stem())
+
+    def test_delete_removes_skeleton_and_leaves(self):
+        h = serialize_object((np.arange(3), np.arange(4)), self._stem())
+        paths = [h.path, *(Path(l.path) for l in h.leaves)]
+        self.assertTrue(all(p.exists() for p in paths))
+        delete_object(h)
+        self.assertFalse(any(p.exists() for p in paths))
+        delete_object(h)  # idempotent
+
+    def test_size_on_disk_matches_files(self):
+        h = serialize_object([np.arange(10), np.arange(20)], self._stem())
+        on_disk = h.path.stat().st_size + sum(Path(l.path).stat().st_size for l in h.leaves)
+        self.assertEqual(h.size_on_disk, on_disk)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1762,6 +1762,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+benchmark = [
+    { name = "psutil" },
+]
 dev = [
     { name = "ipykernel" },
 ]
@@ -1789,6 +1792,7 @@ requires-dist = [
     { name = "numexpr", specifier = ">=2.14.1" },
     { name = "pandas", specifier = "==3.0.2" },
     { name = "polars" },
+    { name = "psutil", marker = "extra == 'benchmark'", specifier = ">=7.2" },
     { name = "pyarrow", specifier = ">=22.0.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },


### PR DESCRIPTION
Extend the runtime buffer pool so intermediate results can be spilled to disk when memory usage exceeds a configured budget. The buffer pool now tracks live entries with access order and applies an LRU eviction policy: when the memory budget is exceeded, the least-recently-used unpinned entries are serialized to disk until usage falls back under the limit.

Spilled entries remain registered in the buffer pool and are transparently reloaded on subsequent pin operations. Pinning is refcounted so actively used buffers are protected from eviction, while unpinned buffers remain eligible for spilling. Re-accessing an entry updates its recency, ensuring frequently used intermediates stay resident when possible.

This change also adds serialization support for runtime intermediates including NumPy arrays, pandas and Polars objects, and primitive Python values. Buffer pool statistics now report cache hits, misses, evictions, serialization and deserialization time, and spilled/loaded byte counts.

A new `buffer_pool_memory_budget` configuration option controls eviction. A budget of zero preserves the previous behavior and disables eviction.

Additional tests cover:
- LRU spill selection
- transparent reload of spilled entries
- protection of pinned buffers from eviction
- pin refcount behavior
- cleanup of spilled files on remove/remove_all
- overwriting previously spilled entries
- object serialization round trips

A runtime benchmark was added to evaluate memory usage and eviction behavior under larger pipeline workloads.

## Benchmark results
### workload 1:
<img width="533" height="303" alt="Screenshot 2026-05-19 at 16 19 02" src="https://github.com/user-attachments/assets/299d46b6-88e5-4b26-af17-7664a1365a7f" />

### Unlimited buffer pool memory
<img width="687" height="347" alt="Screenshot 2026-05-19 at 15 28 11" src="https://github.com/user-attachments/assets/61669a99-2862-4f0b-a9b3-8aad6c512db2" />

### 10Gb buffer pool memory
<img width="687" height="347" alt="Screenshot 2026-05-19 at 15 28 17" src="https://github.com/user-attachments/assets/1220fb8d-c484-415a-816b-8466c2ec8fa2" />

### workload 2:
<img width="533" height="485" alt="Screenshot 2026-05-19 at 16 26 44" src="https://github.com/user-attachments/assets/03d54b1d-fb30-4e70-8f6c-d2a7b10c4086" />


### Unlimited buffer pool memory
<img width="687" height="347" alt="Screenshot 2026-05-19 at 16 09 43" src="https://github.com/user-attachments/assets/39b809e2-3ca0-4c4e-98e4-fa3a0d9909d0" />

### 25Gb buffer pool memory
<img width="687" height="347" alt="Screenshot 2026-05-19 at 16 09 47" src="https://github.com/user-attachments/assets/8660fdfb-ab1d-490c-b631-cc255f75c1e6" />

### 15Gb buffer pool memory
<img width="687" height="347" alt="Screenshot 2026-05-19 at 16 09 50" src="https://github.com/user-attachments/assets/2aa0a2e8-143f-4ea6-9ea0-c714d2f155d3" />

The plots display the overall memory consumption of stratum, this includes the buffer pool and execution memory. The plots show that after the execution of each operator the consumed memory goes to our defined memory threshold as we want.

Closes #72, #73