### PR TITLE
[Optimizer] Infer Output Schema (#85)

### DIFF
--- a/stratum/optimizer/_optimize.py
+++ b/stratum/optimizer/_optimize.py
@@ -56,6 +56,7 @@ class OptConfig():
         numeric_ops: bool = True,
         algebraic_rewrites: bool = True,
         algebraic_rewrite_config: AlgebraicRewritesConfig | None = None,
+        propagate_schema: bool = True,
     ):
         self.cse = cse
         self.dataframe_ops = dataframe_ops
@@ -65,6 +66,7 @@ class OptConfig():
         if algebraic_rewrite_config is None:
             algebraic_rewrite_config = AlgebraicRewritesConfig()
         self.algebraic_rewrite_config = algebraic_rewrite_config
+        self.propagate_schema = propagate_schema
 
 def _debug_show_graph(root: Op, name: str):
     if FLAGS.debug_graph:
@@ -163,6 +165,15 @@ def logical_optimize(dag_root: DataOp, config: OptConfig, env: dict = None) -> O
     if config.unroll_choices:
         root = choice_unrolling(root)
 
+    # Propagate derived schemas through the Op DAG (part of broader metadata
+    # propagation used later for operator selection / parallelization planning).
+    # TODO: schemas are propagated once here, before algebraic_rewrites. Rewrites
+    # that create or replace ops leave new ops without a schema and replaced ones
+    # stale; re-propagate (or update incrementally) once rewrites start consuming
+    # output_schema.
+    if config.propagate_schema:
+        propagate_output_schema(root)
+
     # Final logical DAG
     if config.algebraic_rewrites:
         root = algebraic_rewrites(root, config.algebraic_rewrite_config)
@@ -226,6 +237,14 @@ def extract_numeric_operators(root):
     log_time("to_numeric took", start)
     _debug_show_graph(root, "numeric_rewrite")
     return root
+
+
+def propagate_output_schema(root):
+    """Propagate each op's output schema from its inputs (sources to sinks)."""
+    start = start_time()
+    for op in topological_iterator(root):
+        op.propagate_output_schema()
+    log_time("schema_propagation took", start)
 
 
 def convert_to_ops(dag: DataOp, env: dict = None) -> Op:

--- a/stratum/optimizer/ir/_aggregation_ops.py
+++ b/stratum/optimizer/ir/_aggregation_ops.py
@@ -1,4 +1,5 @@
 from stratum.optimizer.ir._ops import OperandRef, OutputType, MethodCallOp, Op
+from stratum.optimizer.ir import _schema
 
 
 class AggregateOp(Op):
@@ -29,6 +30,17 @@ class AggregateOp(Op):
         self.aggregations = aggregations
         self.groupby_kwargs = groupby_kwargs or {}
         self.output_type = OutputType.FRAME
+
+    def propagate_output_schema(self):
+        """Best-effort: only a dict aggregation spec gives statically known output
+        columns (its keys); a bare function name or list spec is left unknown.
+        See :func:`_schema.aggregate_schema` for the exact rules."""
+        self.output_schema = _schema.aggregate_schema(
+            self.inputs[0].output_schema,
+            self.grouping_attributes,
+            self.aggregations,
+            self.groupby_kwargs.get("as_index"),
+        )
 
 
 class GroupedDataframeOp(Op):

--- a/stratum/optimizer/ir/_base.py
+++ b/stratum/optimizer/ir/_base.py
@@ -228,6 +228,7 @@ class IRNode:
         self.is_split_op = False
         self.was_cloned = False
         self.remove_after: list[IRNode] = []
+        self.output_schema = None
 
     def to_str_helper(self):
         class_name = (self.__class__.__name__ if self._is_physical

--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -1,5 +1,6 @@
 from stratum.optimizer.ir._ops import (OperandRef, OutputType, is_frame_like, BaseEstimatorOp, BinOp, UnaryOp, CallOp, ChoiceOp, GetAttrOp, GetItemOp,
                                        MethodCallOp, Op, TransformerOp, ValueOp)
+from stratum.optimizer.ir import _schema
 from pandas import DataFrame
 from polars import DataFrame as PolarsDataFrame
 from skrub import SelectCols
@@ -45,6 +46,11 @@ class ConcatOp(Op):
         self.others = list(others)
         self.axis = axis
         self.output_type = OutputType.FRAME
+
+    def propagate_output_schema(self):
+        """Concat merges schemas: the result holds every column appearing in any
+        operand (row-wise concat shares columns, column-wise concat unions them)."""
+        self.output_schema = _schema.union_columns([in_op.output_schema for in_op in self.inputs])
 
 
 def _getitem_output_type(op: GetItemOp) -> OutputType:

--- a/stratum/optimizer/ir/_join_ops.py
+++ b/stratum/optimizer/ir/_join_ops.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from stratum.optimizer.ir._ops import OperandRef, OutputType, MethodCallOp, Op
+from stratum.optimizer.ir import _schema
 
 
 class JoinOp(Op):
@@ -27,6 +28,16 @@ class JoinOp(Op):
         self.right_index = right_index
         self.suffixes = suffixes
         self.output_type = OutputType.FRAME
+
+    def propagate_output_schema(self):
+        """Merge left and right schemas, applying suffixes to overlapping
+        non-key columns and collapsing shared (equal-named) join keys."""
+        left = self.inputs[0].output_schema
+        right = self.inputs[1].output_schema
+        left_on = _schema.as_column_list(self.left_on) or []
+        right_on = _schema.as_column_list(self.right_on) or []
+        shared_keys = set(left_on) & set(right_on)
+        self.output_schema = _schema.merge_join_schemas(left, right, shared_keys, self.suffixes)
 
 
 _MERGE_POSITIONAL = ["how", "on", "left_on", "right_on",

--- a/stratum/optimizer/ir/_map_ops.py
+++ b/stratum/optimizer/ir/_map_ops.py
@@ -18,6 +18,7 @@ import polars as pl
 from stratum.optimizer.ir._column_expr import (ColumnExpr, Const, EvalContext,
                                                _Folder)
 from stratum.optimizer.ir._ops import (MethodCallOp, Op, OperandRef, OutputType)
+from stratum.optimizer.ir import _schema
 
 
 class MapOp(Op):
@@ -45,6 +46,12 @@ class AssignMapOp(MapOp):
         super().__init__(name=f"assign: {', '.join(entries)}",
                          inputs=inputs, outputs=outputs)
         self.entries = entries
+
+    def propagate_output_schema(self):
+        """Assigned columns are added/overwritten; dtypes depend on the
+        expressions so they are recorded as Unknown-typed."""
+        self.output_schema = _schema.add_columns(
+            self.inputs[0].output_schema, list(self.entries.keys()))
 
 
 # --- Folding: assign subgraphs -> MapOp ---------------------------------------

--- a/stratum/optimizer/ir/_ops.py
+++ b/stratum/optimizer/ir/_ops.py
@@ -19,6 +19,7 @@ from stratum.optimizer.ir._base import (
     config_key, estimator_key, clone_value,
     _ALL_SELECTOR_KEY, _GRAPH_PARAM_KEY,
 )
+from stratum.optimizer.ir import _schema
 import logging
 import os
 logger = logging.getLogger(__name__)
@@ -122,6 +123,12 @@ class Op(IRNode):
         input_ids = tuple(id(i) for i in self.inputs)
         config = tuple((name, config_key(getattr(self, name))) for name in fields)
         return (type(self), input_ids, config)
+
+    def propagate_output_schema(self):
+        """Default: the output schema is unknown. Ops that can statically determine
+        their columns override this; everything else (UDFs, non-frame ops, frame ops
+        without a propagation rule yet) falls back to the unknown schema."""
+        self.output_schema = None
 
 
 class ImplOp(Op):
@@ -502,6 +509,29 @@ class GetItemOp(Op):
         super().__init__(name=name)
     # Execution lives in the physical impls (physical/_getitem_execs.py).
 
+    def propagate_output_schema(self):
+        """Column projection (`df["c"]`, `df[["a","b"]]`) selects a sub-schema;
+        a slice or a series-shaped row mask (`df[mask]`) preserves the schema. A
+        graph-fed key that isn't series-shaped can't be resolved statically (it
+        may be a computed column selector), so it falls back to the unknown
+        schema rather than over-claiming all columns."""
+        schema = self.inputs[0].output_schema
+        if isinstance(self.key, slice):
+            self.output_schema = schema  # row slice keeps all columns
+        elif isinstance(self.key, OperandRef):
+            # The key's runtime value isn't known statically, so we classify by
+            # the producing op's kind. A SERIES key is treated as a boolean row
+            # mask (`df[df["x"] > 0]`) and keeps the schema; a non-SERIES
+            # (list/array column selector) can't be resolved -> unknown.
+            # HEURISTIC: a SERIES of column *labels* used as `df[series]` is
+            # column selection too, which this misclassifies -- but that idiom
+            # doesn't occur in supported pipelines (a SERIES key is always a
+            # mask there).
+            key_op = self.inputs[self.key.k]
+            self.output_schema = schema if key_op.output_type is OutputType.SERIES else None
+        else:
+            self.output_schema = _schema.select_columns(schema, self.key)
+
 class BinOp(Op):
     fields = ["op", "left", "right"]
     
@@ -512,6 +542,26 @@ class BinOp(Op):
         self.left = left
         self.right = right
 
+    def propagate_output_schema(self):
+        """An elementwise op over frame data keeps the shape of its frame operand
+        (e.g. `df + 1`, `df["x"] > 0`); the dtype may change but the columns don't.
+
+        For a frame-frame op (`df1 + df2`) pandas aligns on column labels and
+        unions them, so we only trust a result when every frame operand carries
+        the same known columns. Differing schemas (or any unknown one) fall back
+        to the unknown schema rather than guessing one side's shape."""
+        if self.output_type not in FRAME_TYPES:
+            self.output_schema = None
+            return
+        frame_schemas = [in_op.output_schema for in_op in self.inputs if is_frame_like(in_op)]
+        if not frame_schemas or any(s is None for s in frame_schemas):
+            self.output_schema = None
+            return
+        first = frame_schemas[0]
+        if any(list(s.keys()) != list(first.keys()) for s in frame_schemas[1:]):
+            self.output_schema = None
+            return
+        self.output_schema = first
 
     def process(self, mode: str, inputs: list):
         left = inputs[self.left.k] if isinstance(self.left, OperandRef) else self.left

--- a/stratum/optimizer/ir/_projection_ops.py
+++ b/stratum/optimizer/ir/_projection_ops.py
@@ -2,6 +2,8 @@ from typing import Callable
 from skrub.selectors._base import make_selector
 from stratum.optimizer.ir._ops import (OutputType, CallOp, GetAttrOp,
                                        MethodCallOp, Op, TransformerOp, _resolve_args, _resolve_kwargs)
+from stratum.optimizer.ir import _schema
+import polars as pl
 
 
 def resolve_selector_columns(frame, selector) -> list[str]:
@@ -69,6 +71,18 @@ class MetadataOp(Op):
         self.kwargs = kwargs
         self.output_type = OutputType.FRAME
 
+    def propagate_output_schema(self):
+        """Currently only ``rename`` is modelled: it remaps the columns named in
+        the ``columns`` (or axis=1 ``mapper``) mapping and leaves the rest. Any
+        other metadata op falls back to the unknown schema."""
+        kwargs = self.kwargs or {}
+        mapping = None
+        if self.func == "rename":
+            mapping = kwargs.get("columns")
+            if mapping is None and kwargs.get("axis") == 1:
+                mapping = kwargs.get("mapper")
+        self.output_schema = _schema.rename_columns(self.inputs[0].output_schema, mapping)
+
 
 class ProjectionOp(Op):
     logical_family = "Projection"
@@ -115,6 +129,19 @@ class DropOp(ProjectionOp):
     def __init__(self, args: tuple | list = (), kwargs: dict = {},
         inputs: list[Op] = None, outputs: list[Op] = None, columns: list[str] = None):
         super().__init__(args=args, kwargs=kwargs, inputs=inputs, outputs=outputs, columns=columns)
+
+    def _dropped_columns(self):
+        """Column labels being dropped, or ``None`` if not statically known."""
+        kwargs = self.kwargs or {}
+        if "columns" in kwargs:
+            return kwargs["columns"]
+        # positional form `df.drop(labels, axis=1)`: labels are columns only when axis==1.
+        if self.args and kwargs.get("axis", 0) == 1:
+            return self.args[0]
+        return None
+
+    def propagate_output_schema(self):
+        self.output_schema = _schema.drop_columns(self.inputs[0].output_schema, self._dropped_columns())
 
 
 class ColumnSelectorOp(Op):
@@ -165,6 +192,9 @@ class ColumnProjectionOp(Op):
         self.output_type = (OutputType.SERIES if isinstance(key, str)
                             else OutputType.FRAME)
 
+    def propagate_output_schema(self):
+        self.output_schema = _schema.select_columns(self.inputs[0].output_schema, self.key)
+
 
 def make_column_projection_op(op) -> ColumnProjectionOp:
     """Rewrite a column-selecting ``df[key]`` :class:`GetItemOp` (a literal
@@ -186,12 +216,23 @@ class AssignOp(ProjectionOp):
         inputs: list[Op] = None, outputs: list[Op] = None, columns: list[str] = None):
         super().__init__(args=args, kwargs=kwargs, inputs=inputs, outputs=outputs, columns=columns)
 
+    def propagate_output_schema(self):
+        """`df.assign(a=..., b=...)` adds/overwrites the kwargs-named columns.
+        Their dtype depends on the assigned expression, so we record them as
+        Unknown-typed while keeping the rest of the input schema intact."""
+        new_columns = list(self.kwargs.keys()) if self.kwargs else []
+        self.output_schema = _schema.add_columns(self.inputs[0].output_schema, new_columns)
+
 
 class DatetimeConversionOp(ProjectionOp):
     def __init__(self, args: tuple | list = (), kwargs: dict = {},
         inputs: list[Op] = None, outputs: list[Op] = None, columns: list[str] = None):
         super().__init__(args=args, kwargs=dict(kwargs or {}), inputs=inputs,
                          outputs=outputs, columns=columns)
+
+    def propagate_output_schema(self):
+        # to_datetime keeps the column names and turns each into a Datetime column.
+        self.output_schema = _schema.retype_columns(self.inputs[0].output_schema, pl.Datetime("us"))
 
 
 class StringMethodOp(ProjectionOp):
@@ -236,6 +277,14 @@ class GetAttrProjectionOp(Op):
         self.inputs = inputs
         self.outputs = outputs
         self.output_type = OutputType.FRAME
+
+    def propagate_output_schema(self):
+        """An attribute/accessor projection (e.g. ``.dt.year``) preserves the
+        input's column names but changes their dtype. The result dtype depends on
+        the accessor (``.dt.year``->int, ``.dt.is_month_end``->bool, ...) and
+        pandas/polars disagree on some, so we keep the names and mark the dtypes
+        ``Unknown`` rather than infer them."""
+        self.output_schema = _schema.retype_columns(self.inputs[0].output_schema)
 
 
 def make_datetime_conversion_op(op: CallOp) -> DatetimeConversionOp:

--- a/stratum/optimizer/ir/_schema.py
+++ b/stratum/optimizer/ir/_schema.py
@@ -1,0 +1,159 @@
+"""Schema algebra for output-schema propagation.
+
+A *schema* is a :class:`polars.Schema` (an ordered mapping ``column name ->
+dtype``). ``None`` is the *unknown* schema: it models the fallback used when an
+op cannot determine its output (e.g. a UDF), and every helper here propagates it
+-- any operation on an unknown schema is unknown.
+
+For a single column (an op whose ``output_type`` is ``SERIES``) we still use a
+one-entry schema, keyed by the column name, so column tracking is uniform across
+frames and series.
+"""
+from __future__ import annotations
+
+import polars as pl
+
+# dtype used for columns whose name is known but whose type we cannot determine
+# (e.g. a freshly assigned column built from an arbitrary expression).
+UNKNOWN_DTYPE = pl.Unknown
+
+
+def is_known(schema) -> bool:
+    """True if ``schema`` carries column information (i.e. is not the unknown schema)."""
+    return schema is not None
+
+
+def as_column_list(columns) -> list[str] | None:
+    """Normalize a ``str``/list/tuple of column labels to a list of names.
+
+    Returns ``None`` when the labels are not statically known string column names
+    (e.g. an :class:`OperandRef`, a slice, or anything non-string), which forces
+    the caller to fall back to the unknown schema.
+    """
+    if isinstance(columns, str):
+        return [columns]
+    if isinstance(columns, (list, tuple)):
+        if all(isinstance(c, str) for c in columns):
+            return list(columns)
+    return None
+
+
+def drop_columns(schema, columns) -> pl.Schema | None:
+    """Input schema with ``columns`` removed; unknown if names aren't known."""
+    names = as_column_list(columns)
+    if not is_known(schema) or names is None:
+        return None
+    drop = set(names)
+    return pl.Schema({name: dt for name, dt in schema.items() if name not in drop})
+
+
+def select_columns(schema, columns) -> pl.Schema | None:
+    """Sub-schema holding only ``columns``, in the requested order.
+
+    Unknown if the input schema is unknown, the labels aren't known names, or a
+    requested column is absent from the input schema.
+    """
+    names = as_column_list(columns)
+    if not is_known(schema) or names is None:
+        return None
+    out: dict = {}
+    for name in names:
+        if name not in schema:
+            return None
+        out[name] = schema[name]
+    return pl.Schema(out)
+
+
+def add_columns(schema, names, dtype=UNKNOWN_DTYPE) -> pl.Schema | None:
+    """Input schema extended with ``names`` (replacing any that already exist).
+
+    New/overwritten columns get ``dtype`` (``Unknown`` by default, since the
+    value usually comes from an arbitrary expression).
+    """
+    if not is_known(schema) or names is None:
+        return None
+    out = dict(schema)
+    for name in names:
+        out[name] = dtype
+    return pl.Schema(out)
+
+
+def retype_columns(schema, dtype=UNKNOWN_DTYPE) -> pl.Schema | None:
+    """Input schema with the same columns but every dtype replaced by ``dtype``.
+
+    Models an accessor/elementwise projection (e.g. ``.dt.year``) that preserves
+    the column names but produces a new dtype; callers pass ``UNKNOWN_DTYPE``
+    (the default) when that resulting dtype can't be inferred."""
+    if not is_known(schema):
+        return None
+    return pl.Schema({name: dtype for name in schema})
+
+
+def rename_columns(schema, mapping) -> pl.Schema | None:
+    """Input schema with column names remapped through ``mapping`` (name->name)."""
+    if not is_known(schema) or not isinstance(mapping, dict):
+        return None
+    return pl.Schema({mapping.get(name, name): dt for name, dt in schema.items()})
+
+
+def union_columns(schemas) -> pl.Schema | None:
+    """Left-to-right union of several schemas (later dtypes win on a name clash).
+
+    Models a column-wise/relaxed concat: the result holds every column that
+    appears in any input. Unknown if any input schema is unknown.
+    """
+    out: dict = {}
+    for schema in schemas:
+        if not is_known(schema):
+            return None
+        out.update(schema)
+    return pl.Schema(out)
+
+
+def merge_join_schemas(left, right, keys, suffixes) -> pl.Schema | None:
+    """Schema of ``left`` merged with ``right`` the way pandas ``merge`` would.
+
+    Columns present on both sides that are *not* shared join keys get the
+    ``suffixes`` appended (left first, right second); shared join keys collapse to
+    a single column. Unknown if either side is unknown.
+    """
+    if not is_known(left) or not is_known(right):
+        return None
+    lsuffix, rsuffix = suffixes
+    keys = set(keys or ())
+    overlap = (set(left) & set(right)) - keys
+    out: dict = {}
+    for name, dt in left.items():
+        out[f"{name}{lsuffix}" if name in overlap else name] = dt
+    for name, dt in right.items():
+        if name in keys:
+            continue
+        out[f"{name}{rsuffix}" if name in overlap else name] = dt
+    return pl.Schema(out)
+
+
+def aggregate_schema(schema, grouping_keys, aggregations, as_index) -> pl.Schema | None:
+    """Schema of a pandas ``groupby(grouping_keys).agg(aggregations)``.
+
+    Only the dict-spec form with scalar aggregations is statically known: its
+    output columns are exactly the dict keys (dtypes left unknown, since they
+    depend on the aggregation function -- ``count``->int, ``mean``->float, ...).
+    Grouping keys are part of the pandas index by default and only become output
+    columns when ``as_index`` is ``False``. Any other spec is unknown: a bare
+    function name applies to every (numeric) non-grouping column, and a list spec
+    -- including a list value inside the dict -- produces MultiIndex columns we
+    can't represent in a flat schema.
+    """
+    keys = as_column_list(grouping_keys)
+    if not is_known(schema) or keys is None or not isinstance(aggregations, dict):
+        return None
+    out: dict = {}
+    if as_index is False:
+        for key in keys:
+            if key in schema:
+                out[key] = schema[key]
+    for col, func in aggregations.items():
+        if not isinstance(col, str) or isinstance(func, (list, tuple)):
+            return None
+        out[col] = UNKNOWN_DTYPE
+    return pl.Schema(out)

--- a/stratum/optimizer/ir/_selection_ops.py
+++ b/stratum/optimizer/ir/_selection_ops.py
@@ -57,6 +57,10 @@ class SelectionOp(Op):
         # stays a series); extraction overrides this with the propagated type.
         self.output_type = OutputType.FRAME
 
+    def propagate_output_schema(self):
+        """Selection restricts rows and keeps columns, so the schema is unchanged."""
+        self.output_schema = self.inputs[0].output_schema if self.inputs else None
+
     # No custom __str__: the base IRNode renders ``<class>(<name>) [df]`` from
     # ``self.name`` (== the kind). While logical, it shows the ``Selection``
     # family; once lowered, ``_is_physical`` flips the class-name component to the

--- a/stratum/optimizer/ir/_source_ops.py
+++ b/stratum/optimizer/ir/_source_ops.py
@@ -1,7 +1,12 @@
 from stratum.optimizer.ir._ops import OperandRef, Op, OutputType, ValueOp, VariableOp, CallOp
+from stratum.optimizer.ir import _schema
 from pandas import DataFrame
 import numpy as np
 import pandas as pd
+import polars as pl
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class DataSourceOp(Op):
@@ -29,6 +34,50 @@ class DataSourceOp(Op):
         # A directly-passed DataFrame or a csv read is a FRAME; np.load yields an
         # ndarray, so an npy source is a MATRIX.
         self.output_type = OutputType.MATRIX if _format == "npy" else OutputType.FRAME
+
+    def propagate_output_schema(self):
+        """Source schema: read from the in-memory frame, or the file header.
+
+        Column *names* are authoritative; *dtypes* are only kept when they are
+        statically certain. A pandas ``object`` column has no column-level element
+        type (it must be inferred by scanning values, which can be confidently
+        wrong -- e.g. ints in early rows, strings later), and a CSV column's dtype
+        needs a full-file scan, so in both cases we keep the name but mark the
+        dtype ``Unknown``. Falls back to the unknown schema (``None``) when even
+        the names can't be read statically (a graph-fed path, an npy matrix, or an
+        unreadable file)."""
+        if self.data is not None:
+            if isinstance(self.data, pl.DataFrame):
+                # polars frames already carry exact dtypes.
+                self.output_schema = self.data.schema
+            else:
+                # head(0) converts names + typed dtypes without copying data or
+                # risking a mixed-object conversion error. An object column is
+                # element-typed only by scanning, so keep its name with an Unknown
+                # dtype rather than a guessed one. An exotic/extension dtype can
+                # still make the conversion fail, so fall back to unknown then.
+                try:
+                    schema = pl.from_pandas(self.data.head(0)).schema
+                    self.output_schema = pl.Schema({
+                        name: (_schema.UNKNOWN_DTYPE if pd.api.types.is_object_dtype(self.data[name]) else dt)
+                        for name, dt in schema.items()
+                    })
+                except Exception:
+                    logger.debug("Could not derive schema for in-memory frame; falling back to unknown.")
+                    self.output_schema = None
+            return
+
+        if isinstance(self.file_path, OperandRef) or self.format != "csv":
+            self.output_schema = None
+            return
+        try:
+            # Read only the header (no rows): names are exact, dtypes need a full
+            # scan to be safe, so leave them Unknown.
+            names = pl.read_csv(self.file_path, n_rows=0).columns
+            self.output_schema = pl.Schema({name: _schema.UNKNOWN_DTYPE for name in names})
+        except Exception:
+            logger.debug("Could not derive schema for %s; falling back to unknown.", self.file_path)
+            self.output_schema = None
 
     def clone(self):
         raise ValueError(f"We should not clone DataSourceOp objects.")

--- a/stratum/optimizer/ir/_split_ops.py
+++ b/stratum/optimizer/ir/_split_ops.py
@@ -15,6 +15,12 @@ class SplitOp(Op):
         self.output_type = OutputType.FRAME
         self.indices = None
 
+    def propagate_output_schema(self):
+        """A split is a structural ``(X, y)`` fan-out, not a single frame: it has
+        no schema of its own. The consuming :class:`SplitOutput`s read their
+        schema from this op's inputs directly."""
+        self.output_schema = None
+
     def process(self, mode: str, inputs: list):
         # we need to handle both pandas and polars dfs
         x = inputs[0]
@@ -35,6 +41,13 @@ class SplitOutput(Op):
         super().__init__(name=name, is_X=False, is_y=False, inputs=inputs, outputs=outputs)
         self.is_x = is_x
         self.output_type = OutputType.FRAME
+
+    def propagate_output_schema(self):
+        # Subsetting rows keeps the columns: take the schema of the matching
+        # SplitOp input (inputs[0] = X, inputs[1] = y, per add_splitting_op).
+        split_op = self.inputs[0]
+        src = split_op.inputs[0 if self.is_x else 1]
+        self.output_schema = src.output_schema
 
     def process(self, mode: str, inputs: list):
         if self.is_x:

--- a/stratum/optimizer/physical/_lowering.py
+++ b/stratum/optimizer/physical/_lowering.py
@@ -52,6 +52,7 @@ def install_lowered(old: Op, new: PhysicalOp, root: IRNode) -> IRNode:
     new.outputs = old.outputs
     new.is_X = old.is_X
     new.is_y = old.is_y
+    new.output_schema = old.output_schema
     if new.output_type is OutputType.UNKNOWN:
         new.output_type = old.output_type
     for in_ in new.inputs:

--- a/stratum/tests/logical_optimizer/test_schema_propagation.py
+++ b/stratum/tests/logical_optimizer/test_schema_propagation.py
@@ -1,0 +1,443 @@
+import operator
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import pandas as pd
+import polars as pl
+
+import stratum as st
+from stratum.optimizer._optimize import OptConfig
+from stratum.optimizer.ir._dataframe_ops import (
+    AggregateOp, AssignOp, AssignMapOp, ConcatOp, DataSourceOp, DatetimeConversionOp, DropOp,
+    GetAttrProjectionOp, JoinOp, MetadataOp, SplitOp, SplitOutput, ColumnProjectionOp,
+    SelectionOp)
+from stratum.optimizer.ir._ops import BinOp, GetItemOp, Op, OperandRef, OutputType
+from stratum.optimizer.physical._source_execs import InMemoryFrame
+from stratum.tests.logical_optimizer.test_dataframe_ops import optimize
+
+
+def _schema_op(dag, op_type):
+    """Optimize `dag` (with frame ops + schema propagation) and return the single op of `op_type`."""
+    ops = optimize(dag, OptConfig(dataframe_ops=True, propagate_schema=True))
+    found = [o for o in ops if isinstance(o, op_type)]
+    assert len(found) == 1, f"expected exactly one {op_type.__name__}, got {len(found)}"
+    return found[0]
+
+
+def _stub(schema, output_type=OutputType.UNKNOWN):
+    """A bare op standing in for an input that already carries `schema`."""
+    op = Op()
+    op.output_schema = schema
+    op.output_type = output_type
+    return op
+
+
+class TestSchemaPropagation(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6], "z": [7, 8, 9]})
+
+    # --- source ----------------------------------------------------------
+    def test_source_schema_from_frame(self):
+        # Lowering replaces DataSourceOp with an InMemoryFrame physical op; the
+        # schema is copied across so the source still carries it.
+        src = _schema_op(st.as_data_op(self.df).drop(columns=["z"]), InMemoryFrame)
+        self.assertEqual(["x", "y", "z"], list(src.output_schema.keys()))
+
+    def test_source_keeps_exact_dtype_for_typed_columns(self):
+        op = DataSourceOp(data=pd.DataFrame({"i": [1, 2], "f": [1.5, 2.5]}))
+        op.propagate_output_schema()
+        self.assertEqual(pl.Int64, op.output_schema["i"])
+        self.assertEqual(pl.Float64, op.output_schema["f"])
+
+    def test_source_object_column_keeps_name_but_unknown_dtype(self):
+        # an object column is element-typed only by scanning; a sample can be
+        # confidently wrong, so the name is kept but the dtype is left Unknown.
+        df = pd.DataFrame({"i": [1, 2, 3], "obj": pd.Series([1, 2, "x"], dtype=object)})
+        op = DataSourceOp(data=df)
+        op.propagate_output_schema()
+        self.assertEqual(["i", "obj"], list(op.output_schema.keys()))
+        self.assertEqual(pl.Int64, op.output_schema["i"])
+        self.assertEqual(pl.Unknown, op.output_schema["obj"])
+
+    def test_source_polars_frame_keeps_exact_schema(self):
+        op = DataSourceOp(data=pl.DataFrame({"a": [1], "b": ["x"]}))
+        op.propagate_output_schema()
+        self.assertEqual(pl.Int64, op.output_schema["a"])
+        self.assertEqual(pl.String, op.output_schema["b"])
+
+    def test_csv_source_names_exact_dtypes_unknown(self):
+        # Write via the path (not an open handle) so pandas controls newline
+        # handling; a text-mode handle on Windows would translate \n -> \r\n and
+        # leave a stray \r on the last column name.
+        fd, path = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            self.df.to_csv(path, index=False)
+            op = DataSourceOp(file_path=path, _format="csv")
+            op.propagate_output_schema()
+            self.assertEqual(["x", "y", "z"], list(op.output_schema.keys()))
+            # dtypes need a full-file scan to be safe -> left Unknown.
+            self.assertTrue(all(dt == pl.Unknown for dt in op.output_schema.values()))
+        finally:
+            os.unlink(path)
+
+    def test_csv_source_unreadable_path_falls_back_to_unknown(self):
+        op = DataSourceOp(file_path="/no/such/file.csv", _format="csv")
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_graph_fed_path_is_unknown(self):
+        op = DataSourceOp(file_path=OperandRef(0), _format="csv")
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_in_memory_conversion_failure_falls_back_to_unknown(self):
+        # an unconvertible pandas frame (e.g. an exotic/extension dtype) must not
+        # crash optimize(); the pandas->polars conversion is caught and the schema
+        # falls back to unknown.
+        op = DataSourceOp(data=self.df)
+        with mock.patch("polars.from_pandas", side_effect=Exception("boom")):
+            op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    # --- column-changing ops --------------------------------------------
+    def test_drop_removes_columns(self):
+        op = _schema_op(st.as_data_op(self.df).drop(columns=["z"]), DropOp)
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_drop_positional_axis1_removes_columns(self):
+        # positional form `df.drop(labels, axis=1)`: labels are columns.
+        op = DropOp(args=[["z"]], kwargs={"axis": 1})
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64, "z": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_drop_row_axis_is_unknown(self):
+        # a positional row drop (`df.drop(labels)`, axis defaults to 0) names no
+        # columns statically, so the schema can't be resolved -> unknown.
+        op = DropOp(args=[[0, 1]], kwargs={"axis": 0})
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_assign_adds_unknown_typed_column(self):
+        # Constant/foldable assign becomes AssignMapOp under the map extractor.
+        op = _schema_op(st.as_data_op(self.df).assign(w=1), AssignMapOp)
+        self.assertEqual(["x", "y", "z", "w"], list(op.output_schema.keys()))
+        self.assertEqual(pl.Unknown, op.output_schema["w"])
+
+    def test_rename_remaps_columns(self):
+        op = _schema_op(st.as_data_op(self.df).rename(columns={"x": "a"}), MetadataOp)
+        self.assertEqual(["a", "y", "z"], list(op.output_schema.keys()))
+
+    def test_rename_via_axis1_mapper_remaps_columns(self):
+        # rename(mapper, axis=1) is the positional equivalent of columns=mapper.
+        op = MetadataOp(func="rename", kwargs={"mapper": {"x": "a"}, "axis": 1})
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64, "z": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["a", "y", "z"], list(op.output_schema.keys()))
+
+    def test_non_rename_metadata_is_unknown(self):
+        # only `rename` is modelled; any other metadata op falls back to unknown.
+        op = MetadataOp(func="reset_index")
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_single_column_selection_is_one_column_schema(self):
+        op = _schema_op(st.as_data_op(self.df)["x"], ColumnProjectionOp)
+        self.assertEqual(["x"], list(op.output_schema.keys()))
+
+    def test_multi_column_projection_selects_subschema(self):
+        op = _schema_op(st.as_data_op(self.df)[["x", "y"]], ColumnProjectionOp)
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_row_slice_preserves_schema(self):
+        # a slice key (`df[1:3]`) selects rows, so all columns are kept.
+        op = GetItemOp(key=slice(1, 3))
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_non_string_label_key_is_unknown(self):
+        # a key that isn't string column labels (e.g. positional ints) can't be
+        # resolved to named columns -> unknown.
+        op = GetItemOp(key=[0, 1])
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_row_mask_preserves_schema(self):
+        data = st.as_data_op(self.df)
+        ops = optimize(data[data["x"] > 1], OptConfig(dataframe_ops=True))
+        row_sel = [o for o in ops if isinstance(o, SelectionOp)]
+        self.assertEqual(1, len(row_sel))
+        self.assertEqual(["x", "y", "z"], list(row_sel[0].output_schema.keys()))
+
+    def test_projection_of_absent_column_is_unknown(self):
+        # selecting a column the input schema doesn't carry can't be resolved
+        # statically -> unknown (rather than an empty/partial schema).
+        op = GetItemOp(key=["x", "missing"])
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_graph_fed_non_series_key_is_unknown(self):
+        # a graph-fed key that isn't a series-shaped mask (e.g. a computed column
+        # selector) can't be resolved statically -> unknown, not all columns.
+        op = GetItemOp(key=OperandRef(1))
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME),
+                     _stub(None, OutputType.UNKNOWN)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_graph_fed_series_mask_preserves_schema(self):
+        # a graph-fed SERIES key is a boolean row mask -> keeps all columns.
+        op = GetItemOp(key=OperandRef(1))
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME),
+                     _stub(pl.Schema({"x": pl.Boolean}), OutputType.SERIES)]
+        op.propagate_output_schema()
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    # --- multi-input ops -------------------------------------------------
+    def test_merge_collapses_shared_key(self):
+        left = pd.DataFrame({"k": [1, 2], "a": [1, 2]})
+        right = pd.DataFrame({"k": [1, 2], "b": [3, 4]})
+        op = _schema_op(st.as_data_op(left).merge(st.as_data_op(right), on="k"), JoinOp)
+        self.assertEqual(["k", "a", "b"], list(op.output_schema.keys()))
+
+    def test_join_overlap_gets_suffixes(self):
+        op = JoinOp(how="inner", left_on="k", right_on="k", suffixes=("_x", "_y"))
+        op.inputs = [_stub(pl.Schema({"k": pl.Int64, "v": pl.Int64})),
+                     _stub(pl.Schema({"k": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        # shared key `k` collapses; the overlapping non-key `v` is suffixed on both sides.
+        self.assertEqual(["k", "v_x", "v_y"], list(op.output_schema.keys()))
+
+    def test_merge_different_key_names_keeps_both(self):
+        # left_on/right_on with different names: pandas keeps both key columns.
+        left = pd.DataFrame({"a": [1, 2], "v": [1, 2]})
+        right = pd.DataFrame({"b": [1, 2], "w": [3, 4]})
+        op = _schema_op(
+            st.as_data_op(left).merge(st.as_data_op(right), left_on="a", right_on="b"),
+            JoinOp)
+        self.assertEqual(["a", "v", "b", "w"], list(op.output_schema.keys()))
+
+    def test_index_join_suffixes_overlapping_columns(self):
+        # an index-based join has no left_on/right_on keys: every overlapping
+        # column is suffixed on both sides, the rest are kept as-is.
+        op = JoinOp(how="left", left_index=True, right_index=True, suffixes=("_l", "_r"))
+        op.inputs = [_stub(pl.Schema({"a": pl.Int64, "v": pl.Int64})),
+                     _stub(pl.Schema({"b": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["a", "v_l", "b", "v_r"], list(op.output_schema.keys()))
+
+    def test_concat_unions_columns(self):
+        op = ConcatOp(first=OperandRef(0), others=[OperandRef(1)], axis=1)
+        op.inputs = [_stub(pl.Schema({"a": pl.Int64})), _stub(pl.Schema({"b": pl.String}))]
+        op.propagate_output_schema()
+        self.assertEqual(["a", "b"], list(op.output_schema.keys()))
+
+    # --- split (X, y fan-out) -------------------------------------------
+    def test_split_outputs_carry_their_input_schema(self):
+        x = _stub(pl.Schema({"a": pl.Int64, "b": pl.Int64}), OutputType.FRAME)
+        y = _stub(pl.Schema({"target": pl.Int64}), OutputType.FRAME)
+        split = SplitOp(inputs=[x, y])
+        out_x = SplitOutput(inputs=[split], is_x=True)
+        out_y = SplitOutput(inputs=[split], is_x=False)
+
+        # the split itself is a structural fan-out, not a single frame.
+        split.propagate_output_schema()
+        self.assertIsNone(split.output_schema)
+
+        # each output keeps the columns of its matching split input.
+        out_x.propagate_output_schema()
+        out_y.propagate_output_schema()
+        self.assertEqual(["a", "b"], list(out_x.output_schema.keys()))
+        self.assertEqual(["target"], list(out_y.output_schema.keys()))
+
+    def test_split_output_unknown_input_propagates(self):
+        x = _stub(None, OutputType.FRAME)
+        y = _stub(pl.Schema({"target": pl.Int64}), OutputType.FRAME)
+        split = SplitOp(inputs=[x, y])
+        out_x = SplitOutput(inputs=[split], is_x=True)
+        out_x.propagate_output_schema()
+        self.assertIsNone(out_x.output_schema)
+
+    # --- unknown propagation --------------------------------------------
+    def test_unknown_input_propagates(self):
+        op = ConcatOp(first=OperandRef(0), others=[OperandRef(1)], axis=0)
+        op.inputs = [_stub(pl.Schema({"a": pl.Int64})), _stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_projection_unknown_input_propagates(self):
+        # a column projection over an unknown input schema stays unknown.
+        op = GetItemOp(key=["x"])
+        op.inputs = [_stub(None, OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_assign_unknown_input_propagates(self):
+        op = AssignOp(kwargs={"w": 1})
+        op.inputs = [_stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_rename_unknown_input_propagates(self):
+        op = MetadataOp(func="rename", kwargs={"columns": {"x": "a"}})
+        op.inputs = [_stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_join_unknown_input_propagates(self):
+        op = JoinOp(how="inner", left_on="k", right_on="k", suffixes=("_x", "_y"))
+        op.inputs = [_stub(pl.Schema({"k": pl.Int64})), _stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_propagate_schema_disabled_leaves_schema_unset(self):
+        # the pass is gated behind OptConfig.propagate_schema; with it off, no op
+        # gets a schema (they keep the constructor default of None).
+        dag = st.as_data_op(self.df).drop(columns=["z"])
+        ops = optimize(dag, OptConfig(dataframe_ops=True, propagate_schema=False))
+        self.assertTrue(all(o.output_schema is None for o in ops))
+
+    def test_udf_falls_back_to_unknown(self):
+        # apply() is a UDF: its output schema cannot be propagated -> None.
+        from stratum.optimizer.ir._dataframe_ops import ApplyUDFOp
+        op = _schema_op(st.as_data_op(self.df).apply(lambda c: c + 1), ApplyUDFOp)
+        self.assertIsNone(op.output_schema)
+
+    def test_unknown_poisons_downstream_known_op(self):
+        # a UDF yields an unknown schema; a downstream drop (normally a known
+        # column-changing op) can't recover columns from it -> stays unknown.
+        dag = st.as_data_op(self.df).apply(lambda c: c + 1).drop(columns=["z"])
+        op = _schema_op(dag, DropOp)
+        self.assertIsNone(op.output_schema)
+
+    # --- accessor projection (.dt.year, ...) ----------------------------
+    def test_getattr_projection_keeps_columns_retypes(self):
+        op = GetAttrProjectionOp(attr_name=["dt", "year"])
+        op.inputs = [_stub(pl.Schema({"d": pl.Datetime("us")}))]
+        op.propagate_output_schema()
+        # column name is preserved; the dtype is no longer tracked.
+        self.assertEqual(["d"], list(op.output_schema.keys()))
+        self.assertEqual(pl.Unknown, op.output_schema["d"])
+
+    def test_getattr_projection_unknown_input_propagates(self):
+        op = GetAttrProjectionOp(attr_name="dt")
+        op.inputs = [_stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    # --- aggregation (groupby.agg) --------------------------------------
+    def test_aggregate_dict_spec_keys_are_columns(self):
+        # as_index defaults to True -> grouping key `g` goes to the index, not a column.
+        op = AggregateOp(grouping_attributes="g", aggregations={"v": "sum"})
+        op.inputs = [_stub(pl.Schema({"g": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["v"], list(op.output_schema.keys()))
+        self.assertEqual(pl.Unknown, op.output_schema["v"])
+
+    def test_aggregate_as_index_false_keeps_grouping_keys(self):
+        op = AggregateOp(grouping_attributes="g", aggregations={"v": "sum"},
+                         groupby_kwargs={"as_index": False})
+        op.inputs = [_stub(pl.Schema({"g": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["g", "v"], list(op.output_schema.keys()))
+
+    def test_aggregate_as_index_false_skips_unknown_grouping_key(self):
+        # as_index=False adds grouping keys as columns, but only those actually
+        # present in the input schema; an unknown key is simply not emitted.
+        op = AggregateOp(grouping_attributes="g", aggregations={"v": "sum"},
+                         groupby_kwargs={"as_index": False})
+        op.inputs = [_stub(pl.Schema({"v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertEqual(["v"], list(op.output_schema.keys()))
+
+    def test_aggregate_string_spec_is_unknown(self):
+        # a bare function name aggregates every column -> not statically known.
+        op = AggregateOp(grouping_attributes="g", aggregations="sum")
+        op.inputs = [_stub(pl.Schema({"g": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_aggregate_list_value_spec_is_unknown(self):
+        # a list value produces MultiIndex columns -> not representable -> unknown.
+        op = AggregateOp(grouping_attributes="g", aggregations={"v": ["sum", "mean"]})
+        op.inputs = [_stub(pl.Schema({"g": pl.Int64, "v": pl.Int64}))]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    # --- elementwise binary ops (df + 1, df["x"] > 0) -------------------
+    def test_binop_frame_operand_keeps_schema(self):
+        # an elementwise op over a frame keeps its columns (the dtype may change).
+        op = BinOp(op=operator.gt, left=OperandRef(0), right=1)
+        op.output_type = OutputType.SERIES
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_binop_frame_frame_same_columns_keeps_schema(self):
+        # df1 + df2 with identical columns keeps that shape.
+        op = BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1))
+        op.output_type = OutputType.FRAME
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME),
+                     _stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertEqual(["x", "y"], list(op.output_schema.keys()))
+
+    def test_binop_frame_frame_differing_columns_is_unknown(self):
+        # df1 + df2 over differing columns unions/aligns in pandas; guessing one
+        # side's shape would be wrong, so fall back to unknown.
+        op = BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1))
+        op.output_type = OutputType.FRAME
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64, "y": pl.Int64}), OutputType.FRAME),
+                     _stub(pl.Schema({"x": pl.Int64, "z": pl.Int64}), OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_binop_non_frame_output_is_unknown(self):
+        # a scalar-producing op (e.g. reduction) carries no column schema.
+        op = BinOp(op=operator.add, left=OperandRef(0), right=OperandRef(1))
+        op.output_type = OutputType.SCALAR
+        op.inputs = [_stub(pl.Schema({"x": pl.Int64}), OutputType.FRAME), _stub(None)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_binop_unknown_frame_input_propagates(self):
+        # frame output but the frame operand's schema is unknown -> unknown.
+        op = BinOp(op=operator.add, left=OperandRef(0), right=1)
+        op.output_type = OutputType.FRAME
+        op.inputs = [_stub(None, OutputType.FRAME)]
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    # --- ops without a propagation rule fall back to unknown ------------
+    def test_generic_op_falls_back_to_unknown(self):
+        # the base Op (any non-frame / no-rule op) yields the unknown schema.
+        op = Op()
+        op.propagate_output_schema()
+        self.assertIsNone(op.output_schema)
+
+    def test_datetime_conversion_is_datetime_typed(self):
+        dt_df = pd.DataFrame({"d": ["2025-11-01", "2025-11-02"]})
+        date = st.as_data_op(dt_df)["d"].skb.apply_func(pd.to_datetime)
+        op = _schema_op(date, DatetimeConversionOp)
+        self.assertEqual(["d"], list(op.output_schema.keys()))
+        self.assertIsInstance(op.output_schema["d"], pl.Datetime)
+
+    def test_datetime_conversion_multi_column_retypes_all(self):
+        # to_datetime over a frame keeps every column name and retypes to Datetime.
+        op = DatetimeConversionOp()
+        op.inputs = [_stub(pl.Schema({"d1": pl.String, "d2": pl.String}))]
+        op.propagate_output_schema()
+        self.assertEqual(["d1", "d2"], list(op.output_schema.keys()))
+        self.assertTrue(all(isinstance(dt, pl.Datetime) for dt in op.output_schema.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a compiler pass that walks the Op DAG sources->sinks and populates each op's output_schema (a polars.Schema, or None for unknown). Many DataFrame rewrites (predicate pushdown, projection pushup) need to know an op's output_schema

Schema algebra (_schema.py):
- A schema is an ordered polars.Schema (column -> dtype); None is the unknown schema and propagates through every helper -- any operation on an unknown input is unknown.
- Helpers: drop_columns, select_columns, add_columns, retype_columns, rename_columns, union_columns, merge_join_schemas, aggregate_schema, plus is_known/as_column_list. Column names are kept exact; a dtype is only kept when statically certain, else left Unknown (e.g. a column from an arbitrary assigned expression).

Per-op rules (infer_output_schema, run in topological order):
- DataSourceOp: read names+dtypes from an in-memory frame, or names from a CSV header (n_rows=0); object/CSV columns keep the name with an Unknown dtype. Both reads fall back to None on failure rather than crashing optimize().
- DropOp/AssignOp/MetadataOp(rename): remove/add/remap the named columns.
- JoinOp: merge left+right, suffixing overlapping non-key columns and collapsing shared (equal-named) keys.
- AggregateOp: only a dict agg spec gives known columns (its keys); grouping keys become columns only when as_index=False; bare/list specs -> unknown.
- ConcatOp: union of every operand's columns.
- GetItemOp: column projection selects a sub-schema; a slice or a series-shaped row mask (`df[mask]`) keeps the schema; any other graph-fed key (e.g. a computed column selector) can't be resolved statically -> unknown.
- BinOp: an elementwise frame op keeps its frame operand's columns; a frame-frame op only trusts a result when both operands carry the same known columns, else unknown.
- GetAttrProjectionOp/DatetimeConversionOp: keep column names, retype.
- SplitOp/SplitOutput: the split is a structural (X, y) fan-out with no schema; each output reads its matching split input's schema.
- UDFs (ApplyUDFOp) and ops without a rule fall back to the unknown schema.

Pass wiring:
- Gated behind OptConfig.infer_schema (default True); runs after choice unrolling, before algebraic rewrites.
- NOTE: schemas are inferred once, so rewrites that later create/replace ops leave new ops without a schema and replaced ones stale; this is fine while nothing consumes output_schema yet (see TODO at the call site).

Add test_schema_inference.py covering sources (frame/csv/object/polars/graph-fed), drop/assign/rename, single/multi-column getitem, row-mask and graph-fed column-selector getitem, join key collapse and suffixing (incl. differing key names and index joins), concat, aggregation specs, accessor/datetime retyping, elementwise binops (frame and frame-frame), split fan-out, and unknown propagation.