### PR TITLE
[Rewrite] eliminate multiply-by-one identity (#92)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -5,6 +5,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_log_exp,
     eliminate_log1p_expm1,
     eliminate_sqrt_square,
+    eliminate_identity_operation,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -20,6 +21,7 @@ class AlgebraicRewritesConfig:
     sqrt_square: bool = True
     log1p_expm1: bool = True
     expm1_log1p: bool = True
+    identity_op: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -35,5 +37,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_log1p_expm1(root)
     if config.expm1_log1p:
         root = eliminate_expm1_log1p(root)
+    if config.identity_op:
+        root = eliminate_identity_operation(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -14,6 +14,30 @@ def match_two_op_chain(op_cls, type1, type2):
     return match
 
 
+def match_identity_operation(op_cls, type1, const):
+    def match(op1):
+        if isinstance(op1, op_cls) and op1.type == type1:
+            if op1.opt_operand is None and op1.constant == const:
+                return (op1,)
+        return None
+    return match
+
+
+def eliminate_single_op_chain_root_safe(op, root):
+    eliminate_single_op_chain(op)
+    if op is root:
+        root = op.inputs[0]
+    return root
+
+
+def eliminate_single_op_chain(op):
+    primary = op.inputs[0]
+    op.replace_input_of_outputs(primary)
+    primary.outputs.remove(op)
+    for out_ in op.outputs:
+        primary.add_output(out_)
+
+
 def eliminate_two_op_chain(op1, op2):
     """Remove a redundant pair of inverse ops: y = f(op2(op1(x))) -> y = f(x).
 
@@ -81,4 +105,9 @@ _replace_with_abs = make_replace_two_op_chain_root_safe(
 eliminate_sqrt_square = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.SQUARE, NumericOpType.SQRT),
     _replace_with_abs,
+)
+
+eliminate_identity_operation = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 1),
+    eliminate_single_op_chain_root_safe,
 )

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -112,7 +112,6 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
-
     def test_disable_log_exp_rewrite2(self):
         df = st.as_data_op(1)
         t1 = df.skb.apply_func(np.log)
@@ -233,3 +232,35 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
+
+    def test_eliminate_identity_operation(self):
+        df = st.as_data_op(2)
+        t1 = df * 1
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", {}, [out[0].value]), 5)
+
+    def test_disable_eliminate_identity_operation(self):
+        df = st.as_data_op(2)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_op=False),
+        )
+        t1 = df * 1
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+        multiply_result = out[1].process("fit", {}, [out[0].value])
+        self.assertEqual(multiply_result, 2)
+        self.assertEqual(out[2].process("fit", {}, [multiply_result]), 5)
+
+    def test_eliminate_identity_operation_root_safe(self):
+        value = st.as_data_op(2)
+        root = value * 1
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].process("fit", {}, [out[0].value]), 2)


### PR DESCRIPTION
- Add an algebraic rewrite that removes multiply-by-one numeric identity operations.
- Wire the rewrite into `AlgebraicRewritesConfig` behind `identity_op`.
- Add tests for enabled, disabled, and root-safe identity elimination behavior.

Closes #92.
