### PR TITLE
[FrameOperator] JoinOp with pandas backend (#55)

### DIFF
--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from collections.abc import Sequence
 from stratum.optimizer.ir._ops import (DATA_OP_PLACEHOLDER, BaseEstimatorOp, BinOp, CallOp, GetAttrOp, GetItemOp,
                                        MethodCallOp, Op, ValueOp, VariableOp,_resolve_args, _resolve_kwargs)
 from pandas import DataFrame
@@ -48,6 +49,48 @@ class DataSourceOp(Op):
 
     def clone(self):
         raise ValueError(f"We should not clone DataSourceOp objects.")
+
+class JoinOp(Op):
+    fields = ["how", "left_on", "right_on", "left_index", "right_index", "suffixes"]
+
+    def __init__(
+        self,
+        how: str = "inner",
+        left_on: str | list[str] | None = None,
+        right_on: str | list[str] | None = None,
+        left_index: bool = False,
+        right_index: bool = False,
+        suffixes: Sequence[str] = ("_x", "_y"),
+        inputs: list[Op] | None = None,
+        outputs: list[Op] | None = None,
+    ):
+        super().__init__(name="JOIN", inputs=inputs, outputs=outputs)
+        self.how = how
+        self.left_on = left_on
+        self.right_on = right_on
+        self.left_index = left_index
+        self.right_index = right_index
+        self.suffixes = suffixes
+        self.is_dataframe_op = True
+
+    def process(self, mode: str, environment: dict, inputs: list):
+        if len(inputs) != 2:
+            raise ValueError(f"JoinOp expects exactly 2 inputs (left and right dataframes), got {len(inputs)}.")
+        left_df = inputs[0]
+        right_df = inputs[1]
+
+        if FLAGS.force_polars:
+            raise NotImplementedError("JoinOp Polars backend is not implemented yet.")
+        else:
+            return left_df.merge(
+                right_df,
+                left_on=self.left_on,
+                right_on=self.right_on,
+                how=self.how,
+                suffixes=self.suffixes,
+                left_index=self.left_index,
+                right_index=self.right_index
+            )
 
 class MetadataOp(Op):
     fields = ["func", "args", "kwargs"]
@@ -246,6 +289,7 @@ class GetAttrProjectionOp(Op):
             for attr in self.attr_name:
                 tmp = getattr(tmp, attr)
             return tmp
+
 class GroupedDataframeOp(Op):
     def __init__(self, ops: list[Op]):
         super().__init__(name="GROUPED_DATAFRAME", is_X=False, is_y=False)
@@ -377,6 +421,8 @@ def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
             elif op.method_name in ["assign"]:
                 new_op = AssignOp(args=op.args, kwargs=op.kwargs, inputs=op.inputs, outputs=op.outputs)
                 op.replace_output_of_inputs(new_op)
+            elif op.method_name in ["join", "merge"]:
+                new_op = make_join_op(op)
 
         # GetAttr Fusing and conversion to GetAttrDataframeOp
         elif isinstance(op, GetAttrOp) and op.inputs[0].is_dataframe_op:
@@ -443,6 +489,109 @@ def make_read_op(op: CallOp, format: str = "csv") -> DataSourceOp:
         in_.replace_output(op, new_op)
     return new_op
 
+
+_MERGE_POSITIONAL = ["how", "on", "left_on", "right_on",
+                    "left_index", "right_index", "sort", "suffixes"]
+_JOIN_POSITIONAL = ["on", "how", "lsuffix", "rsuffix", "sort"]
+_JOIN_OP_FIELDS = {"how", "left_on", "right_on", "left_index", "right_index", "suffixes"}
+
+def make_join_op(op: MethodCallOp) -> JoinOp:
+    # First positional arg is the right/other df; it's already in op.inputs
+    pos_args = op.args[1:] if op.args else ()
+    pos_names = _MERGE_POSITIONAL if op.method_name == "merge" else _JOIN_POSITIONAL
+
+    params = dict(zip(pos_names, pos_args))
+    if op.kwargs:
+        params.update(op.kwargs)
+    params.pop("other", None)
+
+    other_arg = op.args[0] if op.args else None
+    if other_arg is None and op.kwargs:
+        other_arg = op.kwargs.get("other")
+
+    if isinstance(other_arg, (list, tuple)):
+        if len(other_arg) != len(set(id(x) for x in other_arg)):
+            raise ValueError(
+                "Duplicate right-hand frames in chained joins are not supported."
+            )
+
+    is_chained = (
+        op.method_name == "join"
+        and (isinstance(other_arg, (list, tuple)) or len(op.inputs) > 2)
+    )
+
+    if op.method_name == "join":
+        # pandas .join() defaults to how="left" and matches against right's index.
+        params.setdefault("how", "left")
+        if is_chained:
+            # Chained joins are always index-based on every link.
+            params["left_index"] = True
+            params["right_index"] = True
+            params.pop("on", None)
+            params.pop("left_on", None)
+            params.pop("right_on", None)
+        elif "on" in params:
+            params["left_on"] = params.pop("on")
+            params["left_index"] = False
+            params["right_index"] = True
+        else:
+            params["left_index"] = True
+            params["right_index"] = True
+        # join uses lsuffix/rsuffix instead of suffixes; both default to "" in pandas.
+        if "lsuffix" in params or "rsuffix" in params:
+            params["suffixes"] = (params.pop("lsuffix", ""), params.pop("rsuffix", ""))
+        params.setdefault("suffixes", ("", ""))
+    else:
+        # merge's `on` applies to both sides when left_on/right_on are unset.
+        if "on" in params and "left_on" not in params and "right_on" not in params:
+            shared = params.pop("on")
+            params["left_on"] = shared
+            params["right_on"] = shared
+        else:
+            params.pop("on", None)
+        params.setdefault("suffixes", ("_x", "_y"))
+
+    if params.pop("sort", False):
+        raise NotImplementedError(
+            "sort=True is not supported by JoinOp."
+        )
+
+    unsupported = [
+        k for k in params
+        if k not in _JOIN_OP_FIELDS and k not in ("right", "other")
+    ]
+    if unsupported:
+        raise NotImplementedError(
+            f"Unsupported arguments for {op.method_name}(): {', '.join(sorted(unsupported))}"
+        )
+
+    join_kwargs = {k: v for k, v in params.items() if k in _JOIN_OP_FIELDS}
+
+    if is_chained:
+        return _make_chained_join_op(op, join_kwargs)
+
+    new_op = JoinOp(**join_kwargs, inputs=op.inputs, outputs=op.outputs)
+    op.replace_output_of_inputs(new_op)
+    return new_op
+
+def _make_chained_join_op(op: MethodCallOp, join_kwargs: dict) -> JoinOp:
+    """Unroll df1.join([df2, df3, ...]) into a chain of binary JoinOps."""
+    dfs = op.inputs
+    prev = dfs[0]
+    final_join = None
+    n_links = len(dfs) - 1
+    for i, right in enumerate(dfs[1:]):
+        is_last = i == n_links - 1
+        join = JoinOp(**join_kwargs, inputs=[prev, right],
+                      outputs=op.outputs if is_last else [])
+        right.replace_output(op, join)
+        if final_join is not None:
+            final_join.outputs = [join]
+        else:
+            prev.replace_output(op, join)
+        prev = join
+        final_join = join
+    return final_join
 
 def make_frame_get_attr(new_op: GetAttrProjectionOp, op: GetAttrOp) -> GetAttrProjectionOp:
     input_ = op.inputs[0]

--- a/stratum/tests/logical_optimizer/test_dataframe_ops.py
+++ b/stratum/tests/logical_optimizer/test_dataframe_ops.py
@@ -13,7 +13,7 @@ from stratum._config import FLAGS
 from stratum.optimizer._optimize import OptConfig, optimize as optimize_
 from stratum.optimizer.ir._dataframe_ops import (
     ApplyUDFOp, AssignOp, ConcatOp, DataSourceOp, DatetimeConversionOp, DropOp,
-    GetAttrProjectionOp, MetadataOp, ProjectionOp, SplitOp,
+    GetAttrProjectionOp, JoinOp, MetadataOp, ProjectionOp, SplitOp,
     make_datetime_conversion_op, make_read_op)
 from stratum.optimizer.ir._ops import (CallOp, DATA_OP_PLACEHOLDER, GetItemOp,
                                        MethodCallOp, Op, ValueOp)
@@ -422,3 +422,257 @@ class TestMakeDatetimeConversionOp(unittest.TestCase):
                     args=(DATA_OP_PLACEHOLDER, "ISO8601"), kwargs={})
         new_op = make_datetime_conversion_op(op)
         self.assertEqual(("ISO8601",), tuple(new_op.args))
+
+
+class TestJoinOpPandas(unittest.TestCase):
+    """`JoinOp.process` on the pandas backend."""
+
+    def test_merge_on_key(self):
+        left = pd.DataFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
+        right = pd.DataFrame({"k": [2, 3, 4], "b": [200, 300, 400]})
+        op = JoinOp(how="inner", left_on="k", right_on="k")
+        result = run_op(op, left, right)
+        self.assertEqual([2, 3], result["k"].tolist())
+        self.assertEqual([20, 30], result["a"].tolist())
+        self.assertEqual([200, 300], result["b"].tolist())
+
+    def test_merge_left_on_right_on_distinct(self):
+        left = pd.DataFrame({"lk": [1, 2], "a": [10, 20]})
+        right = pd.DataFrame({"rk": [2, 3], "b": [200, 300]})
+        op = JoinOp(how="inner", left_on="lk", right_on="rk")
+        result = run_op(op, left, right)
+        self.assertEqual([2], result["lk"].tolist())
+        self.assertEqual([2], result["rk"].tolist())
+
+    def test_join_index_based_with_suffixes(self):
+        left = pd.DataFrame({"x": [1, 2, 3]}, index=["a", "b", "c"])
+        right = pd.DataFrame({"x": [10, 20, 30]}, index=["b", "c", "d"])
+        op = JoinOp(how="left", left_index=True, right_index=True,
+                    suffixes=("_L", "_R"))
+        result = run_op(op, left, right)
+        self.assertEqual(["a", "b", "c"], result.index.tolist())
+        self.assertIn("x_L", result.columns)
+        self.assertIn("x_R", result.columns)
+
+    def test_outer_join(self):
+        left = pd.DataFrame({"a": [1, 2]}, index=["x", "y"])
+        right = pd.DataFrame({"b": [10, 20]}, index=["y", "z"])
+        op = JoinOp(how="outer", left_index=True, right_index=True)
+        result = run_op(op, left, right)
+        self.assertEqual({"x", "y", "z"}, set(result.index.tolist()))
+
+    def test_wrong_input_count_raises(self):
+        op = JoinOp(how="inner", left_on="k", right_on="k")
+        with self.assertRaises(ValueError):
+            run_op(op, pd.DataFrame({"k": [1]}))
+
+    def test_polars_not_implemented(self):
+        with force_polars():
+            op = JoinOp(how="inner", left_on="k", right_on="k")
+            with self.assertRaises(NotImplementedError):
+                run_op(op, pl.DataFrame({"k": [1]}), pl.DataFrame({"k": [1]}))
+
+
+class TestJoinRewrites(unittest.TestCase):
+    """End-to-end: skrub DataOp expressions get rewritten to JoinOp(s)."""
+
+    def _run_plan(self, ops):
+        """Execute a linearized DAG and return the last op's output."""
+        pool = BufferPool()
+        for op in ops:
+            inputs = [pool.pin(key) for key in op.inputs]
+            pool.put(op, op.process("fit_transform", {}, inputs))
+        return pool.pin(ops[-1])
+
+    def test_merge_on_key_rewrites_and_executes(self):
+        df1 = pd.DataFrame({"k": [1, 2, 3], "a": [10, 20, 30]})
+        df2 = pd.DataFrame({"k": [2, 3, 4], "b": [200, 300, 400]})
+        data = st.as_data_op(df1).merge(st.as_data_op(df2), on="k")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertEqual("k", join_ops[0].left_on)
+        self.assertEqual("k", join_ops[0].right_on)
+        self.assertEqual("inner", join_ops[0].how)
+
+        result = self._run_plan(ops)
+        expected = df1.merge(df2, on="k")
+        pd.testing.assert_frame_equal(
+            result.reset_index(drop=True), expected.reset_index(drop=True))
+
+    def test_merge_left_on_right_on_preserved(self):
+        df1 = pd.DataFrame({"lk": [1, 2], "a": [10, 20]})
+        df2 = pd.DataFrame({"rk": [2, 3], "b": [200, 300]})
+        data = st.as_data_op(df1).merge(
+            st.as_data_op(df2), left_on="lk", right_on="rk", how="outer")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertEqual("lk", join_ops[0].left_on)
+        self.assertEqual("rk", join_ops[0].right_on)
+        self.assertEqual("outer", join_ops[0].how)
+
+    def test_merge_sort_true_raises(self):
+        df1 = pd.DataFrame({"k": [1, 2]})
+        df2 = pd.DataFrame({"k": [1, 2]})
+        data = st.as_data_op(df1).merge(
+            st.as_data_op(df2), on="k", sort=True)
+        with self.assertRaises(NotImplementedError):
+            optimize(data, OptConfig(dataframe_ops=True))
+
+    def test_merge_sort_false_is_accepted(self):
+        df1 = pd.DataFrame({"k": [1, 2], "a": [10, 20]})
+        df2 = pd.DataFrame({"k": [1, 2], "b": [100, 200]})
+        data = st.as_data_op(df1).merge(
+            st.as_data_op(df2), on="k", sort=False)
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+
+    def test_join_no_args_defaults_to_index_based_left(self):
+        df1 = pd.DataFrame({"a": [1, 2]}, index=["x", "y"])
+        df2 = pd.DataFrame({"b": [10, 20]}, index=["x", "y"])
+        data = st.as_data_op(df1).join(st.as_data_op(df2))
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertEqual("left", join_ops[0].how)
+        self.assertTrue(join_ops[0].left_index)
+        self.assertTrue(join_ops[0].right_index)
+
+    def test_join_with_on_uses_left_on_and_right_index(self):
+        df1 = pd.DataFrame({"k": ["x", "y"], "a": [1, 2]})
+        df2 = pd.DataFrame({"b": [10, 20]}, index=["x", "y"])
+        data = st.as_data_op(df1).join(st.as_data_op(df2), on="k")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertEqual("k", join_ops[0].left_on)
+        self.assertFalse(join_ops[0].left_index)
+        self.assertTrue(join_ops[0].right_index)
+
+    def test_join_with_suffixes_rewrites_and_executes(self):
+        df1 = pd.DataFrame({"x": [1, 2, 3]}, index=["a", "b", "c"])
+        df2 = pd.DataFrame({"x": [10, 20, 30]}, index=["b", "c", "d"])
+        data = st.as_data_op(df1).join(
+            st.as_data_op(df2), lsuffix="_L", rsuffix="_R")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertTrue(join_ops[0].left_index)
+        self.assertTrue(join_ops[0].right_index)
+        self.assertEqual(("_L", "_R"), join_ops[0].suffixes)
+
+        result = self._run_plan(ops)
+        expected = df1.join(df2, lsuffix="_L", rsuffix="_R")
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_merge_overlapping_non_key_columns_uses_pandas_default_suffixes(self):
+        df1 = pd.DataFrame({"k": [1, 2], "v": [10, 20]})
+        df2 = pd.DataFrame({"k": [1, 2], "v": [100, 200]})
+        data = st.as_data_op(df1).merge(st.as_data_op(df2), on="k")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+        self.assertEqual(("_x", "_y"), join_ops[0].suffixes)
+
+        result = self._run_plan(ops)
+        expected = df1.merge(df2, on="k")
+        pd.testing.assert_frame_equal(
+            result.reset_index(drop=True), expected.reset_index(drop=True))
+        self.assertIn("v_x", result.columns)
+        self.assertIn("v_y", result.columns)
+
+    def test_join_overlapping_columns_without_suffixes_raises(self):
+        # Pandas .join() defaults both lsuffix and rsuffix to "", so overlapping
+        # columns raise ValueError. JoinOp must reproduce that — not silently
+        # invent suffixes like "_left"/"_right".
+        df1 = pd.DataFrame({"x": [1, 2]}, index=["a", "b"])
+        df2 = pd.DataFrame({"x": [10, 20]}, index=["a", "b"])
+        with self.assertRaisesRegex(Exception, "columns overlap"):
+            data = st.as_data_op(df1).join(st.as_data_op(df2))
+            optimize(data, OptConfig(dataframe_ops=True))
+
+    def test_join_overlapping_columns_with_suffixes_succeeds(self):
+        # Sibling to the above: with suffixes provided, the same join works.
+        df1 = pd.DataFrame({"x": [1, 2]}, index=["a", "b"])
+        df2 = pd.DataFrame({"x": [10, 20]}, index=["a", "b"])
+        data = st.as_data_op(df1).join(
+            st.as_data_op(df2), lsuffix="_L", rsuffix="_R")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(("_L", "_R"), join_ops[0].suffixes)
+
+        result = self._run_plan(ops)
+        expected = df1.join(df2, lsuffix="_L", rsuffix="_R")
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_chained_join_decomposes_into_binary_chain(self):
+        df1 = pd.DataFrame({"a": [1, 2, 3]}, index=["x", "y", "z"])
+        df2 = pd.DataFrame({"b": [10, 20, 30]}, index=["x", "y", "z"])
+        df3 = pd.DataFrame({"c": [100, 200, 300]}, index=["x", "y", "z"])
+        data = st.as_data_op(df1).join(
+            [st.as_data_op(df2), st.as_data_op(df3)])
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(2, len(join_ops))
+        # Both chain links are index-based.
+        for j in join_ops:
+            self.assertTrue(j.left_index)
+            self.assertTrue(j.right_index)
+        # Second JoinOp's left input is the first JoinOp.
+        self.assertIs(join_ops[0], join_ops[1].inputs[0])
+
+        result = self._run_plan(ops)
+        expected = df1.join([df2, df3])
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_chained_join_with_duplicate_inputs_raises_error(self):
+        df1 = pd.DataFrame({"a": [1, 2, 3]}, index=["x", "y", "z"])
+        df2 = pd.DataFrame(index=["x", "y", "z"])
+
+        df2_op = st.as_data_op(df2)
+        data = st.as_data_op(df1).join([df2_op, df2_op])
+        with self.assertRaisesRegex(ValueError, "Duplicate right-hand frames in chained joins are not supported"):
+            optimize(data, OptConfig(dataframe_ops=True))
+
+    def test_join_with_other_kwarg(self):
+        df1 = pd.DataFrame({"a": [1, 2]}, index=["x", "y"])
+        df2 = pd.DataFrame({"b": [10, 20]}, index=["x", "y"])
+        data = st.as_data_op(df1).join(other=st.as_data_op(df2))
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+
+        join_ops = [o for o in ops if isinstance(o, JoinOp)]
+        self.assertEqual(1, len(join_ops))
+
+        result = self._run_plan(ops)
+        expected = df1.join(df2)
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_merge_unsupported_arguments_raises(self):
+        df1 = pd.DataFrame({"k": [1, 2]})
+        df2 = pd.DataFrame({"k": [1, 2]})
+        data = st.as_data_op(df1).merge(
+            st.as_data_op(df2), on="k", indicator=True
+        )
+        with self.assertRaisesRegex(NotImplementedError, "Unsupported arguments for merge"):
+            optimize(data, OptConfig(dataframe_ops=True))
+
+    def test_join_unsupported_arguments_raises(self):
+        df1 = pd.DataFrame({"a": [1, 2]})
+        df2 = pd.DataFrame({"b": [1, 2]})
+        data = st.as_data_op(df1).join(
+            st.as_data_op(df2), validate="one_to_one"
+        )
+        with self.assertRaisesRegex(NotImplementedError, "Unsupported arguments for join"):
+            optimize(data, OptConfig(dataframe_ops=True))
+
+


### PR DESCRIPTION
  - New JoinOp: wraps pandas merge() with support for inner/outer/left/right joins, key-based and index-based matching, and configurable suffixes
  - Rewrite rules: extract_dataframe_op converts .merge() and .join() MethodCallOps into JoinOp, mapping pandas .join() semantics (lsuffix/rsuffix, default left join, index-based) to the unified JoinOp interface
  - Chained joins: df.join([df2, df3, ...]) decomposes into a binary JoinOp chain
  - Unsupported argument detection: raises NotImplementedError for sort=True, indicator, validate, etc.
  - Polars backend stubbed with NotImplementedError

Closes #55