### PR TITLE
[Fix] eliminate log1p/expm1 inverse chains (#52)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -1,5 +1,11 @@
 from dataclasses import dataclass
-from stratum.optimizer._numeric_rewrites import eliminate_log_exp, eliminate_exp_log, eliminate_sqrt_square
+from stratum.optimizer._numeric_rewrites import (
+    eliminate_exp_log,
+    eliminate_expm1_log1p,
+    eliminate_log_exp,
+    eliminate_log1p_expm1,
+    eliminate_sqrt_square,
+)
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
 import logging
@@ -12,6 +18,8 @@ class AlgebraicRewritesConfig:
     log_exp: bool = True
     exp_log: bool = True
     sqrt_square: bool = True
+    log1p_expm1: bool = True
+    expm1_log1p: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -23,5 +31,9 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_exp_log(root)
     if config.sqrt_square:
         root = eliminate_sqrt_square(root)
+    if config.log1p_expm1:
+        root = eliminate_log1p_expm1(root)
+    if config.expm1_log1p:
+        root = eliminate_expm1_log1p(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -2,6 +2,7 @@ from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
 from stratum.optimizer.ir._ops import Op
 
+
 def match_two_op_chain(op_cls, type1, type2):
     """Match predicate for two consecutive ops of the same class with given types."""
     def match(op):
@@ -12,6 +13,7 @@ def match_two_op_chain(op_cls, type1, type2):
         return None
     return match
 
+
 def eliminate_two_op_chain(op1, op2):
     """Remove a redundant pair of inverse ops: y = f(op2(op1(x))) -> y = f(x).
 
@@ -20,6 +22,7 @@ def eliminate_two_op_chain(op1, op2):
     x = op1.inputs[0]
     x.outputs = [out for out in x.outputs if out is not op1]
     replace_op_in_outputs(op2, x)
+
 
 def eliminate_two_op_chain_root_safe(op1: Op, op2: Op, root: Op) -> Op:
     """Wrapper around eliminate_two_op_chain that handles the case where
@@ -51,7 +54,6 @@ def make_replace_two_op_chain_root_safe(make_replacement):
     return action
 
 
-
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -62,10 +64,21 @@ eliminate_exp_log = rewrite_pass(
     eliminate_two_op_chain_root_safe,
 )
 
-_replace_with_abs = make_replace_two_op_chain_root_safe(lambda : NumericOp(inputs=[], outputs=[], type=NumericOpType.ABS))
+eliminate_expm1_log1p = rewrite_pass(
+    match_two_op_chain(NumericOp, NumericOpType.EXPM1, NumericOpType.LOG1P),
+    eliminate_two_op_chain_root_safe,
+)
+
+eliminate_log1p_expm1 = rewrite_pass(
+    match_two_op_chain(NumericOp, NumericOpType.LOG1P, NumericOpType.EXPM1),
+    eliminate_two_op_chain_root_safe,
+)
+
+_replace_with_abs = make_replace_two_op_chain_root_safe(
+    lambda: NumericOp(inputs=[], outputs=[], type=NumericOpType.ABS)
+)
 
 eliminate_sqrt_square = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.SQUARE, NumericOpType.SQRT),
     _replace_with_abs,
 )
-

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -10,6 +10,8 @@ class NumericOpType(Enum):
     SQRT = "sqrt"
     ABS = "abs"
     SQUARE = "square"
+    LOG1P = "log1p"
+    EXPM1 = "expm1"
     ADD = "add"
     SUBTRACT = "subtract"
     MULTIPLY = "multiply"
@@ -35,6 +37,8 @@ _NUMPY_UNARY_MAP = {
     np.sqrt: NumericOpType.SQRT,
     np.abs: NumericOpType.ABS,
     np.square: NumericOpType.SQUARE,
+    np.log1p: NumericOpType.LOG1P,
+    np.expm1: NumericOpType.EXPM1,
 }
 
 _UNARY_NUMPY_FUNCS = frozenset(_NUMPY_UNARY_MAP.keys())
@@ -83,6 +87,10 @@ class NumericOp(Op):
             return np.abs(inputs[0])
         elif self.type == NumericOpType.SQUARE:
             return np.square(inputs[0])
+        elif self.type == NumericOpType.LOG1P:
+            return np.log1p(inputs[0])
+        elif self.type == NumericOpType.EXPM1:
+            return np.expm1(inputs[0])
         elif self.type in _BINARY_TYPES:
             primary = inputs[0]
             operand = inputs[1] if self.opt_operand is DATA_OP_PLACEHOLDER else self.constant

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -46,6 +46,24 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 1)
 
+    def test_log1p_expm1(self):
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log1p)
+        t2 = t1.skb.apply_func(np.expm1)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)
+
+    def test_expm1_log1p(self):
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.expm1)
+        t2 = t1.skb.apply_func(np.log1p)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)
+
     def test_log_log1p(self):
         "no algebraic rewrite should be applied here "
         df = st.as_data_op(1)
@@ -205,4 +223,3 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
-


### PR DESCRIPTION
## Summary

Adds numeric operator support and algebraic rewrites for the `log1p` / `expm1` inverse pairs.

- Recognize `np.log1p` and `np.expm1` as specialized `NumericOp` variants
- Eliminate `log1p -> expm1` and `expm1 -> log1p` chains during algebraic rewrites
- Add optimizer tests for both inverse orders

Closes #52.

## Validation

- `git diff --check`
- `.venv/bin/python -m pytest stratum/tests/logical_optimizer/test_numeric_ops.py stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py`
- `.venv/bin/python -m pytest`