### PR TITLE
[Minor] Redundant Graph building/reordering if CSE is disabled (#77)

### DIFF
--- a/stratum/optimizer/_optimize.py
+++ b/stratum/optimizer/_optimize.py
@@ -77,11 +77,11 @@ def optimize(dag_root: DataOp, config: OptConfig = None):
     if config is None:
         config = OptConfig()
 
-    children, nodes, parents = get_dataops_graph(dag_root)
-    order = topological_traverse(nodes, parents, children)
 
     # Apply CSE on skrub IR
     if FLAGS.cse:
+        children, nodes, parents = get_dataops_graph(dag_root)
+        order = topological_traverse(nodes, parents, children)
         run_cse_pass(dag_root, nodes, order, parents)
 
     # Convert to Op DAG and add splitting op


### PR DESCRIPTION
If CSE is disabled, we still do the graph building and the topological order twice, which is not necessary and redundant.

Closes #77