### PR TITLE
[IR] Replace DATA_OP_PLACEHOLDER with explicit OperandRef (#87)

### DIFF
--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -43,6 +43,7 @@ class _Flags:
     DEBUG: bool = False
     force_polars: bool = _env_bool("STRATUM_FORCE_POLARS", False)
     fast_dataops_convert: bool = True
+    validate_dag: bool = True
 
 FLAGS = _Flags()
 
@@ -59,7 +60,8 @@ def set_config(rust_backend: bool | None = None,
     DEBUG: bool | None = None,
     force_polars: bool = False,
     cse: bool = True,
-    fast_dataops_convert: bool = True) -> None:
+    fast_dataops_convert: bool = True,
+    validate_dag: bool = True) -> None:
     """Runtime toggles (synced env for Rust to read).
 
     Parameter:
@@ -135,6 +137,7 @@ def set_config(rust_backend: bool | None = None,
 
     #FIXME: This should be the default. No need to set it. Remove.
     FLAGS.fast_dataops_convert = bool(fast_dataops_convert)
+    FLAGS.validate_dag = bool(validate_dag)
 
 
 def get_config() -> dict:
@@ -154,6 +157,7 @@ def get_config() -> dict:
         "force_polars": FLAGS.force_polars,
         "cse": FLAGS.cse,
         "fast_dataops_convert": FLAGS.fast_dataops_convert,
+        "validate_dag": FLAGS.validate_dag,
     }
 
 @contextmanager

--- a/stratum/optimizer/_op_utils.py
+++ b/stratum/optimizer/_op_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from collections import deque
 from typing import Iterator
 from graphviz import Digraph
-from stratum.optimizer.ir._ops import DATA_OP_PLACEHOLDER, Op, ChoiceOp
+from stratum.optimizer.ir._ops import OperandRef, Op, ChoiceOp
 from stratum._config import get_config
 import os
 from dataclasses import dataclass
@@ -126,9 +126,9 @@ def compute_graph_node_indegree(root: Op) -> tuple[deque[Op], dict[Op, int]]:
         else:
             for in_op in op.inputs:
                 if in_op not in indegree:
-                    if in_op is DATA_OP_PLACEHOLDER:
+                    if isinstance(in_op, OperandRef):
                         raise RuntimeError(
-                            f"Encountered DATA_OP_PLACEHOLDER as input of op {op}, which should not happen.")
+                            f"Encountered OperandRef as input of op {op}, which should not happen.")
                     curr_indegree = len(in_op.inputs)
                     indegree[in_op] = curr_indegree
                     queue1.append(in_op)
@@ -160,10 +160,45 @@ def topological_iterator_dfs(queue, indegree) -> Iterator[Op]:
             if indegree[out_op] == 0:
                 stack.append(out_op)
 
+def _iter_operand_refs(value):
+    """Yield every OperandRef nested in value (recurses lists/tuples/dicts)."""
+    if isinstance(value, OperandRef):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            yield from _iter_operand_refs(v)
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_operand_refs(v)
+
+
+def validate_operands(op: Op) -> None:
+    """Assert every OperandRef stored on `op` indexes a valid entry of op.inputs.
+
+    Catches rewrites that drop/reorder inputs without renumbering operand refs.
+    """
+    n = len(op.inputs)
+    for attr, value in op.__dict__.items():
+        if attr in ("inputs", "outputs", "remove_after"):
+            continue
+        for ref in _iter_operand_refs(value):
+            if not (0 <= ref.k < n):
+                raise ValueError(
+                    f"Operand {ref} on {op!r} (attr '{attr}') is out of range for "
+                    f"{n} input(s); a rewrite likely changed inputs without renumbering.")
+
+
+def validate_dag(root: Op) -> None:
+    """Run `validate_operands` over every op reachable from root."""
+    for op in topological_iterator(root):
+        validate_operands(op)
+
+
 def show_graph(root: Op, filename: str = 'plan'):
     """Show the runtime plan of the DataOp DAG."""
     dot = Digraph(comment=filename, format='png', graph_attr={'rankdir': 'BT'})
     for current_op in topological_iterator(root):
+        validate_operands(current_op)
         current_op.update_name()
         name = str(current_op) if not isinstance(current_op, ChoiceOp) else current_op.name
         name = name.replace("<","'").replace(">","'") if name is not None else "None"

--- a/stratum/optimizer/_optimize.py
+++ b/stratum/optimizer/_optimize.py
@@ -1,12 +1,12 @@
 from skrub._data_ops._evaluation import _Graph
 from skrub._data_ops import DataOp
 from skrub._data_ops._subsampling import SubsamplePreviews
-from collections import deque
+from collections import deque, defaultdict
 from ._cse import apply_cse
 from .ir._dataframe_ops import extract_dataframe_op, add_splitting_op
 from .ir._numeric_ops import extract_numeric_op
-from .ir._ops import ChoiceOp, ImplOp, Op, SearchEvalOp, as_op
-from ._op_utils import clone_sub_dag, find_choice_naive, replace_op_in_outputs, show_graph, topological_iterator
+from .ir._ops import ChoiceOp, Op, SearchEvalOp, as_op
+from ._op_utils import clone_sub_dag, find_choice_naive, replace_op_in_outputs, show_graph, topological_iterator, validate_dag
 from ._explain import explain_linear_plan
 from ._algebraic_rewrites import algebraic_rewrites, AlgebraicRewritesConfig
 from ._linearization import linearize_dag
@@ -75,6 +75,15 @@ def _debug_explain_linear_plan(name: str, linearized_dag: list, split_pos: int |
     if FLAGS.explain_linear_plan:
         explain_linear_plan(name, linearized_dag, split_pos)
 
+
+def _debug_validate_dag(root: Op):
+    """Assert every OperandRef indexes a valid input edge across the whole DAG.
+
+    Gated by FLAGS.validate_dag so a rewrite that drops/reorders inputs without
+    renumbering its operand refs fails loudly instead of silently miswiring."""
+    if FLAGS.validate_dag:
+        validate_dag(root)
+
 def optimize(dag_root: DataOp, config: OptConfig = None):
     """ Entry point for the logical optimizer. Takes a Skrub DataOp DAG, applies logical optimizations,
     and returns an Op root node."""
@@ -92,6 +101,7 @@ def optimize(dag_root: DataOp, config: OptConfig = None):
     # Convert to Op DAG and add splitting op
     root = convert_to_ops(dag_root)
     root = add_splitting_op(root)
+    _debug_validate_dag(root)  # operand refs as wired by as_op
 
     # Extract specialized operators from generic MethodCallOp / CallOp
     if config.dataframe_ops:
@@ -115,6 +125,7 @@ def optimize(dag_root: DataOp, config: OptConfig = None):
         _debug_show_graph(root, "algebraic_rewrite")
 
     # Final passes: linearization and buffer removal planning
+    _debug_validate_dag(root)  # operand refs after all rewrites, before linearization
     linearized_dag, split_pos, flagged_ops = linearize_dag(root)
     pinned_ops = compute_pinned_ops(linearized_dag, split_pos, flagged_ops)
     plan_input_removals(linearized_dag, pinned_ops)
@@ -164,37 +175,34 @@ def extract_frame_and_numeric_operators(root):
 
 
 def convert_to_ops(dag: DataOp) -> Op:
-    """ Convert a Skrub DataOp DAG to a stratum's logical IR (Op DAG)"""
+    """Convert a Skrub DataOp DAG to stratum's logical IR (Op DAG).
+
+    Single fused topological pass: ``as_op`` builds each op together with its
+    de-duplicated ``inputs`` list, operand references, and output edges. Inputs
+    are resolved through ``ids_to_ops`` (keyed by ``id(DataOp)``), which is
+    guaranteed populated because we walk in topological, inputs-first order.
+    """
     start = start_time()
     children, nodes, parents = get_dataops_graph(dag)
     order = topological_traverse(nodes, parents, children)
     root_id = order[-1]
 
-    # make logical IR:
-    # we start by making unconnected ops
-    ids_to_ops = {node: as_op(nodes[node]) for node in order}
-    # we then connect the ops to a graph
-    for node in order:
-        op = ids_to_ops[node]
-        if isinstance(op, ImplOp) and isinstance(op.skrub_impl, SubsamplePreviews):
-            output_ids = parents.get(node, [])
-            output_ops = [ids_to_ops[output] for output in output_ids]
-            input_id = children.get(node, [])[0]
-            input_op = ids_to_ops[input_id]
-            input_op.outputs.remove(op)
-            input_op.outputs.extend(output_ops)
-            for output_id in output_ids:
-                children[output_id].remove(node)
-                children[output_id].append(input_id)
-            del ids_to_ops[node]
-        else:
-            op.outputs = [ids_to_ops[output] for output in parents.get(node, [])]
+    # id(DataOp) -> Op. Keyed by DataOp identity (not the graph's node keys) so
+    # as_op's operand binder can resolve inputs found in the impl fields directly.
+    ids_to_ops = {}
+    for node_key in order:
+        skrub_op = nodes[node_key]
+        impl = skrub_op._skrub_impl
+        if isinstance(impl, SubsamplePreviews):
+            # Drop the preview node: route its single input straight to consumers.
+            # Consumers reference this node's DataOp in their fields, so mapping it
+            # to the input op makes them wire to the input op directly.
+            input_key = children.get(node_key, [])[0]
+            ids_to_ops[id(skrub_op)] = ids_to_ops[id(nodes[input_key])]
+            continue
+        ids_to_ops[id(skrub_op)] = as_op(skrub_op, ids_to_ops)
 
-            if op.is_choice():
-                convert_handle_choice(node, op, ids_to_ops, children)
-            else:
-                op.inputs = [ids_to_ops[input] for input in children.get(node, [])]
-    root = ids_to_ops[root_id]
+    root = ids_to_ops[id(nodes[root_id])]
     log_time("conversion took", start)
     _debug_show_graph(root, "conversion")
     return root
@@ -211,15 +219,6 @@ def get_dataops_graph(dag: DataOp) -> tuple[dict, dict, dict]:
     children = g["children"]
     log_time("Conversion dag took", start)
     return children, nodes, parents
-
-
-def convert_handle_choice(node, op, ids_to_ops, children):
-    input_iter = iter(ids_to_ops[input] for input in children.get(node, []))
-    for j, p in enumerate(op.inputs):
-        if p == 0:
-            op.inputs[j] = next(input_iter)
-        else:
-            p.outputs = [op]
 
 
 def choice_unrolling(root: Op):

--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -1,6 +1,6 @@
 from typing import Callable
 from collections.abc import Sequence
-from stratum.optimizer.ir._ops import (DATA_OP_PLACEHOLDER, BaseEstimatorOp, BinOp, CallOp, GetAttrOp, GetItemOp,
+from stratum.optimizer.ir._ops import (OperandRef, BaseEstimatorOp, BinOp, CallOp, GetAttrOp, GetItemOp,
                                        MethodCallOp, Op, ValueOp, VariableOp,_resolve_args, _resolve_kwargs)
 from pandas import DataFrame
 import pandas as pd
@@ -36,14 +36,16 @@ class DataSourceOp(Op):
             else:
                 return self.data
         else:
-            file_path = inputs[0] if self.file_path is DATA_OP_PLACEHOLDER else self.file_path
+            file_path = inputs[self.file_path.k] if isinstance(self.file_path, OperandRef) else self.file_path
+            read_args = _resolve_args(self.read_args, inputs) if self.read_args else []
+            read_kwargs = _resolve_kwargs(self.read_kwargs, inputs) if self.read_kwargs else {}
             if FLAGS.force_polars:
-                return pl.read_csv(file_path, *self.read_args, **self.read_kwargs)
+                return pl.read_csv(file_path, *read_args, **read_kwargs)
             else:
                 if self.format == "csv":
-                    return pd.read_csv(file_path, *self.read_args, **self.read_kwargs)
+                    return pd.read_csv(file_path, *read_args, **read_kwargs)
                 elif self.format == "npy":
-                    return np.load(file_path, *self.read_args, **self.read_kwargs)
+                    return np.load(file_path, *read_args, **read_kwargs)
                 else:
                     raise ValueError(f"Unsupported format: {self.format}")
 
@@ -105,10 +107,9 @@ class MetadataOp(Op):
         self.is_dataframe_op = True
 
     def process(self, mode: str, environment: dict, inputs: list):
-        input_iter = iter(inputs)
-        _obj = next(input_iter)
-        _args = _resolve_args(self.args, input_iter)
-        _kwargs = _resolve_kwargs(self.kwargs, input_iter)
+        _obj = inputs[0]
+        _args = _resolve_args(self.args, inputs)
+        _kwargs = _resolve_kwargs(self.kwargs, inputs)
         if FLAGS.force_polars:
             if "columns" in _kwargs:
                 _args.append(_kwargs["columns"])
@@ -142,12 +143,12 @@ class ProjectionOp(Op):
 
     def _extract_args_and_kwargs(self, inputs: list):
         """Extract and process arguments and kwargs from inputs."""
-        input_iter, args_iter = iter(inputs), iter(self.args)
-        _obj = next(input_iter)
-        if self.func is not None:
-            next(args_iter)
-        _args = _resolve_args(args_iter, input_iter)
-        _kwargs = _resolve_kwargs(self.kwargs, input_iter)
+        # The object is the implicit primary operand (index 0). For func-based ops
+        # the first positional arg is that object slot, so skip it here.
+        _obj = inputs[0]
+        args = self.args[1:] if self.func is not None else self.args
+        _args = _resolve_args(args, inputs)
+        _kwargs = _resolve_kwargs(self.kwargs, inputs)
         return _obj, _args, _kwargs
 
     def process(self, mode: str, environment: dict, inputs: list):
@@ -222,7 +223,7 @@ class AssignOp(ProjectionOp):
         if FLAGS.force_polars:
             checked_kwargs = {}
             for k, v in _kwargs.items():
-                if v is DATA_OP_PLACEHOLDER:
+                if isinstance(v, OperandRef):
                     raise NotImplementedError("Is not yet suppoerted, please report this issue")
                 elif isinstance(v, pd.Series) or isinstance(v, pd.DataFrame):
                     logger.warning(f"Converting pandas object to polars object for column {k}")
@@ -308,18 +309,18 @@ class ConcatOp(Op):
         0: "diagonal_relaxed",
         1: "horizontal",
     }
-    def __init__(self, first: Op, others: list[Op], axis: int):
+    def __init__(self, first, others: list, axis):
         super().__init__(name="CONCAT", is_X=False, is_y=False)
-        self.first = DATA_OP_PLACEHOLDER if isinstance(first, DataOp) else first
-        self.others = [DATA_OP_PLACEHOLDER if isinstance(other, DataOp) else other for other in others]
-        self.axis = DATA_OP_PLACEHOLDER if isinstance(axis, DataOp) else axis
+        # first/others entries/axis are OperandRefs when graph-fed, else constants.
+        self.first = first
+        self.others = list(others)
+        self.axis = axis
         self.is_dataframe_op = True
 
     def process(self, mode: str, environment: dict, inputs: list):
-        input_iter = iter(inputs)
-        first = next(input_iter) if self.first is DATA_OP_PLACEHOLDER else self.first
-        others = [next(input_iter) if other is DATA_OP_PLACEHOLDER else other for other in self.others]
-        axis = next(input_iter) if self.axis is DATA_OP_PLACEHOLDER else self.axis
+        first = inputs[self.first.k] if isinstance(self.first, OperandRef) else self.first
+        others = [inputs[o.k] if isinstance(o, OperandRef) else o for o in self.others]
+        axis = inputs[self.axis.k] if isinstance(self.axis, OperandRef) else self.axis
         if FLAGS.force_polars:
             return pl.concat([first, *others], how=self.axis_map[axis])
         else:
@@ -458,32 +459,31 @@ def make_datetime_conversion_op(op: CallOp) -> DatetimeConversionOp:
 
 
 def make_read_op(op: CallOp, format: str = "csv") -> DataSourceOp:
-    input_iter = iter(op.inputs)
-    # assume all inputs are ValueOps
+    # assume all inputs are ValueOps or VariableOps
     assert all(isinstance(arg, ValueOp) or isinstance(arg, VariableOp) for arg in op.inputs), "All inputs must be ValueOps or VariableOps"
+    # Rebuild a fresh, renumbered inputs list keeping only VariableOps as edges;
+    # ValueOp operands are inlined as their constant value.
     inputs = []
-    args = []
-    for arg in op.args:
-        if arg is DATA_OP_PLACEHOLDER:
-            actual_input_op = next(input_iter)
+    index = {}  # id(input op) -> new operand index
+
+    def keep(input_op):
+        i = index.get(id(input_op))
+        if i is None:
+            i = len(inputs)
+            inputs.append(input_op)
+            index[id(input_op)] = i
+        return OperandRef(i)
+
+    def convert(value):
+        if isinstance(value, OperandRef):
+            actual_input_op = op.inputs[value.k]
             if isinstance(actual_input_op, VariableOp):
-                args.append(DATA_OP_PLACEHOLDER)
-                inputs.append(actual_input_op)
-            else:
-                args.append(actual_input_op.value)
-        else:
-            args.append(arg)
-    kwargs = {}
-    for k, v in op.kwargs.items():
-        if v is DATA_OP_PLACEHOLDER:
-            actual_input_op = next(input_iter)
-            if isinstance(actual_input_op, VariableOp):
-                kwargs[k] = DATA_OP_PLACEHOLDER
-                inputs.append(actual_input_op)
-            else:
-                kwargs[k] = actual_input_op.value
-        else:
-            kwargs[k] = v
+                return keep(actual_input_op)
+            return actual_input_op.value
+        return value
+
+    args = [convert(a) for a in op.args]
+    kwargs = {k: convert(v) for k, v in op.kwargs.items()}
     new_op = DataSourceOp(file_path=args[0], _format=format, read_args=args[1:], read_kwargs=kwargs, inputs=inputs, outputs=op.outputs)
     for in_ in inputs:
         in_.replace_output(op, new_op)
@@ -510,7 +510,10 @@ def make_join_op(op: MethodCallOp) -> JoinOp:
         other_arg = op.kwargs.get("other")
 
     if isinstance(other_arg, (list, tuple)):
-        if len(other_arg) != len(set(id(x) for x in other_arg)):
+        # Compare by operand index: a frame used twice de-duplicates to one input
+        # edge (the same OperandRef.k), which the chained-join unrolling can't handle.
+        keys = [x.k if isinstance(x, OperandRef) else id(x) for x in other_arg]
+        if len(keys) != len(set(keys)):
             raise ValueError(
                 "Duplicate right-hand frames in chained joins are not supported."
             )

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -1,4 +1,4 @@
-from stratum.optimizer.ir._ops import BinOp, CallOp, Op, DATA_OP_PLACEHOLDER
+from stratum.optimizer.ir._ops import BinOp, CallOp, Op, OperandRef
 import operator
 import numpy as np
 from enum import Enum
@@ -92,8 +92,10 @@ class NumericOp(Op):
         elif self.type == NumericOpType.EXPM1:
             return np.expm1(inputs[0])
         elif self.type in _BINARY_TYPES:
+            # The primary operand is always input 0 (bound first); the optional
+            # second operand is referenced explicitly so x op x (single edge) works.
             primary = inputs[0]
-            operand = inputs[1] if self.opt_operand is DATA_OP_PLACEHOLDER else self.constant
+            operand = inputs[self.opt_operand.k] if isinstance(self.opt_operand, OperandRef) else self.constant
             left, right = (operand, primary) if self.reversed else (primary, operand)
             if self.type == NumericOpType.ADD:
                 return np.add(left, right)
@@ -119,10 +121,10 @@ def make_binary_numeric_op(op: CallOp, type: NumericOpType) -> NumericOp:
         raise ValueError(
             f"make_binary_numeric_op called with args that are not a pair: {args}"
         )
-    l_ph = args[0] is DATA_OP_PLACEHOLDER
-    r_ph = args[1] is DATA_OP_PLACEHOLDER
+    l_ph = isinstance(args[0], OperandRef)
+    r_ph = isinstance(args[1], OperandRef)
     if l_ph and r_ph:
-        extra = dict(opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+        extra = dict(opt_operand=args[1], reversed=False)
     elif l_ph:
         extra = dict(constant=args[1], reversed=False)
     elif r_ph:
@@ -139,11 +141,11 @@ def extract_numeric_op(op: Op, root: Op) -> tuple[Op, bool]:
     if isinstance(op, BinOp) and op.op is operator.pow and op.right == 2:
         new_op = NumericOp(func=np.square, args=(), kwargs={}, inputs=op.inputs, outputs=op.outputs)
     elif isinstance(op, BinOp) and op.op in _ARITH_OP_MAP:
-        l_ph = op.left is DATA_OP_PLACEHOLDER
-        r_ph = op.right is DATA_OP_PLACEHOLDER
+        l_ph = isinstance(op.left, OperandRef)
+        r_ph = isinstance(op.right, OperandRef)
         extra = None
         if l_ph and r_ph:
-            extra = dict(opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+            extra = dict(opt_operand=op.right, reversed=False)
         elif l_ph:
             extra = dict(constant=op.right, reversed=False)
         elif r_ph:

--- a/stratum/optimizer/ir/_ops.py
+++ b/stratum/optimizer/ir/_ops.py
@@ -9,32 +9,128 @@ from skrub._data_ops._choosing import Choice
 from skrub._data_ops._data_ops import DataOp, Apply, Value, CallMethod, Call, GetAttr, GetItem, BinOp as SkrubBinOp, Concat, Var, _wrap_estimator
 from pandas import DataFrame
 from polars import DataFrame as PlDataFrame, Series as PlSeries
+from stratum.utils._skrub_graph import _collect_child_data_ops
 import logging
 import os
 logger = logging.getLogger(__name__)
 
-class PlaceHolder():
-    def __init__(self, name: str):
-        self.name = name
-    
+
+def _operand_index_from_impl(skrub_impl) -> dict:
+    """Map id(DataOp) -> operand index, in the canonical field-walk order.
+
+    Uses the same walk as graph extraction (`_collect_child_data_ops` over
+    `impl._fields`), de-duplicating repeated DataOps to the same index. This is
+    the single source of truth shared with the converter so that an ImplOp's
+    `inputs` list and its operand indices always agree.
+    """
+    index: dict = {}
+    for field_name in skrub_impl._fields:
+        for data_op in _collect_child_data_ops(getattr(skrub_impl, field_name)):
+            if id(data_op) not in index:
+                index[id(data_op)] = len(index)
+    return index
+
+class OperandRef:
+    """Explicit reference to the ``k``-th entry of an :class:`Op`'s ``inputs`` list.
+
+    Replaces the old opaque ``DATA_OP_PLACEHOLDER`` sentinel. Instead of relying on
+    the *order* in which placeholders are walked at runtime, an operand now carries
+    the exact index of the input that fills it, so ``process()`` can resolve
+    ``inputs[ref.k]`` directly and rewrites that reorder inputs are checkable.
+    """
+    __slots__ = ("k",)
+
+    def __init__(self, k: int):
+        self.k = k
+
+    def __eq__(self, other):
+        return isinstance(other, OperandRef) and other.k == self.k
+
+    def __hash__(self):
+        return hash(("OperandRef", self.k))
+
     def __str__(self):
-        return self.name
+        return f"${self.k}"
 
     def __repr__(self):
-        return self.name
-
-# unique identifier for arguments, which need to be replaced with Op references later
-DATA_OP_PLACEHOLDER = PlaceHolder("DATA_OP_PLACEHOLDER")
+        return f"OperandRef({self.k})"
 
 
-def _resolve_args(args, input_iter):
-    """Replace DATA_OP_PLACEHOLDERs in an args sequence with values from input_iter."""
-    return [next(input_iter) if a is DATA_OP_PLACEHOLDER else a for a in args]
+class OperandBinder:
+    """Builds an op's de-duplicated ``inputs`` list and replaces DataOps in
+    structured fields with :class:`OperandRef`, all from a single ordered walk.
+
+    The order in which ``ref``/``bind_seq``/``bind_map`` are called defines the
+    canonical operand order (e.g. the implicit primary object is bound first, so
+    it becomes ``OperandRef(0)``). Repeated DataOps map to the same index, so the
+    same upstream op feeding two slots produces a single input edge.
+    """
+
+    def __init__(self, ids_to_ops: dict):
+        self.ids_to_ops = ids_to_ops
+        self.inputs: list = []
+        self._index: dict = {}  # id(Op) -> position in self.inputs
+
+    def ref_op(self, op: "Op") -> OperandRef:
+        """Bind an already-converted Op (not a DataOp) to an OperandRef."""
+        idx = self._index.get(id(op))
+        if idx is None:
+            idx = len(self.inputs)
+            self.inputs.append(op)
+            self._index[id(op)] = idx
+        return OperandRef(idx)
+
+    def ref(self, data_op: DataOp) -> OperandRef:
+        """Bind a single DataOp to an OperandRef via the id->Op lookup."""
+        return self.ref_op(self.ids_to_ops[id(data_op)])
+
+    def bind(self, value):
+        """Recursively replace DataOps nested in tuples/lists/dicts with OperandRefs.
+
+        The recursion order mirrors ``_collect_child_data_ops`` so operand indices
+        line up with the graph's child order (e.g. ``df.join([df2, df3])`` binds
+        df2 then df3 inside the list argument).
+        """
+        if isinstance(value, DataOp):
+            return self.ref(value)
+        if isinstance(value, tuple):
+            return tuple(self.bind(v) for v in value)
+        if isinstance(value, list):
+            return [self.bind(v) for v in value]
+        if isinstance(value, dict):
+            return {k: self.bind(v) for k, v in value.items()}
+        return value
+
+    def bind_seq(self, seq):
+        """Bind DataOps in a tuple/list argument sequence to OperandRefs."""
+        return tuple(self.bind(a) for a in seq)
+
+    def bind_map(self, mapping):
+        """Bind DataOps in a kwargs dict to OperandRefs."""
+        return {k: self.bind(v) for k, v in mapping.items()}
 
 
-def _resolve_kwargs(kwargs, input_iter):
-    """Replace DATA_OP_PLACEHOLDERs in a kwargs dict with values from input_iter."""
-    return {k: next(input_iter) if v is DATA_OP_PLACEHOLDER else v for k, v in kwargs.items()}
+def _resolve_operand(value, inputs):
+    """Recursively replace OperandRefs nested in value with values from inputs."""
+    if isinstance(value, OperandRef):
+        return inputs[value.k]
+    if isinstance(value, tuple):
+        return tuple(_resolve_operand(v, inputs) for v in value)
+    if isinstance(value, list):
+        return [_resolve_operand(v, inputs) for v in value]
+    if isinstance(value, dict):
+        return {k: _resolve_operand(v, inputs) for k, v in value.items()}
+    return value
+
+
+def _resolve_args(args, inputs):
+    """Replace OperandRefs in an args sequence with values from the inputs list."""
+    return [_resolve_operand(a, inputs) for a in args]
+
+
+def _resolve_kwargs(kwargs, inputs):
+    """Replace OperandRefs in a kwargs dict with values from the inputs list."""
+    return {k: _resolve_operand(v, inputs) for k, v in kwargs.items()}
 
 class Op():
     def __init__(self, inputs=None,outputs=None, name=None, is_X=False, is_y=False):
@@ -73,11 +169,24 @@ class Op():
     def is_choice(self) -> bool:
         return isinstance(self, ChoiceOp)
 
+    @property
+    def num_input_operands(self) -> int:
+        return len(self.inputs)
+
     def add_output(self, output: Op):
+        """Add an output edge, de-duplicating so an op appears at most once."""
+        for out_ in self.outputs:
+            if out_ is output:
+                return
         self.outputs.append(output)
 
-    def add_input(self, input: Op):
+    def add_input(self, input: Op) -> int:
+        """Add an input edge, de-duplicating. Returns the operand index of `input`."""
+        for i, in_ in enumerate(self.inputs):
+            if in_ is input:
+                return i
         self.inputs.append(input)
+        return len(self.inputs) - 1
 
     def replace_input(self, old_input: Op, new_input: Op):
         for i, in_ in enumerate(self.inputs):
@@ -142,14 +251,23 @@ class ImplOp(Op):
         new_op.was_cloned = True
         return new_op
 
+    @property
+    def operand_index(self) -> dict:
+        """Cached id(DataOp) -> operand index map for this impl's fields."""
+        idx = getattr(self, "_operand_index", None)
+        if idx is None:
+            idx = _operand_index_from_impl(self.skrub_impl)
+            self._operand_index = idx
+        return idx
+
     def replace_fields_with_values(self, inputs):
         """Replace DataOp fields in implementation with their computed values."""
-        input_iter = iter(inputs)
+        index = self.operand_index
 
         def replace_dataop(value):
-            """Recursively replace DataOp instances with their actual values."""
+            """Recursively replace DataOp instances with their resolved input."""
             if isinstance(value, DataOp):
-                return next(input_iter)
+                return inputs[index[id(value)]]
             elif isinstance(value, (list, tuple)):
                 new_seq = [replace_dataop(item) for item in value]
                 return type(value)(new_seq)
@@ -163,17 +281,20 @@ class ImplOp(Op):
     def process(self, mode: str, environment: dict, inputs: list):
         if hasattr(self.skrub_impl, "eval"):
             # DataOp with eval method have a fused implementation of the generator and the compute method
-            # we need to iterate over the generator and replace the requested fields with correct inputs
+            # we need to iterate over the generator and replace the requested fields with correct inputs.
+            # Indices are assigned in yield order (de-duplicating repeated DataOps), matching the
+            # order in which inputs are consumed.
+            index = {}
             last_yield = None
             gen = self.skrub_impl.eval(mode=mode, environment=environment)
-            input_iter = iter(inputs)
             while True:
                 try:
                     last_yield = gen.send(last_yield)
                 except StopIteration as e:
                     return e.value
                 if isinstance(last_yield, DataOp):
-                    last_yield = next(input_iter)
+                    k = index.setdefault(id(last_yield), len(index))
+                    last_yield = inputs[k]
         else:
             ns = self.replace_fields_with_values(inputs)
             return self.skrub_impl.compute(ns, mode, environment)
@@ -194,23 +315,25 @@ class VariableOp(Op):
         return environment[self.name]
 
 class BaseEstimatorOp(Op):
-    fields = ["estimator", "y", "cols", "how", "allow_reject", "unsupervised", "kwargs"]
-    
-    def __init__(self, estimator: BaseEstimator, y=None, cols=None, how="no-wrap", allow_reject=False, unsupervised=False, kwargs=None):
+    fields = ["estimator", "y", "cols", "how", "allow_reject", "unsupervised", "kwargs", "param_refs"]
+
+    def __init__(self, estimator: BaseEstimator, y=None, cols=None, how="no-wrap", allow_reject=False, unsupervised=False, kwargs=None, param_refs=None):
         super().__init__(name=estimator.__class__.__name__)
         if kwargs is None:
             kwargs = {}
         self.check_kwargs(kwargs)
         self.estimator = estimator
-        place_holders = {k: v for k, v in self.estimator.get_params().items() if isinstance(v, DataOp)}
-        self.estimator.set_params(**place_holders)
         self.original_estimator = clone(self.estimator)
-        self.y = DATA_OP_PLACEHOLDER if isinstance(y, DataOp) else y
-        self.cols = DATA_OP_PLACEHOLDER if isinstance(cols, DataOp) else cols
+        # X is the implicit primary operand (OperandRef(0)); y/cols are OperandRef
+        # when fed by the graph, otherwise plain values. param_refs maps the names of
+        # estimator hyper-parameters that are graph-fed to their OperandRef.
+        self.y = y
+        self.cols = cols
         self.how = how
         self.allow_reject = allow_reject
         self.unsupervised = unsupervised
-        self.kwargs = remove_datops_from_args(kwargs) if kwargs is not None else kwargs
+        self.kwargs = kwargs
+        self.param_refs = param_refs if param_refs is not None else {}
         self.parallelism = os.cpu_count() # TODO:this will should be set during physical planning phase
 
     def clone(self):
@@ -218,13 +341,14 @@ class BaseEstimatorOp(Op):
         estimator_new = clone(self.estimator)
         estimator_new.set_params(**params)
         new_op = self.__class__(
-            estimator=estimator_new, 
-            y=self.y, 
-            cols=self.cols, 
-            how=self.how, 
-            allow_reject=self.allow_reject, 
-            unsupervised=self.unsupervised, 
-            kwargs=self.kwargs
+            estimator=estimator_new,
+            y=self.y,
+            cols=self.cols,
+            how=self.how,
+            allow_reject=self.allow_reject,
+            unsupervised=self.unsupervised,
+            kwargs=self.kwargs,
+            param_refs=self.param_refs,
         )
         new_op.was_cloned = True
         return new_op
@@ -235,14 +359,13 @@ class BaseEstimatorOp(Op):
 
         Returns a tuple of picklable data that can be sent to worker processes.
         """
-        input_iter = iter(inputs)
-        x = next(input_iter)
+        x = inputs[0]
         assert x is not None, f"X is None for {self}"
-        y = None if mode == 'predict' else next(input_iter) if self.y == DATA_OP_PLACEHOLDER else self.y
+        y = None if mode == 'predict' else inputs[self.y.k] if isinstance(self.y, OperandRef) else self.y
         estm = self.estimator if mode == "predict" else self.original_estimator
-        place_holders = {k: next(input_iter) for k, v in estm.get_params().items() if isinstance(v, DataOp)}
+        place_holders = {name: inputs[ref.k] for name, ref in self.param_refs.items()}
         estm.set_params(**place_holders)
-        cols = next(input_iter) if self.cols == DATA_OP_PLACEHOLDER else self.cols
+        cols = inputs[self.cols.k] if isinstance(self.cols, OperandRef) else self.cols
         return (
             estm,
             x,
@@ -347,7 +470,7 @@ def process_transformer_task(task_data):
 class ChoiceOp(Op):
     fields = ["outcome_names"]
     
-    def __init__(self, outcome_names: list[str] = None, n_outcomes: int = None, choice_name: str=None, append_choice_name = True, inputs: list[Op] = None):
+    def __init__(self, outcome_names: list[str] = None, n_outcomes: int = None, choice_name: str=None, append_choice_name = True, inputs: list = None):
         if inputs is None:
             inputs = []
         if outcome_names is None:
@@ -404,14 +527,14 @@ class MethodCallOp(Op):
         if kwargs is not None:
             self.check_kwargs(kwargs)
         self.method_name = method_name
-        self.args = remove_datops_from_args(args) if args is not None else args
-        self.kwargs = remove_datops_from_args(kwargs) if kwargs is not None else kwargs
+        self.args = args
+        self.kwargs = kwargs
 
     def process(self, mode: str, environment: dict, inputs: list):
-        input_iter = iter(inputs)
-        _obj = next(input_iter)
-        _args = _resolve_args(self.args, input_iter)
-        _kwargs = _resolve_kwargs(self.kwargs, input_iter)
+        # The object the method is called on is the implicit primary operand (index 0).
+        _obj = inputs[0]
+        _args = _resolve_args(self.args, inputs)
+        _kwargs = _resolve_kwargs(self.kwargs, inputs)
         if self.method_name == "apply" and isinstance(_obj, PlSeries):
             return _obj.map_elements(*_args, **_kwargs)
         return _obj.__getattribute__(self.method_name)(*_args, **_kwargs)
@@ -426,13 +549,12 @@ class CallOp(Op):
         if kwargs is not None:
             self.check_kwargs(kwargs)
         self.func = func
-        self.args = remove_datops_from_args(args) if args is not None else args
-        self.kwargs = remove_datops_from_args(kwargs) if kwargs is not None else kwargs
+        self.args = args
+        self.kwargs = kwargs
 
     def process(self, mode: str, environment: dict, inputs: list):
-        input_iter = iter(inputs)
-        _args = _resolve_args(self.args, input_iter)
-        _kwargs = _resolve_kwargs(self.kwargs, input_iter)
+        _args = _resolve_args(self.args, inputs)
+        _kwargs = _resolve_kwargs(self.kwargs, inputs)
         return self.func(*_args, **_kwargs)
 
 class GetAttrOp(Op):
@@ -454,16 +576,17 @@ class GetAttrOp(Op):
 class GetItemOp(Op):
     fields = ["key"]
     
-    def __init__(self, key=None):
-        self.key = DATA_OP_PLACEHOLDER if isinstance(key, DataOp) else key
-        name = key._skrub_impl.__class__.__name__ if isinstance(key, DataOp) else str(self.key)
+    def __init__(self, key=None, name=None):
+        # key is either a constant or an OperandRef (when the key is graph-fed).
+        self.key = key
+        if name is None:
+            name = str(key)
         super().__init__(name=name)
 
 
     def process(self, mode: str, environment: dict, inputs: list):
-        key = self.key
-        if key is DATA_OP_PLACEHOLDER:
-            key = inputs[1]
+        # The container being indexed is the implicit primary operand (index 0).
+        key = inputs[self.key.k] if isinstance(self.key, OperandRef) else self.key
         return inputs[0][key]
 
 class BinOp(Op):
@@ -472,22 +595,14 @@ class BinOp(Op):
     def __init__(self, op: Callable, left, right):
         super().__init__(name=op.__name__.lstrip('__').rstrip('__'))
         self.op = op
-        self.left = DATA_OP_PLACEHOLDER if isinstance(left, DataOp) else left
-        self.right = DATA_OP_PLACEHOLDER if isinstance(right, DataOp) else right
+        # left/right are OperandRefs when graph-fed, otherwise constants.
+        self.left = left
+        self.right = right
 
 
     def process(self, mode: str, environment: dict, inputs: list):
-        i = 0
-        if self.left is DATA_OP_PLACEHOLDER:
-            left = inputs[i]
-            i += 1
-        else:
-            left = self.left
-        if self.right is DATA_OP_PLACEHOLDER:
-            right = inputs[i]
-            i += 1
-        else:
-            right = self.right
+        left = inputs[self.left.k] if isinstance(self.left, OperandRef) else self.left
+        right = inputs[self.right.k] if isinstance(self.right, OperandRef) else self.right
         return self.op(left, right)
 
 class SearchEvalOp(Op):    
@@ -501,65 +616,102 @@ class SearchEvalOp(Op):
     def clone(self, children: list[Op] = None, parents: list[Op] = None):
         raise ValueError(f"We should not clone SearchEvalOp objects.")
 
-def remove_datops_from_args(args: tuple  | dict):
-    if isinstance(args, tuple):
-        return tuple(DATA_OP_PLACEHOLDER if isinstance(a, DataOp) else a for a in args)
-    elif isinstance(args, dict):
-        return {k: DATA_OP_PLACEHOLDER if isinstance(v, DataOp) else v for k,v in args.items()}
-    else:
-        raise ValueError(f"Expected tuple or dict, got {type(args)}")
+def _bind_or_value(binder: OperandBinder, value):
+    """Bind a field that is either a single DataOp (-> OperandRef) or a constant."""
+    return binder.ref(value) if isinstance(value, DataOp) else value
 
-def as_op(data_op: DataOp):
+
+def as_op(data_op: DataOp, ids_to_ops: dict) -> Op:
+    """Convert a single skrub DataOp into an Op, building its de-duplicated
+    ``inputs`` list and operand references in one canonical field walk.
+
+    ``ids_to_ops`` maps ``id(DataOp) -> Op`` and must already contain every input
+    of ``data_op`` (guaranteed by converting in topological order). Output edges
+    are wired here too: each input op gets ``data_op``'s Op added to its outputs.
+    """
     impl = data_op._skrub_impl
-    is_X = False
-    is_y = False
+    is_X = is_y = False
     if impl is not None:
         is_X = impl.is_X
         is_y = impl.is_y
+    binder = OperandBinder(ids_to_ops)
     return_op = None
+
     if isinstance(impl, Value):
         if isinstance(impl.value, Choice):
             choice = impl.value
-            parents = [0]*len(choice.outcomes)
-            for i, outcome in enumerate(choice.outcomes):
-                if not isinstance(outcome, DataOp):
-                    # TODO handle tuples of dataops
-                    parents[i] = ValueOp(outcome)
-            return_op = ChoiceOp(choice.outcome_names, len(choice.outcomes), choice.name, inputs=parents)
+            # Choice outcomes are consumed positionally by ChoiceOp.process; keep one
+            # input entry per outcome (constants become fresh ValueOps).
+            inputs = [ids_to_ops[id(o)] if isinstance(o, DataOp) else ValueOp(o)
+                      for o in choice.outcomes]
+            return_op = ChoiceOp(choice.outcome_names, len(choice.outcomes), choice.name)
+            return_op.inputs = inputs
         else:
             return_op = ValueOp(impl.value)
     elif isinstance(impl, CallMethod):
-        return_op = MethodCallOp(impl.method_name, impl.args, impl.kwargs)
+        binder.ref(impl.obj)  # implicit primary operand -> OperandRef(0)
+        return_op = MethodCallOp(impl.method_name, binder.bind_seq(impl.args), binder.bind_map(impl.kwargs))
+        return_op.inputs = binder.inputs
     elif isinstance(impl, Call):
         return_op = CallOp(
             name=impl.get_func_name(),
             func=impl.func,
-            args=impl.args,
-            kwargs=impl.kwargs
+            args=binder.bind_seq(impl.args),
+            kwargs=binder.bind_map(impl.kwargs),
         )
+        return_op.inputs = binder.inputs
     elif isinstance(impl, GetAttr):
+        binder.ref(impl.source_object)  # OperandRef(0)
         return_op = GetAttrOp(attr_name=impl.attr_name)
+        return_op.inputs = binder.inputs
     elif isinstance(impl, GetItem):
-        return_op = GetItemOp(key=impl.key)
+        binder.ref(impl.container)  # OperandRef(0)
+        key = _bind_or_value(binder, impl.key)
+        name = impl.key._skrub_impl.__class__.__name__ if isinstance(impl.key, DataOp) else str(impl.key)
+        return_op = GetItemOp(key=key, name=name)
+        return_op.inputs = binder.inputs
     elif isinstance(impl, SkrubBinOp):
-        return_op = BinOp(op=impl.op, left=impl.left, right=impl.right)
+        left = _bind_or_value(binder, impl.left)
+        right = _bind_or_value(binder, impl.right)
+        return_op = BinOp(op=impl.op, left=left, right=right)
+        return_op.inputs = binder.inputs
     elif isinstance(impl, Apply):
         estimator_class = EstimatorOp if hasattr(impl.estimator, "predict") else TransformerOp
+        binder.ref(impl.X)  # OperandRef(0)
+        param_refs = {k: binder.ref(v) for k, v in impl.estimator.get_params().items()
+                      if isinstance(v, DataOp) and id(v) in ids_to_ops}
+        y = _bind_or_value(binder, impl.y)
+        cols = _bind_or_value(binder, impl.cols)
         return_op = estimator_class(
-            y=impl.y, 
-            estimator=impl.estimator, 
-            cols=impl.cols, 
-            how=impl.how, 
-            allow_reject=impl.allow_reject, 
-            unsupervised=impl.unsupervised, 
-            kwargs= {})
+            estimator=impl.estimator,
+            y=y,
+            cols=cols,
+            how=impl.how,
+            allow_reject=impl.allow_reject,
+            unsupervised=impl.unsupervised,
+            kwargs={},
+            param_refs=param_refs,
+        )
+        return_op.inputs = binder.inputs
     elif isinstance(impl, Var):
         return_op = VariableOp(name=impl.name, value=impl.value)
     elif isinstance(impl, Concat):
         from stratum.optimizer.ir._dataframe_ops import ConcatOp
-        return_op = ConcatOp(first=impl.first, others=impl.others, axis=impl.axis)
+        first = _bind_or_value(binder, impl.first)
+        others = list(binder.bind_seq(impl.others))
+        axis = _bind_or_value(binder, impl.axis)
+        return_op = ConcatOp(first=first, others=others, axis=axis)
+        return_op.inputs = binder.inputs
     else:
+        for field_name in impl._fields:
+            for child in _collect_child_data_ops(getattr(impl, field_name)):
+                binder.ref(child)
         return_op = ImplOp(skrub_impl=impl, name=data_op.__skrub_short_repr__())
+        return_op.inputs = binder.inputs
+
+    # Wire output edges: every input op gets this op added to its outputs (deduped).
+    for in_op in return_op.inputs:
+        in_op.add_output(return_op)
 
     return_op.is_X = is_X
     return_op.is_y = is_y

--- a/stratum/tests/logical_optimizer/test_dataframe_ops.py
+++ b/stratum/tests/logical_optimizer/test_dataframe_ops.py
@@ -15,7 +15,7 @@ from stratum.optimizer.ir._dataframe_ops import (
     ApplyUDFOp, AssignOp, ConcatOp, DataSourceOp, DatetimeConversionOp, DropOp,
     GetAttrProjectionOp, JoinOp, MetadataOp, ProjectionOp, SplitOp,
     make_datetime_conversion_op, make_read_op)
-from stratum.optimizer.ir._ops import (CallOp, DATA_OP_PLACEHOLDER, GetItemOp,
+from stratum.optimizer.ir._ops import (CallOp, OperandRef, GetItemOp,
                                        MethodCallOp, Op, ValueOp)
 from stratum.runtime._buffer_pool import BufferPool
 
@@ -213,7 +213,7 @@ class TestProjectionOp(unittest.TestCase):
 
     def test_func_path(self):
         op = ProjectionOp(func=lambda df, v: df * v,
-                          args=(DATA_OP_PLACEHOLDER, 2), kwargs={})
+                          args=(OperandRef(0), 2), kwargs={})
         result = run_op(op, pd.DataFrame({"a": [1, 2]}))
         self.assertEqual([2, 4], result["a"].tolist())
 
@@ -292,9 +292,10 @@ class TestAssignOpPolars(PolarsTestCase):
         self.assertIn("b", result.columns)
 
     def test_placeholder_raises(self):
-        op = AssignOp(args=(), kwargs={"b": DATA_OP_PLACEHOLDER})
+        # An OperandRef surviving into a polars assign kwarg is unsupported.
+        op = AssignOp(args=(), kwargs={"b": OperandRef(1)})
         with self.assertRaises(NotImplementedError):
-            run_op(op, pl.DataFrame({"a": [1, 2]}), DATA_OP_PLACEHOLDER)
+            run_op(op, pl.DataFrame({"a": [1, 2]}), OperandRef(1))
 
 
 class TestDatetimeConversionOp(unittest.TestCase):
@@ -334,8 +335,7 @@ class TestGetAttrProjectionOp(unittest.TestCase):
 
 class TestConcatOpPolars(PolarsTestCase):
     def test_polars_concat(self):
-        op = ConcatOp(first=MagicMock(spec=DataOp),
-                      others=[MagicMock(spec=DataOp)], axis=0)
+        op = ConcatOp(first=OperandRef(0), others=[OperandRef(1)], axis=0)
         result = run_op(op, pl.DataFrame({"a": [1, 2]}), pl.DataFrame({"a": [3, 4]}))
         self.assertEqual(4, len(result))
 
@@ -409,7 +409,7 @@ class TestMakeReadOp(unittest.TestCase):
 
     def test_with_plain_positional_arg(self):
         call_op = CallOp(func=pd.read_csv,
-                         args=(DATA_OP_PLACEHOLDER, ","), kwargs={})
+                         args=(OperandRef(0), ","), kwargs={})
         call_op.inputs = [ValueOp("dummy.csv")]
         new_op = make_read_op(call_op)
         self.assertIsInstance(new_op, DataSourceOp)
@@ -419,7 +419,7 @@ class TestMakeReadOp(unittest.TestCase):
 class TestMakeDatetimeConversionOp(unittest.TestCase):
     def test_extra_positional_args(self):
         op = CallOp(func=pd.to_datetime,
-                    args=(DATA_OP_PLACEHOLDER, "ISO8601"), kwargs={})
+                    args=(OperandRef(0), "ISO8601"), kwargs={})
         new_op = make_datetime_conversion_op(op)
         self.assertEqual(("ISO8601",), tuple(new_op.args))
 

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -5,7 +5,7 @@ import stratum as st
 import numpy as np
 from sklearn.dummy import DummyRegressor
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType, make_binary_numeric_op
-from stratum.optimizer.ir._ops import CallOp, DATA_OP_PLACEHOLDER
+from stratum.optimizer.ir._ops import CallOp, OperandRef
 from stratum.optimizer._optimize import optimize
 
 class TestNumericOps(unittest.TestCase):
@@ -163,23 +163,23 @@ class TestNumericOps(unittest.TestCase):
         self.assertEqual(out[1].type, NumericOpType.DIVIDE)
 
     def test_process_add_var_var(self):
-        op = NumericOp([], [], type=NumericOpType.ADD, opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+        op = NumericOp([], [], type=NumericOpType.ADD, opt_operand=OperandRef(1), reversed=False)
         self.assertIsNone(op.constant)
         result = op.process("fit", {}, [np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])])
         np.testing.assert_array_almost_equal(result, np.array([5.0, 7.0, 9.0]))
 
     def test_process_subtract_var_var(self):
-        op = NumericOp([], [], type=NumericOpType.SUBTRACT, opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+        op = NumericOp([], [], type=NumericOpType.SUBTRACT, opt_operand=OperandRef(1), reversed=False)
         result = op.process("fit", {}, [np.array([10.0, 9.0, 8.0]), np.array([1.0, 2.0, 3.0])])
         np.testing.assert_array_almost_equal(result, np.array([9.0, 7.0, 5.0]))
 
     def test_process_multiply_var_var(self):
-        op = NumericOp([], [], type=NumericOpType.MULTIPLY, opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+        op = NumericOp([], [], type=NumericOpType.MULTIPLY, opt_operand=OperandRef(1), reversed=False)
         result = op.process("fit", {}, [np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])])
         np.testing.assert_array_almost_equal(result, np.array([4.0, 10.0, 18.0]))
 
     def test_process_divide_var_var(self):
-        op = NumericOp([], [], type=NumericOpType.DIVIDE, opt_operand=DATA_OP_PLACEHOLDER, reversed=False)
+        op = NumericOp([], [], type=NumericOpType.DIVIDE, opt_operand=OperandRef(1), reversed=False)
         result = op.process("fit", {}, [np.array([6.0, 8.0, 9.0]), np.array([2.0, 4.0, 3.0])])
         np.testing.assert_array_almost_equal(result, np.array([3.0, 2.0, 3.0]))
 
@@ -187,7 +187,7 @@ class TestNumericOps(unittest.TestCase):
         ops = [op for op in out if isinstance(op, NumericOp) and op.type == numeric_type]
         self.assertEqual(len(ops), 1)
         op = ops[0]
-        self.assertIs(op.opt_operand, DATA_OP_PLACEHOLDER)
+        self.assertEqual(op.opt_operand, OperandRef(1))
         self.assertIsNone(op.constant)
         self.assertFalse(op.reversed)
         return op
@@ -309,13 +309,13 @@ class TestNumericOps(unittest.TestCase):
 
     def test_make_binary_numeric_op_raises_on_non_pair_args(self):
         op = CallOp(func=np.add, args=None)
-        op.args = (DATA_OP_PLACEHOLDER,)
+        op.args = (OperandRef(0),)
         with self.assertRaises(ValueError):
             make_binary_numeric_op(op, NumericOpType.ADD)
 
     def test_make_binary_numeric_op_const_var(self):
         op = CallOp(func=np.subtract, args=None)
-        op.args = (10, DATA_OP_PLACEHOLDER)
+        op.args = (10, OperandRef(0))
         result = make_binary_numeric_op(op, NumericOpType.SUBTRACT)
         self.assertEqual(result.constant, 10)
         self.assertTrue(result.reversed)

--- a/stratum/tests/logical_optimizer/test_op_utils.py
+++ b/stratum/tests/logical_optimizer/test_op_utils.py
@@ -2,7 +2,12 @@
 import unittest
 import stratum as st
 from stratum.optimizer._optimize import optimize as optimize_, OptConfig, choice_unrolling, convert_to_ops
-from stratum.optimizer._op_utils import show_graph, clone_sub_dag, topological_iterator, FLAGS
+from stratum.optimizer._op_utils import (
+    show_graph, clone_sub_dag, topological_iterator, validate_operands,
+    validate_dag, compute_graph_node_indegree, FLAGS,
+)
+from stratum.optimizer.ir._ops import BinOp, CallOp, OperandRef, Op, ValueOp
+import operator
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum._config import config
 graph = False
@@ -156,6 +161,57 @@ class TestOpUtils(unittest.TestCase):
         out = choice_unrolling(root)
         if graph:
             show_graph(out, filename='choice_unrolling')
+
+
+class TestValidateOperands(unittest.TestCase):
+    def _wire(self, op, *inputs):
+        op.inputs = list(inputs)
+        return op
+
+    def test_valid_op_passes(self):
+        op = self._wire(BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1)),
+                        ValueOp(1), ValueOp(2))
+        validate_operands(op)  # must not raise
+
+    def test_ref_out_of_range_raises(self):
+        # right references index 1 but only one input edge exists
+        op = self._wire(BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1)),
+                        ValueOp(1))
+        with self.assertRaises(ValueError):
+            validate_operands(op)
+
+    def test_negative_ref_raises(self):
+        op = self._wire(BinOp(op=operator.add, left=OperandRef(-1), right=2), ValueOp(1))
+        with self.assertRaises(ValueError):
+            validate_operands(op)
+
+    def test_nested_ref_in_args_validated(self):
+        # OperandRef nested inside a tuple arg is reached by the recursive walk
+        op = self._wire(CallOp(func=lambda *a: a, args=((OperandRef(0), OperandRef(5)),), kwargs={}),
+                        ValueOp(1))
+        with self.assertRaises(ValueError):
+            validate_operands(op)
+
+    def test_nested_ref_in_kwargs_validated(self):
+        # OperandRef nested inside a kwargs dict is reached by the recursive walk
+        op = self._wire(CallOp(func=lambda **k: k, args=(), kwargs={"a": OperandRef(0), "b": OperandRef(7)}),
+                        ValueOp(1))
+        with self.assertRaises(ValueError):
+            validate_operands(op)
+
+    def test_validate_dag_walks_all_ops(self):
+        a = ValueOp(1)
+        bad = self._wire(BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(9)), a)
+        a.add_output(bad)
+        with self.assertRaises(ValueError):
+            validate_dag(bad)
+
+    def test_indegree_rejects_operandref_as_input(self):
+        # A raw OperandRef leaking into the inputs list is a bug; indegree must flag it.
+        op = Op()
+        op.inputs = [OperandRef(0)]
+        with self.assertRaises(RuntimeError):
+            compute_graph_node_indegree(op)
 
 
 

--- a/stratum/tests/logical_optimizer/test_ops.py
+++ b/stratum/tests/logical_optimizer/test_ops.py
@@ -11,11 +11,10 @@ from sklearn.preprocessing import StandardScaler
 from skrub._data_ops._data_ops import DataOp
 
 from stratum.optimizer.ir._ops import (
-    DATA_OP_PLACEHOLDER, BinOp, CallOp, DummyConfigManager, GetAttrOp,
-    GetItemOp, ImplOp, MethodCallOp, Op, PlaceHolder, SearchEvalOp, ValueOp,
+    OperandRef, OperandBinder, BinOp, CallOp, DummyConfigManager, GetAttrOp,
+    GetItemOp, ImplOp, MethodCallOp, Op, SearchEvalOp, ValueOp,
     VariableOp, check_estm_inputs, estimator_parallel_config,
     estm_supports_polars, process_estimator_task, process_transformer_task,
-    remove_datops_from_args,
 )
 from stratum.optimizer._optimize import optimize as optimize_
 
@@ -81,10 +80,11 @@ class TestOpCloning(unittest.TestCase):
 
 
 class TestOpMisc(unittest.TestCase):
-    def test_placeholder_str_repr(self):
-        ph = PlaceHolder("test")
-        self.assertEqual(str(ph), "test")
-        self.assertEqual(repr(ph), "test")
+    def test_operand_ref_eq_hash_repr(self):
+        self.assertEqual(OperandRef(2), OperandRef(2))
+        self.assertNotEqual(OperandRef(2), OperandRef(3))
+        self.assertEqual(hash(OperandRef(2)), hash(OperandRef(2)))
+        self.assertEqual(repr(OperandRef(1)), "OperandRef(1)")
 
     def test_update_name_noop(self):
         Op().update_name()
@@ -92,10 +92,6 @@ class TestOpMisc(unittest.TestCase):
     def test_check_kwargs_bad_type(self):
         with self.assertRaises(TypeError):
             Op().check_kwargs("not_a_dict")
-
-    def test_remove_datops_bad_type(self):
-        with self.assertRaises(ValueError):
-            remove_datops_from_args([1, 2, 3])
 
 
 class TestVariableOp(unittest.TestCase):
@@ -121,14 +117,16 @@ class TestImplOp(unittest.TestCase):
         self.assertIsNot(op, cloned)
 
     def test_replace_fields_with_values(self):
+        # The same DataOp appearing in several fields is a single operand (dedup):
+        # every occurrence resolves to the same input value.
         mock_dataop = MagicMock(spec=DataOp)
         cls = type("Impl", (), {"_fields": ["x", "y", "z"], "x": mock_dataop, "y": [mock_dataop, 5], "z": {"k": mock_dataop}})
         op = ImplOp(name="test", skrub_impl=cls())
-        inputs = ["vx", "vy", "vz"]
+        inputs = ["vx"]
         ns = op.replace_fields_with_values(inputs)
         self.assertEqual(ns.x, "vx")
         self.assertEqual(ns.y[1], 5)
-        self.assertEqual(ns.z["k"], "vz")
+        self.assertEqual(ns.z["k"], "vx")
 
     def test_process_with_eval(self):
         mock_dataop = MagicMock(spec=DataOp)
@@ -199,12 +197,13 @@ class TestOpProcess(unittest.TestCase):
         self.assertEqual(result, "HELLO")
 
     def test_method_call_with_placeholders(self):
-        op = MethodCallOp("format", args=(DATA_OP_PLACEHOLDER,), kwargs={"end": DATA_OP_PLACEHOLDER})
+        # input 0 is the implicit object; the format arg/kwarg reference inputs 1 and 2.
+        op = MethodCallOp("format", args=(OperandRef(1),), kwargs={"end": OperandRef(2)})
         result = op.process("fit_transform", {}, ["{0} {end}", "hello", "world"])
         self.assertEqual(result, "hello world")
 
     def test_call_op(self):
-        op = CallOp(func=lambda a, b: a + b, args=(DATA_OP_PLACEHOLDER, DATA_OP_PLACEHOLDER), kwargs={})
+        op = CallOp(func=lambda a, b: a + b, args=(OperandRef(0), OperandRef(1)), kwargs={})
         result = op.process("fit_transform", {}, [3, 7])
         self.assertEqual(result, 10)
 
@@ -220,17 +219,98 @@ class TestOpProcess(unittest.TestCase):
         self.assertEqual(result, 3.0)
 
     def test_getitem_with_placeholder(self):
-        op = GetItemOp(key="dummy")
-        op.key = DATA_OP_PLACEHOLDER
+        # input 0 is the container, input 1 is the graph-fed key.
+        op = GetItemOp(key=OperandRef(1))
         result = op.process("fit_transform", {}, [{"x": 42}, "x"])
         self.assertEqual(result, 42)
 
     def test_binop_both_placeholders(self):
-        op = BinOp(op=operator.add, left=DATA_OP_PLACEHOLDER, right=DATA_OP_PLACEHOLDER)
+        op = BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1))
         result = op.process("fit_transform", {}, [10, 20])
         self.assertEqual(result, 30)
 
     def test_binop_left_literal(self):
-        op = BinOp(op=operator.mul, left=5, right=DATA_OP_PLACEHOLDER)
+        op = BinOp(op=operator.mul, left=5, right=OperandRef(0))
         result = op.process("fit_transform", {}, [3])
         self.assertEqual(result, 15)
+
+
+class TestOperandRef(unittest.TestCase):
+    def test_eq_and_hash(self):
+        self.assertEqual(OperandRef(2), OperandRef(2))
+        self.assertNotEqual(OperandRef(2), OperandRef(3))
+        # not equal to a bare int with the same value
+        self.assertNotEqual(OperandRef(2), 2)
+        self.assertEqual(hash(OperandRef(2)), hash(OperandRef(2)))
+        # usable as a dict/set key
+        self.assertEqual(len({OperandRef(0), OperandRef(0), OperandRef(1)}), 2)
+
+    def test_str_and_repr(self):
+        self.assertEqual(str(OperandRef(4)), "$4")
+        self.assertEqual(repr(OperandRef(1)), "OperandRef(1)")
+
+
+class TestOperandBinder(unittest.TestCase):
+    """Bind DataOps to OperandRefs through the id->Op lookup, deduplicating edges."""
+
+    def _binder_for(self, *data_ops):
+        ids_to_ops = {id(d): ValueOp(i) for i, d in enumerate(data_ops)}
+        return OperandBinder(ids_to_ops), ids_to_ops
+
+    def test_repeated_dataop_shares_single_edge(self):
+        x = st.as_data_op(1)
+        binder, ids = self._binder_for(x)
+        # x + x: same upstream DataOp feeding two slots -> one input edge, two refs at 0
+        left = binder.ref(x)
+        right = binder.ref(x)
+        self.assertEqual(left, OperandRef(0))
+        self.assertEqual(right, OperandRef(0))
+        self.assertEqual(len(binder.inputs), 1)
+        self.assertIs(binder.inputs[0], ids[id(x)])
+
+    def test_distinct_dataops_get_increasing_indices(self):
+        a, b = st.as_data_op(1), st.as_data_op(2)
+        binder, _ = self._binder_for(a, b)
+        self.assertEqual(binder.ref(a), OperandRef(0))
+        self.assertEqual(binder.ref(b), OperandRef(1))
+        self.assertEqual(binder.ref(a), OperandRef(0))  # still deduped
+        self.assertEqual(len(binder.inputs), 2)
+
+    def test_bind_recurses_nested_containers(self):
+        a, b, c = st.as_data_op(1), st.as_data_op(2), st.as_data_op(3)
+        binder, _ = self._binder_for(a, b, c)
+        bound = binder.bind({"xs": [a, (b, 7)], "y": c, "lit": "keep"})
+        self.assertEqual(
+            bound,
+            {"xs": [OperandRef(0), (OperandRef(1), 7)], "y": OperandRef(2), "lit": "keep"},
+        )
+        self.assertEqual(len(binder.inputs), 3)
+
+    def test_bind_seq_and_bind_map(self):
+        a, b = st.as_data_op(1), st.as_data_op(2)
+        binder, _ = self._binder_for(a, b)
+        self.assertEqual(binder.bind_seq((a, 5)), (OperandRef(0), 5))
+        self.assertEqual(binder.bind_map({"k": b, "c": 9}), {"k": OperandRef(1), "c": 9})
+
+    def test_ref_op_binds_already_converted_op(self):
+        binder = OperandBinder({})
+        op0, op1 = ValueOp(1), ValueOp(2)
+        self.assertEqual(binder.ref_op(op0), OperandRef(0))
+        self.assertEqual(binder.ref_op(op1), OperandRef(1))
+        self.assertEqual(binder.ref_op(op0), OperandRef(0))  # dedup by identity
+
+
+class TestEdgeDedup(unittest.TestCase):
+    def test_add_input_dedup_returns_index(self):
+        op, a, b = Op(), ValueOp(1), ValueOp(2)
+        self.assertEqual(op.add_input(a), 0)
+        self.assertEqual(op.add_input(b), 1)
+        self.assertEqual(op.add_input(a), 0)  # already present -> existing index, no dup
+        self.assertEqual(op.inputs, [a, b])
+        self.assertEqual(op.num_input_operands, 2)
+
+    def test_add_output_dedup(self):
+        op, out = Op(), Op()
+        op.add_output(out)
+        op.add_output(out)
+        self.assertEqual(op.outputs, [out])

--- a/stratum/tests/utils/test_graph.py
+++ b/stratum/tests/utils/test_graph.py
@@ -9,23 +9,22 @@ class TestGraph(unittest.TestCase):
     def _graph_signature(self,graph):
         """Return an id-agnostic structural summary of a skrub graph dict."""
         nodes = graph["nodes"]
-        n = len(nodes)
 
         children = graph["children"]
         parents = graph["parents"]
 
-        out_degrees = [len(children.get(i, [])) for i in range(n)]
-        in_degrees = [len(parents.get(i, [])) for i in range(n)]
+        out_degrees = [len(children.get(node_id, [])) for node_id in nodes]
+        in_degrees = [len(parents.get(node_id, [])) for node_id in nodes]
 
         edge_count = sum(out_degrees)
 
-        roots = sum(1 for i in range(n) if len(parents.get(i, [])) == 0)
-        leaves = sum(1 for i in range(n) if len(children.get(i, [])) == 0)
+        roots = sum(1 for node_id in nodes if len(parents.get(node_id, [])) == 0)
+        leaves = sum(1 for node_id in nodes if len(children.get(node_id, [])) == 0)
 
         in_out_pairs = sorted(zip(sorted(in_degrees), sorted(out_degrees)))
 
         return {
-            "n_nodes": n,
+            "n_nodes": len(nodes),
             "edge_count": edge_count,
             "in_degrees_sorted": sorted(in_degrees),
             "out_degrees_sorted": sorted(out_degrees),
@@ -66,6 +65,16 @@ class TestGraph(unittest.TestCase):
         fast_sig = self._graph_signature(fast)
 
         self.assertEqual(ref_sig, fast_sig)
+
+    def test_build_graph_edges_are_deduplicated(self):
+        dag = self._build_example_dag()
+        fast = build_graph(dag)
+        for node_id, child_ids in fast["children"].items():
+            self.assertEqual(len(child_ids), len(set(child_ids)),
+                             f"duplicate child edges for node {node_id}")
+        for node_id, parent_ids in fast["parents"].items():
+            self.assertEqual(len(parent_ids), len(set(parent_ids)),
+                             f"duplicate parent edges for node {node_id}")
 
 
     def test_build_graph_matches_skrub_graph_for_branching_dag(self):

--- a/stratum/utils/_skrub_graph.py
+++ b/stratum/utils/_skrub_graph.py
@@ -79,14 +79,9 @@ def build_graph(data_op):
                 if child_id not in visited:
                     stack.append(child)
 
-    short = {obj_id: i for i, obj_id in enumerate(raw_nodes)}
-    nodes = {short[k]: v for k, v in raw_nodes.items()}
-    children = {
-        short[k]: [short[c] for c in _unique(v)]
-        for k, v in raw_children.items()
-    }
-    parents = {
-        short[k]: [short[p] for p in _unique(v)]
-        for k, v in raw_parents.items()
-    }
-    return {"nodes": nodes, "children": children, "parents": parents}
+    # De-duplicate edges (a node may reference the same child via several fields).
+    # Operand multiplicity is reconstructed separately from the impl field walk, so
+    # collapsing duplicate edges keeps the topology clean without losing information.
+    children = {k: _unique(v) for k, v in raw_children.items()}
+    parents = {k: _unique(v) for k, v in raw_parents.items()}
+    return {"nodes": raw_nodes, "children": children, "parents": parents}


### PR DESCRIPTION
Operands in the operator IR were marked with an DATA_OP_PLACEHOLDER sentinel and re-matched to the inputs list by walk order at runtime. This implicit positional contract broke silently whenever a rewrite reordered, dropped, or merged inputs.
Replace the sentinel with OperandRef(k), which references the k-th entry of an op's inputs list directly. process() now resolves inputs[ref.k] instead of relying on iteration order, and operand binding is order-independent. Key changes:
- Add OperandRef + OperandBinder; the binder builds a de-duplicated inputs list and assigns refs in one canonical field walk (_collect_child_data_ops order), so topology and operand refs share a single source of truth.
- Operand model is dedup + shared refs: the same upstream op feeding two slots (e.g. x + x) is a single input edge with two OperandRef(0). add_input/ add_output dedup edges; build_graph re-introduces edge dedup.
- Fuse conversion into one topological pass (convert_to_ops): as_op builds each op's inputs, refs, and output edges using an id(DataOp)->Op lookup. Remove the old two-phase converter, convert_to_ops2, and convert_handle_choice.
- Update rewrites that restructure inputs (make_read_op, chained joins, numeric operand collapse) to renumber refs via the binder.
- Add validate_operands/validate_dag to assert every ref is in range, turning silent miswiring into a failure.