### PR TITLE
[FrameOperator] AggregateOp groupby/agg fusion (#90)

### DIFF
--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -1,6 +1,6 @@
 from typing import Callable
 from collections.abc import Sequence
-from stratum.optimizer.ir._ops import (OperandRef, BaseEstimatorOp, BinOp, CallOp, GetAttrOp, GetItemOp,
+from stratum.optimizer.ir._ops import (OperandRef, BaseEstimatorOp, BinOp, CallOp, ChoiceOp, GetAttrOp, GetItemOp,
                                        MethodCallOp, Op, ValueOp, VariableOp,_resolve_args, _resolve_kwargs)
 from pandas import DataFrame
 import pandas as pd
@@ -66,7 +66,7 @@ class JoinOp(Op):
         inputs: list[Op] | None = None,
         outputs: list[Op] | None = None,
     ):
-        super().__init__(name="JOIN", inputs=inputs, outputs=outputs)
+        super().__init__(name="", inputs=inputs, outputs=outputs)
         self.how = how
         self.left_on = left_on
         self.right_on = right_on
@@ -93,6 +93,37 @@ class JoinOp(Op):
                 left_index=self.left_index,
                 right_index=self.right_index
             )
+
+class AggregateOp(Op):
+    """Fused ``groupby(...).agg(...)`` operation.
+
+    Captures a ``DataFrame.groupby(by)`` followed by a single aggregation call
+    (e.g. ``.agg("mean")``, ``.sum()``, ``.mean()``, ``.count()``) as one op.
+    Both the direct methods and ``.agg(spec)`` are normalized to ``aggregations``
+    so ``grouped.agg(aggregations)`` reproduces the original result.
+    """
+    fields = ["grouping_attributes", "aggregations", "groupby_kwargs"]
+
+    def __init__(self, grouping_attributes: str | list[str] | OperandRef,
+                 aggregations: str | list[str] | dict | OperandRef,
+                 groupby_kwargs: dict | None = None,
+                 inputs: list[Op] | None = None, outputs: list[Op] | None = None):
+        super().__init__(name="", inputs=inputs, outputs=outputs)
+        self.grouping_attributes = grouping_attributes
+        self.aggregations = aggregations
+        self.groupby_kwargs = groupby_kwargs or {}
+        self.is_dataframe_op = True
+
+    def __str__(self):
+        return f"AggregateOp(by={self.grouping_attributes}, agg={self.aggregations}) [df]"
+
+    def process(self, mode: str, environment: dict, inputs: list):
+        _obj = inputs[0]
+        grouping = inputs[self.grouping_attributes.k] if isinstance(self.grouping_attributes, OperandRef) else self.grouping_attributes
+        aggregations = inputs[self.aggregations.k] if isinstance(self.aggregations, OperandRef) else self.aggregations
+        if FLAGS.force_polars:
+            raise NotImplementedError("AggregateOp Polars backend is not implemented yet.")
+        return _obj.groupby(grouping, **self.groupby_kwargs).agg(aggregations)
 
 class MetadataOp(Op):
     fields = ["func", "args", "kwargs"]
@@ -409,7 +440,13 @@ def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
                 new_op = make_datetime_conversion_op(op)
 
         elif isinstance(op, MethodCallOp):
-            if op.method_name in ["rename"]:
+            if op.method_name == "groupby":
+                # Leave groupby as-is; mark it as a dataframe op so the following
+                # aggregation call is visited and can fuse with it.
+                op.is_dataframe_op = True
+            elif _is_aggregation(op):
+                new_op = make_aggregate_op(op)
+            elif op.method_name in ["rename"]:
                 new_op = MetadataOp(func=op.method_name, args=op.args, kwargs=op.kwargs, inputs=op.inputs,
                                     outputs=op.outputs)
                 op.replace_output_of_inputs(new_op)
@@ -437,6 +474,11 @@ def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
         elif isinstance(op, GetItemOp) or isinstance(op, BaseEstimatorOp):
             op.is_dataframe_op = True
 
+        elif isinstance(op, ChoiceOp):
+            # check if all outcomes are dataframe ops
+            if all(outcome.is_dataframe_op for outcome in op.inputs):
+                op.is_dataframe_op = True
+
     if new_op is None:
         return root, False
     else:
@@ -444,6 +486,87 @@ def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
         if root is op:
             root = new_op
     return root, True
+
+
+# Aggregation methods callable directly on a groupby (no .agg wrapper needed).
+_AGG_METHODS = {"sum", "mean", "count", "min", "max", "median", "std", "var",
+                "first", "last", "prod", "size", "nunique", "sem"}
+# Generic aggregation entrypoints that take the aggregation spec as an argument.
+_AGG_FUNCS = {"agg", "aggregate"}
+
+
+def _is_groupby_op(op: Op) -> bool:
+    return isinstance(op, MethodCallOp) and op.method_name == "groupby"
+
+
+def _is_aggregation(op: MethodCallOp) -> bool:
+    """True for a `groupby(...).<agg>()` pair that can fuse into an AggregateOp.
+
+    Requires the aggregation to consume a `groupby` op directly (no GetItem or
+    other op in between) and that groupby to have a single consumer.
+    """
+    if not op.inputs or not _is_groupby_op(op.inputs[0]):
+        return False
+    if len(op.inputs[0].outputs) != 1:
+        return False
+    if _extract_grouping(op.inputs[0]) is None:
+        return False
+    if op.method_name in _AGG_METHODS:
+        return True
+    # `.agg(spec)` / `.aggregate(spec)`: only the positional-spec form is supported.
+    return op.method_name in _AGG_FUNCS and bool(op.args)
+
+
+def _extract_grouping(groupby_op: MethodCallOp) -> str | list[str] | OperandRef:
+    if groupby_op.args:
+        return groupby_op.args[0]
+    if groupby_op.kwargs and "by" in groupby_op.kwargs:
+        return groupby_op.kwargs["by"]
+    return None
+
+
+def _extract_aggregations(op: MethodCallOp) -> str | list[str] | OperandRef:
+    if op.method_name in _AGG_FUNCS:
+        return op.args[0]
+    # direct method such as .mean()/.sum()/.count() -> normalize to its name
+    return op.method_name
+
+
+def make_aggregate_op(op: MethodCallOp) -> AggregateOp:
+    """Fuse `groupby(by).agg(...)` (or `.sum()/.mean()/...`) into an AggregateOp."""
+    groupby_op = op.inputs[0]
+    df = groupby_op.inputs[0]
+
+    grouping_attributes = _extract_grouping(groupby_op)
+    aggregations = _extract_aggregations(op)
+
+    # Inputs in resolution order: the frame, then any placeholder operands of the
+    # grouping key, then any placeholder operands of the aggregation spec.
+    inputs = [df] + list(groupby_op.inputs[1:]) + list(op.inputs[1:])
+
+    # OperandRefs in aggregations index into op.inputs. After prepending
+    # groupby_op.inputs[1:], those refs need to shift by that slice's length.
+    offset = len(groupby_op.inputs) - 1
+    if isinstance(aggregations, OperandRef):
+        aggregations = OperandRef(aggregations.k + offset)
+
+    # All groupby kwargs except 'by', which is captured in grouping_attributes.
+    groupby_kwargs = {k: v for k, v in (groupby_op.kwargs or {}).items() if k != "by"}
+
+    new_op = AggregateOp(
+        grouping_attributes=grouping_attributes,
+        aggregations=aggregations,
+        groupby_kwargs=groupby_kwargs,
+        inputs=inputs,
+        outputs=op.outputs,
+    )
+    # Bypass the now-orphaned groupby op: rewire the frame and grouping-key
+    # producers, plus any aggregation-arg producers, to feed the new op.
+    groupby_op.replace_output_of_inputs(new_op)
+    for extra in op.inputs[1:]:
+        extra.replace_output(op, new_op)
+    groupby_op.outputs.remove(op)
+    return new_op
 
 
 def make_datetime_conversion_op(op: CallOp) -> DatetimeConversionOp:

--- a/stratum/tests/logical_optimizer/test_dataframe_ops.py
+++ b/stratum/tests/logical_optimizer/test_dataframe_ops.py
@@ -12,8 +12,10 @@ from skrub._data_ops._data_ops import DataOp
 from stratum._config import FLAGS
 from stratum.optimizer._optimize import OptConfig, optimize as optimize_
 from stratum.optimizer.ir._dataframe_ops import (
-    ApplyUDFOp, AssignOp, ConcatOp, DataSourceOp, DatetimeConversionOp, DropOp,
-    GetAttrProjectionOp, JoinOp, MetadataOp, ProjectionOp, SplitOp,
+    AggregateOp, ApplyUDFOp, AssignOp, ConcatOp, DataSourceOp,
+    DatetimeConversionOp, DropOp, GetAttrProjectionOp, JoinOp, MetadataOp,
+    ProjectionOp, SplitOp, _extract_aggregations, _extract_grouping,
+    _is_aggregation, _is_groupby_op, make_aggregate_op,
     make_datetime_conversion_op, make_read_op)
 from stratum.optimizer.ir._ops import (CallOp, OperandRef, GetItemOp,
                                        MethodCallOp, Op, ValueOp)
@@ -674,5 +676,237 @@ class TestJoinRewrites(unittest.TestCase):
         )
         with self.assertRaisesRegex(NotImplementedError, "Unsupported arguments for join"):
             optimize(data, OptConfig(dataframe_ops=True))
+
+
+def _groupby_agg_pair(group_args=("g",), group_kwargs=None,
+                      agg_method="sum", agg_args=(), agg_kwargs=None):
+    """Build a `groupby(...)` MethodCallOp feeding an aggregation MethodCallOp."""
+    groupby = MethodCallOp("groupby", args=group_args, kwargs=group_kwargs or {})
+    agg = MethodCallOp(agg_method, args=agg_args, kwargs=agg_kwargs or {})
+    agg.inputs = [groupby]
+    groupby.outputs = [agg]
+    return groupby, agg
+
+
+class TestAggregateOp(unittest.TestCase):
+    """`AggregateOp.process` execution on both backends."""
+
+    def test_pandas_direct_spec(self):
+        df = pd.DataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3]})
+        op = AggregateOp(grouping_attributes="g", aggregations="sum")
+        result = run_op(op, df)
+        pd.testing.assert_frame_equal(result, df.groupby("g").agg("sum"))
+
+    def test_pandas_dict_spec(self):
+        df = pd.DataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3], "w": [4, 5, 6]})
+        op = AggregateOp(grouping_attributes="g", aggregations={"v": "sum"})
+        result = run_op(op, df)
+        pd.testing.assert_frame_equal(result, df.groupby("g").agg({"v": "sum"}))
+
+    def test_grouping_placeholder_resolved_from_inputs(self):
+        df = pd.DataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3]})
+        op = AggregateOp(grouping_attributes=OperandRef(1), aggregations="sum")
+        result = run_op(op, df, "g")
+        pd.testing.assert_frame_equal(result, df.groupby("g").agg("sum"))
+
+    def test_aggregation_placeholder_resolved_from_inputs(self):
+        df = pd.DataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3]})
+        op = AggregateOp(grouping_attributes="g", aggregations=OperandRef(1))
+        result = run_op(op, df, "mean")
+        pd.testing.assert_frame_equal(result, df.groupby("g").agg("mean"))
+
+    def test_str(self):
+        op = AggregateOp(grouping_attributes="g", aggregations="sum")
+        self.assertIn("AggregateOp", str(op))
+        self.assertIn("g", str(op))
+
+    def test_polars_not_implemented(self):
+        with force_polars():
+            op = AggregateOp(grouping_attributes="g", aggregations="sum")
+            with self.assertRaises(NotImplementedError):
+                run_op(op, pl.DataFrame({"g": ["a"], "v": [1]}))
+
+
+class TestAggregateHelpers(unittest.TestCase):
+    """Unit tests for the groupby/aggregation fusion predicates and extractors."""
+
+    def test_is_groupby_op(self):
+        self.assertTrue(_is_groupby_op(MethodCallOp("groupby", args=("g",), kwargs={})))
+        self.assertFalse(_is_groupby_op(MethodCallOp("sum", args=(), kwargs={})))
+        self.assertFalse(_is_groupby_op(Op()))
+
+    def test_is_aggregation_direct_method(self):
+        _, agg = _groupby_agg_pair(agg_method="mean")
+        self.assertTrue(_is_aggregation(agg))
+
+    def test_is_aggregation_agg_with_spec(self):
+        _, agg = _groupby_agg_pair(agg_method="agg", agg_args=("sum",))
+        self.assertTrue(_is_aggregation(agg))
+
+    def test_is_aggregation_agg_without_spec_is_false(self):
+        _, agg = _groupby_agg_pair(agg_method="agg", agg_args=())
+        self.assertFalse(_is_aggregation(agg))
+
+    def test_is_aggregation_no_inputs_is_false(self):
+        self.assertFalse(_is_aggregation(MethodCallOp("sum", args=(), kwargs={})))
+
+    def test_is_aggregation_non_groupby_input_is_false(self):
+        agg = MethodCallOp("sum", args=(), kwargs={})
+        agg.inputs = [DataSourceOp(data=pd.DataFrame({"a": [1]}))]
+        self.assertFalse(_is_aggregation(agg))
+
+    def test_is_aggregation_multi_consumer_groupby_is_false(self):
+        groupby, agg = _groupby_agg_pair()
+        # A second consumer of the groupby blocks fusion.
+        groupby.outputs.append(MethodCallOp("count", args=(), kwargs={}))
+        self.assertFalse(_is_aggregation(agg))
+
+    def test_is_aggregation_unknown_method_is_false(self):
+        _, agg = _groupby_agg_pair(agg_method="head")
+        self.assertFalse(_is_aggregation(agg))
+
+    def test_extract_grouping_from_args(self):
+        gb = MethodCallOp("groupby", args=("g",), kwargs={})
+        self.assertEqual("g", _extract_grouping(gb))
+
+    def test_extract_grouping_from_kwarg(self):
+        gb = MethodCallOp("groupby", args=(), kwargs={"by": "g"})
+        self.assertEqual("g", _extract_grouping(gb))
+
+    def test_extract_grouping_none(self):
+        gb = MethodCallOp("groupby", args=(), kwargs={})
+        self.assertIsNone(_extract_grouping(gb))
+
+    def test_extract_aggregations_from_agg_spec(self):
+        agg = MethodCallOp("agg", args=("mean",), kwargs={})
+        self.assertEqual("mean", _extract_aggregations(agg))
+
+    def test_extract_aggregations_from_direct_method(self):
+        agg = MethodCallOp("sum", args=(), kwargs={})
+        self.assertEqual("sum", _extract_aggregations(agg))
+
+    def test_make_aggregate_op_normalizes_direct_method(self):
+        df = DataSourceOp(data=pd.DataFrame({"g": ["a"], "v": [1]}))
+        groupby = MethodCallOp("groupby", args=("g",), kwargs={})
+        groupby.inputs = [df]
+        df.outputs = [groupby]
+        agg = MethodCallOp("sum", args=(), kwargs={})
+        agg.inputs = [groupby]
+        groupby.outputs = [agg]
+
+        new_op = make_aggregate_op(agg)
+        self.assertIsInstance(new_op, AggregateOp)
+        self.assertEqual("g", new_op.grouping_attributes)
+        self.assertEqual("sum", new_op.aggregations)
+        # The groupby op is bypassed: the frame now feeds the AggregateOp.
+        self.assertIs(df, new_op.inputs[0])
+        self.assertIn(new_op, df.outputs)
+
+
+class TestAggregateRewrites(unittest.TestCase):
+    """End-to-end: skrub `groupby(...).agg(...)` expressions fuse into AggregateOp."""
+
+    def _run_plan(self, ops, env=None):
+        pool = BufferPool()
+        for op in ops:
+            inputs = [pool.pin(key) for key in op.inputs]
+            pool.put(op, op.process("fit_transform", env or {}, inputs))
+        return pool.pin(ops[-1])
+
+    def setUp(self):
+        self.df = pd.DataFrame({
+            "g": ["a", "a", "b"],
+            "h": ["x", "y", "x"],
+            "v": [1, 2, 3],
+            "w": [4, 5, 6],
+        })
+
+    def test_agg_with_spec_fuses_and_executes(self):
+        data = st.as_data_op(self.df).groupby("g").agg("sum")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual("g", agg_ops[0].grouping_attributes)
+        self.assertEqual("sum", agg_ops[0].aggregations)
+        pd.testing.assert_frame_equal(
+            self._run_plan(ops), self.df.groupby("g").agg("sum"))
+
+    def test_direct_method_fuses_and_executes(self):
+        data = st.as_data_op(self.df).groupby("g").mean(numeric_only=True)
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual("mean", agg_ops[0].aggregations)
+
+    def test_multikey_dict_spec_fuses(self):
+        data = st.as_data_op(self.df).groupby(["g", "h"]).agg({"v": "sum"})
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual(["g", "h"], agg_ops[0].grouping_attributes)
+        self.assertEqual({"v": "sum"}, agg_ops[0].aggregations)
+
+    def test_by_kwarg_fuses(self):
+        data = st.as_data_op(self.df).groupby(by="g").agg("sum")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual("g", agg_ops[0].grouping_attributes)
+
+    def test_variable_grouping_key_uses_placeholder(self):
+        data = st.as_data_op(self.df).groupby(st.var("key")).agg("sum")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual(OperandRef(1), agg_ops[0].grouping_attributes)
+        result = self._run_plan(ops, env={"key": "g"})
+        pd.testing.assert_frame_equal(result, self.df.groupby("g").agg("sum"))
+
+    def test_variable_aggregation_spec_uses_placeholder(self):
+        data = st.as_data_op(self.df).groupby("g").agg(st.var("spec"))
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual(OperandRef(1), agg_ops[0].aggregations)
+        result = self._run_plan(ops, env={"spec": "sum"})
+        pd.testing.assert_frame_equal(result, self.df.groupby("g").agg("sum"))
+
+    def test_both_grouping_key_and_agg_spec_are_variables(self):
+        # Both operands are graph-fed; the aggregation OperandRef must be shifted
+        # by the number of extra groupby inputs to avoid aliasing the key slot.
+        data = st.as_data_op(self.df).groupby(st.var("key")).agg(st.var("spec"))
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual(OperandRef(1), agg_ops[0].grouping_attributes)
+        self.assertEqual(OperandRef(2), agg_ops[0].aggregations)
+        result = self._run_plan(ops, env={"key": "g", "spec": "sum"})
+        pd.testing.assert_frame_equal(result, self.df.groupby("g").agg("sum"))
+
+    def test_groupby_kwargs_preserved_after_fusion(self):
+        data = st.as_data_op(self.df).groupby("g", sort=False).agg("sum")
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        agg_ops = [o for o in ops if isinstance(o, AggregateOp)]
+        self.assertEqual(1, len(agg_ops))
+        self.assertEqual({"sort": False}, agg_ops[0].groupby_kwargs)
+        result = self._run_plan(ops)
+        pd.testing.assert_frame_equal(
+            result, self.df.groupby("g", sort=False).agg("sum"))
+
+    def test_level_based_groupby_does_not_fuse(self):
+        # groupby(level=...) has no 'by' argument; fusion must be skipped to
+        # avoid passing groupby(None) at runtime.
+        idx = pd.MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 1)], names=["g", "h"])
+        df = pd.DataFrame({"v": [1, 2, 3]}, index=idx)
+        data = st.as_data_op(df).groupby(level=0).sum()
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        self.assertEqual(0, len([o for o in ops if isinstance(o, AggregateOp)]))
+
+    def test_column_selection_between_groupby_and_agg_does_not_fuse(self):
+        # groupby('g')['v'].sum() inserts a GetItemOp between the two, so the
+        # aggregation no longer consumes the groupby directly -> no fusion.
+        data = st.as_data_op(self.df).groupby("g")["v"].sum()
+        ops = optimize(data, OptConfig(dataframe_ops=True))
+        self.assertEqual(0, len([o for o in ops if isinstance(o, AggregateOp)]))
 
 


### PR DESCRIPTION
Fuse DataFrame.groupby(by).agg(...) (and direct methods like .sum(), .mean(), .count()) into a single AggregateOp in the IR, eliminating the intermediate MethodCallOps for groupby and aggregation.

  - Add AggregateOp with grouping_attributes, aggregations, and groupby_kwargs fields; pandas backend only (Polars raises NotImplementedError)
  - Add _is_aggregation / _is_groupby_op predicates and _extract_grouping /_extract_aggregations helpers; fuse in extract_dataframe_op
  - Add ChoiceOp is_dataframe_op propagation when all outcomes are frame ops
  - Rebase aggregation OperandRef by len(groupby_op.inputs)-1 so it resolves to the correct slot when the groupby key is also graph-fed
  - Preserve non-'by' groupby kwargs (as_index, sort, observed, dropna) through fusion via groupby_kwargs
  - Guard _is_aggregation against level=-based groupby (no 'by' arg) to avoid a runtime groupby(None) TypeError
  - Clear the stale groupby_op.outputs edge after fusion to maintain the DAG invariant that .outputs mirrors consumers' .inputs

Closes #90.