### PR TITLE
[FrameOperator] SelectionOp + column-expression predicate folding (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ benchmarks-staging
 *.pdf
 *.ipynb
 *.npy
+*.png
 
 # coding agents
 .cursor

--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -19,14 +19,6 @@ def _env_int(name, default=0):
     v = os.getenv(name)
     return int(v) if v is not None else int(default)
 
-def _env_str(name, default=None):
-    v = os.getenv(name)
-    if v is None:
-        return default
-    s = str(v).strip().lower()
-    if s in ("", "none", "null"):
-        return None
-    return s
 
 @dataclass
 class _Flags:
@@ -43,8 +35,11 @@ class _Flags:
     cse: bool = True
     DEBUG: bool = False
     force_polars: bool = _env_bool("STRATUM_FORCE_POLARS", False)
+    pandas_query: bool = _env_bool("STRATUM_PANDAS_QUERY", False)
     fast_dataops_convert: bool = True
     validate_dag: bool = True
+    make_selection_op: bool = True
+    rechunk: bool = True
     buffer_pool_memory_budget: int = 0
 
 FLAGS = _Flags()
@@ -61,10 +56,14 @@ def set_config(rust_backend: bool | None = None,
     explain_linear_plan: bool = False,
     DEBUG: bool | None = None,
     force_polars: bool = False,
+    pandas_query: bool = False,
     cse: bool = True,
     fast_dataops_convert: bool = True,
     validate_dag: bool = True,
-    buffer_pool_memory_budget: int = 0) -> None:
+    make_selection_op: bool = True,
+    rechunk: bool = True,
+buffer_pool_memory_budget: int = 0
+               ) -> None:
     """Runtime toggles (synced env for Rust to read).
 
     Parameter:
@@ -103,6 +102,11 @@ def set_config(rust_backend: bool | None = None,
 
         force_polars: bool, default false
             Force use of Polars instead of Pandas for dataframe operations.
+
+        pandas_query: bool, default false
+            Evaluate MASK selections on the pandas backend via ``DataFrame.query()``
+            when the predicate is expressible as a query string (no OperandLeaf / str
+            accessor); otherwise fall back to boolean-mask indexing.
     """
     if rust_backend is not None:
         FLAGS.rust_backend = bool(rust_backend)
@@ -131,14 +135,18 @@ def set_config(rust_backend: bool | None = None,
     if force_polars is not None:
         FLAGS.force_polars = bool(force_polars)
         os.environ["STRATUM_FORCE_POLARS"] = "1" if FLAGS.force_polars else "0"
+    FLAGS.pandas_query = bool(pandas_query)
+    os.environ["STRATUM_PANDAS_QUERY"] = "1" if FLAGS.pandas_query else "0"
     # TODO: Select between multiple schedulers in the future.
     FLAGS.scheduler = bool(scheduler)
     FLAGS.cse = bool(cse)
     FLAGS.debug_graph = bool(debug_graph)
     FLAGS.open_graph = bool(open_graph)
-    FLAGS.explain_linear_plan = bool(explain_linear_plan)
-
     FLAGS.buffer_pool_memory_budget = int(buffer_pool_memory_budget)
+    FLAGS.explain_linear_plan = bool(explain_linear_plan)
+    FLAGS.make_selection_op = bool(make_selection_op)
+    FLAGS.rechunk = bool(rechunk)
+
     #FIXME: This should be the default. No need to set it. Remove.
     FLAGS.fast_dataops_convert = bool(fast_dataops_convert)
     FLAGS.validate_dag = bool(validate_dag)
@@ -146,24 +154,7 @@ def set_config(rust_backend: bool | None = None,
 
 def get_config() -> dict:
     # Shallow copy for safety
-    return {
-        "rust_backend": FLAGS.rust_backend,
-        "num_threads": FLAGS.num_threads,
-        "debug_timing": FLAGS.debug_timing,
-        "allow_patch": FLAGS.allow_patch,
-        "scheduler": FLAGS.scheduler,
-        "stats": FLAGS.stats,
-        "stats_top_k": FLAGS.stats_top_k,
-        "debug_graph": FLAGS.debug_graph,
-        "open_graph": FLAGS.open_graph,
-        "explain_linear_plan": FLAGS.explain_linear_plan,
-        "DEBUG" : FLAGS.DEBUG,
-        "force_polars": FLAGS.force_polars,
-        "cse": FLAGS.cse,
-        "fast_dataops_convert": FLAGS.fast_dataops_convert,
-        "validate_dag": FLAGS.validate_dag,
-        "buffer_pool_memory_budget": FLAGS.buffer_pool_memory_budget,
-    }
+    return vars(FLAGS).copy() # asdict if we want a deep copy
 
 @contextmanager
 def config(**kwargs):

--- a/stratum/optimizer/_op_cse.py
+++ b/stratum/optimizer/_op_cse.py
@@ -131,4 +131,7 @@ def _remap_refs(value, mapping: dict):
         return [_remap_refs(v, mapping) for v in value]
     if isinstance(value, dict):
         return {k: _remap_refs(v, mapping) for k, v in value.items()}
+    if hasattr(value, "remap_operand_refs"):
+        # Column-expression tree (immutable) -> rebuild with remapped refs.
+        return value.remap_operand_refs(mapping)
     return value

--- a/stratum/optimizer/_op_utils.py
+++ b/stratum/optimizer/_op_utils.py
@@ -161,7 +161,8 @@ def topological_iterator_dfs(queue, indegree) -> Iterator[Op]:
                 stack.append(out_op)
 
 def _iter_operand_refs(value):
-    """Yield every OperandRef nested in value (recurses lists/tuples/dicts)."""
+    """Yield every OperandRef nested in value (recurses lists/tuples/dicts, and
+    column-expression trees that expose ``iter_operand_refs``)."""
     if isinstance(value, OperandRef):
         yield value
     elif isinstance(value, (list, tuple)):
@@ -170,6 +171,8 @@ def _iter_operand_refs(value):
     elif isinstance(value, dict):
         for v in value.values():
             yield from _iter_operand_refs(v)
+    elif hasattr(value, "iter_operand_refs"):
+        yield from value.iter_operand_refs()
 
 
 def validate_operands(op: Op) -> None:

--- a/stratum/optimizer/_optimize.py
+++ b/stratum/optimizer/_optimize.py
@@ -91,10 +91,6 @@ def optimize(dag_root: DataOp, config: OptConfig = None, env: dict = None):
     # Convert to Op DAG
     root = convert_to_ops(dag_root, env)
 
-    # Apply CSE on the Op IR (post-conversion)
-    if FLAGS.cse:
-        root = run_op_cse_pass(root)
-
     # Add splitting op
     root = add_splitting_op(root)
     _debug_validate_dag(root)  # operand refs as wired by as_op
@@ -104,6 +100,13 @@ def optimize(dag_root: DataOp, config: OptConfig = None, env: dict = None):
         root = extract_frame_operators(root)
     if config.numeric_ops:
         root = extract_numeric_operators(root)
+
+    # Apply CSE on the Op IR *after* extraction, so it can dedup whole specialized
+    # ops (e.g. two identical mask SelectionOps). Running it earlier would merge a
+    # mask's shared sub-expressions into a node with multiple consumers, which then
+    # blocks selection folding.
+    if FLAGS.cse:
+        root = run_op_cse_pass(root)
 
     # Unrolling of choices to a dag with only a single ChoiceOp at the end
     if config.unroll_choices:
@@ -140,7 +143,7 @@ def extract_frame_operators(root):
     """ Rewrite the dataframe ops in the dag to the new dataframe ops."""
     start = start_time()
     for op in topological_iterator(root):
-        root, _ = extract_dataframe_op(op, root)
+        root, _ = extract_dataframe_op(op, root, FLAGS.make_selection_op)
     log_time("dataframe_rewrite took", start)
     _debug_show_graph(root, "frame_rewrite")
     return root

--- a/stratum/optimizer/ir/_column_expr.py
+++ b/stratum/optimizer/ir/_column_expr.py
@@ -1,0 +1,440 @@
+"""Backend-agnostic column expression tree.
+
+Used by selections (boolean predicates) and maps (computed columns).
+Expressions are immutable value types and compare structurally.
+"""
+from __future__ import annotations
+import operator
+
+import polars as pl
+
+from stratum.optimizer.ir._ops import OperandRef, BinOp, UnaryOp, GetItemOp, Op
+from stratum.optimizer.ir._projection_ops import StringMethodOp, STR_POLARS_METHODS
+
+# operator callable -> symbol. A binary/unary op whose callable is not in the
+# corresponding map is not foldable into a column expression.
+BINARY_SYMBOLS = {
+    operator.gt: ">", operator.lt: "<", operator.ge: ">=", operator.le: "<=",
+    operator.eq: "==", operator.ne: "!=",
+    operator.and_: "&", operator.or_: "|", operator.xor: "^",
+    operator.add: "+", operator.sub: "-", operator.mul: "*",
+    operator.truediv: "/", operator.floordiv: "//", operator.mod: "%",
+    operator.pow: "**",
+}
+UNARY_SYMBOLS = {operator.invert: "~", operator.neg: "-", operator.pos: "+"}
+
+
+class ColumnExpr:
+    """Base class for column-expression nodes."""
+    __slots__ = ()
+
+    def _key(self):
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self._key() == other._key()
+
+    def __hash__(self):
+        return hash((type(self).__name__, self._key()))
+
+    def to_pandas(self, frame, inputs):
+        """Evaluate the expression against a pandas frame."""
+        raise NotImplementedError
+
+    def to_polars(self, inputs):
+        """Convert the expression to a Polars expression."""
+        raise NotImplementedError
+
+    def to_pandas_query(self, params: dict) -> str | None:
+        """Return a pandas ``query()`` string, or ``None`` if unsupported.
+
+        Literals are bound into ``params`` and referenced as ``@p<i>``. A ``None``
+        anywhere falls back to the boolean-mask path (``to_pandas``).
+        """
+        return None
+
+    def iter_operand_refs(self):
+        """Yield all referenced ``OperandRef`` objects."""
+        return iter(())
+
+    def remap_operand_refs(self, mapping: dict) -> "ColumnExpr":
+        """Return a copy with operand references remapped."""
+        return self
+
+
+class Col(ColumnExpr):
+    """Reference to a source-frame column."""
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def _key(self):
+        return self.name
+
+    def __repr__(self):
+        return f"Col({self.name!r})"
+
+    def to_pandas(self, frame, inputs):
+        return frame[self.name]
+
+    def to_polars(self, inputs):
+        return pl.col(self.name)
+
+    def to_pandas_query(self, params):
+        # Backtick the name so spaces / keywords / dots stay valid inside the query.
+        return f"`{self.name}`"
+
+
+class Const(ColumnExpr):
+    """Literal scalar value."""
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
+
+    def _key(self):
+        try:
+            hash(self.value)
+        except TypeError:
+            return ("__id__", id(self.value))
+        return self.value
+
+    def __repr__(self):
+        return f"Const({self.value!r})"
+
+    def to_pandas(self, frame, inputs):
+        return self.value
+
+    def to_polars(self, inputs):
+        return pl.lit(self.value)
+
+    def to_pandas_query(self, params):
+        # Bind the literal as a real object (referenced as @p<i>) rather than
+        # stringifying it -- keeps timestamps/strings/NaN intact in the query.
+        name = f"p{len(params)}"
+        params[name] = self.value
+        return f"@{name}"
+
+
+class OperandLeaf(ColumnExpr):
+    """Reference to an operator input that was not folded."""
+    __slots__ = ("ref",)
+
+    def __init__(self, ref):
+        self.ref = ref
+
+    def _key(self):
+        return self.ref
+
+    def __repr__(self):
+        return f"OperandLeaf({self.ref})"
+
+    def to_pandas(self, frame, inputs):
+        return inputs[self.ref.k]
+
+    def to_polars(self, inputs):
+        return inputs[self.ref.k]
+
+    def iter_operand_refs(self):
+        yield self.ref
+
+    def remap_operand_refs(self, mapping):
+        return OperandLeaf(OperandRef(mapping[self.ref.k]))
+
+
+class BinOpExpr(ColumnExpr):
+    """Binary operation on two expressions."""
+    __slots__ = ("op", "left", "right")
+
+    def __init__(self, op, left: ColumnExpr, right: ColumnExpr):
+        self.op = op
+        self.left = left
+        self.right = right
+
+    def _key(self):
+        return (self.op, self.left, self.right)
+
+    def __repr__(self):
+        return f"({self.left!r} {BINARY_SYMBOLS.get(self.op, self.op)} {self.right!r})"
+
+    def to_pandas(self, frame, inputs):
+        return self.op(self.left.to_pandas(frame, inputs),
+                       self.right.to_pandas(frame, inputs))
+
+    def to_polars(self, inputs):
+        return self.op(self.left.to_polars(inputs), self.right.to_polars(inputs))
+
+    def to_pandas_query(self, params):
+        sym = BINARY_SYMBOLS.get(self.op)
+        if sym is None:
+            return None
+        left = self.left.to_pandas_query(params)
+        right = self.right.to_pandas_query(params)
+        if left is None or right is None:
+            return None
+        return f"({left} {sym} {right})"
+
+    def iter_operand_refs(self):
+        yield from self.left.iter_operand_refs()
+        yield from self.right.iter_operand_refs()
+
+    def remap_operand_refs(self, mapping):
+        return BinOpExpr(self.op, self.left.remap_operand_refs(mapping),
+                         self.right.remap_operand_refs(mapping))
+
+
+class UnaryOpExpr(ColumnExpr):
+    """Unary operation on an expression."""
+    __slots__ = ("op", "operand")
+
+    def __init__(self, op, operand: ColumnExpr):
+        self.op = op
+        self.operand = operand
+
+    def _key(self):
+        return (self.op, self.operand)
+
+    def __repr__(self):
+        return f"{UNARY_SYMBOLS.get(self.op, self.op)}({self.operand!r})"
+
+    def to_pandas(self, frame, inputs):
+        return self.op(self.operand.to_pandas(frame, inputs))
+
+    def to_polars(self, inputs):
+        return self.op(self.operand.to_polars(inputs))
+
+    def to_pandas_query(self, params):
+        sym = UNARY_SYMBOLS.get(self.op)
+        if sym is None:
+            return None
+        operand = self.operand.to_pandas_query(params)
+        if operand is None:
+            return None
+        return f"({sym}{operand})"
+
+    def iter_operand_refs(self):
+        yield from self.operand.iter_operand_refs()
+
+    def remap_operand_refs(self, mapping):
+        return UnaryOpExpr(self.op, self.operand.remap_operand_refs(mapping))
+
+
+class StrExpr(ColumnExpr):
+    """String accessor call (``.str.<method>()``)."""
+    __slots__ = ("operand", "method", "args", "kwargs")
+
+    def __init__(self, operand: ColumnExpr, method: str, args=(), kwargs=None):
+        self.operand = operand
+        self.method = method
+        self.args = tuple(args)
+        self.kwargs = kwargs or {}
+
+    def _key(self):
+        return (self.operand, self.method, self.args, frozenset(self.kwargs.items()))
+
+    def __repr__(self):
+        inner = ", ".join([repr(self.operand)]
+                          + [repr(a) for a in self.args]
+                          + [f"{k}={v!r}" for k, v in self.kwargs.items()])
+        return f"str.{self.method}({inner})"
+
+    def to_pandas(self, frame, inputs):
+        obj = self.operand.to_pandas(frame, inputs)
+        return getattr(obj.str, self.method)(*self.args, **self.kwargs)
+
+    def to_polars(self, inputs):
+        obj = self.operand.to_polars(inputs)
+        name = STR_POLARS_METHODS.get(self.method, self.method)
+        return getattr(obj.str, name)(*self.args, **self.kwargs)
+
+    def iter_operand_refs(self):
+        yield from self.operand.iter_operand_refs()
+
+    def remap_operand_refs(self, mapping):
+        return StrExpr(self.operand.remap_operand_refs(mapping),
+                       self.method, self.args, self.kwargs)
+
+
+# --- Conversion: op subgraph -> ColumnExpr -----------------------------------
+
+class _Folder:
+    """Fold an operator subgraph into a ``ColumnExpr``.
+
+    Runs three passes: :meth:`_discover` collects the foldable cone,
+    :meth:`_absorbable` keeps only nodes private to it, and :meth:`_build`
+    materialises the tree, emitting an :class:`OperandLeaf` for the rest. The
+    new operator's inputs are ``[src, *leaf_ops]``.
+    """
+
+    def __init__(self, src: Op):
+        self.src = src
+        self.absorbed: list[Op] = []
+        self._absorbed_ids: set[int] = set()
+        self.leaf_ops: list[Op] = []
+        self._leaf_index: dict[int, int] = {}
+
+    def fold(self, root: Op, root_consumer: Op) -> ColumnExpr:
+        assert any(o is root_consumer for o in root.outputs)
+        cone, child_ops = self._discover(root)
+        absorbable = self._absorbable(root, root_consumer, cone, child_ops)
+        return self._build(root, absorbable, child_ops)
+
+    # --- structural classification -------------------------------------------
+
+    def _is_foldable(self, node: Op) -> bool:
+        """Return whether ``node`` can be represented as a ``ColumnExpr``."""
+        if isinstance(node, BinOp):
+            return node.op in BINARY_SYMBOLS
+        if isinstance(node, UnaryOp):
+            return node.op in UNARY_SYMBOLS
+        if isinstance(node, GetItemOp):
+            # A column of the source frame: df["col"]. Anything else (a chained
+            # getitem, a non-string key) is not a Col leaf.
+            return (isinstance(node.key, str) and bool(node.inputs)
+                    and node.inputs[0] is self.src)
+        if isinstance(node, StringMethodOp):
+            # A graph-fed arg isn't representable in StrExpr; such a call stays a leaf.
+            return (not any(isinstance(a, OperandRef) for a in (node.args or ()))
+                    and not any(isinstance(v, OperandRef)
+                                for v in (node.kwargs or {}).values()))
+        return False
+
+    def _producer_ops(self, node: Op) -> list[Op]:
+        """Return foldable operand producers for ``node``."""
+        if isinstance(node, BinOp):
+            return [node.inputs[r.k] for r in (node.left, node.right)
+                    if isinstance(r, OperandRef)]
+        if isinstance(node, UnaryOp):
+            if isinstance(node.operand, OperandRef):
+                return [node.inputs[node.operand.k]]
+            return []
+        if isinstance(node, StringMethodOp):
+            return [node.inputs[0]]
+        return []
+
+    # --- pass 1: discover the foldable cone -----------------------------------
+
+    def _discover(self, root: Op) -> tuple[dict[int, Op], dict[int, list[Op]]]:
+        """Collect the foldable subgraph rooted at ``root``."""
+        cone: dict[int, Op] = {}
+        child_ops: dict[int, list[Op]] = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if id(node) in cone or not self._is_foldable(node):
+                continue
+            cone[id(node)] = node
+            children = [p for p in self._producer_ops(node)
+                        if p is not self.src and self._is_foldable(p)]
+            child_ops[id(node)] = children
+            stack.extend(children)
+        return cone, child_ops
+
+    # --- pass 2: which cone nodes are fully private ---------------------------
+
+    def _absorbable(self, root: Op, root_consumer: Op,
+                    cone: dict[int, Op], child_ops: dict[int, list[Op]]) -> set[int]:
+        """Return foldable nodes with no external consumers."""
+        dropped: set[int] = set()
+        stack: list[Op] = []
+        for nid, node in cone.items():
+            for consumer in node.outputs:
+                internal = (id(consumer) in cone
+                            or (node is root and consumer is root_consumer))
+                if not internal:
+                    dropped.add(nid)
+                    stack.append(node)
+                    break
+        while stack:
+            node = stack.pop()
+            for child in child_ops[id(node)]:
+                if id(child) not in dropped:
+                    dropped.add(id(child))
+                    stack.append(child)
+        return {nid for nid in cone if nid not in dropped}
+
+    # --- pass 3: materialise the expression bottom-up -------------------------
+
+    def _build(self, root: Op, absorbable: set[int],
+               child_ops: dict[int, list[Op]]) -> ColumnExpr:
+        """Build the expression tree from absorbable nodes."""
+        if id(root) not in absorbable:
+            return self._leaf(root)
+        # Iterative post-order over the absorbed sub-DAG: an operand is built (and
+        # memoised) before the node that consumes it, so shared nodes fold once.
+        order: list[Op] = []
+        visited: set[int] = set()
+        stack = [(root, False)]
+        while stack:
+            node, expanded = stack.pop()
+            if expanded:
+                order.append(node)
+                continue
+            if id(node) in visited:
+                continue
+            visited.add(id(node))
+            stack.append((node, True))
+            for child in child_ops[id(node)]:
+                if id(child) in absorbable and id(child) not in visited:
+                    stack.append((child, False))
+        memo: dict[int, ColumnExpr] = {}
+        for node in order:
+            memo[id(node)] = self._make_expr(node, absorbable, memo)
+            self._absorb(node)
+        return memo[id(root)]
+
+    def _make_expr(self, node: Op, absorbable: set[int],
+                   memo: dict[int, ColumnExpr]) -> ColumnExpr:
+        if isinstance(node, BinOp):
+            return BinOpExpr(node.op,
+                             self._operand(node.left, node, absorbable, memo),
+                             self._operand(node.right, node, absorbable, memo))
+        if isinstance(node, UnaryOp):
+            return UnaryOpExpr(node.op,
+                               self._operand(node.operand, node, absorbable, memo))
+        if isinstance(node, GetItemOp):
+            return Col(node.key)
+        # StringMethodOp: the .str accessor was fused away in frame extraction, so the
+        # column is just inputs[0]; args/kwargs are literals (checked in _is_foldable).
+        operand = self._resolve(node.inputs[0], absorbable, memo)
+        return StrExpr(operand, node.method,
+                       tuple(node.args or ()), dict(node.kwargs or {}))
+
+    def _operand(self, operand, parent: Op, absorbable: set[int],
+                 memo: dict[int, ColumnExpr]) -> ColumnExpr:
+        if isinstance(operand, OperandRef):
+            return self._resolve(parent.inputs[operand.k], absorbable, memo)
+        return Const(operand)
+
+    def _resolve(self, node: Op, absorbable: set[int],
+                 memo: dict[int, ColumnExpr]) -> ColumnExpr:
+        """Return the folded expression or an ``OperandLeaf``."""
+        if id(node) in absorbable:
+            return memo[id(node)]
+        return self._leaf(node)
+
+    def _absorb(self, node: Op) -> None:
+        if id(node) not in self._absorbed_ids:
+            self._absorbed_ids.add(id(node))
+            self.absorbed.append(node)
+
+    def _leaf(self, node: Op) -> OperandLeaf:
+        if node is self.src:
+            return OperandLeaf(OperandRef(0))
+        idx = self._leaf_index.get(id(node))
+        if idx is None:
+            idx = len(self.leaf_ops)
+            self.leaf_ops.append(node)
+            self._leaf_index[id(node)] = idx
+        return OperandLeaf(OperandRef(1 + idx))
+
+
+def fold_column_expr(root_node: Op, src: Op, root_consumer: Op):
+    """Fold an operator subgraph into a column expression.
+
+    Returns ``(expr, absorbed_ops, leaf_ops)``.
+    """
+    folder = _Folder(src)
+    expr = folder.fold(root_node, root_consumer)
+    return expr, folder.absorbed, folder.leaf_ops

--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -1,4 +1,4 @@
-from stratum.optimizer.ir._ops import (OperandRef, OutputType, is_frame_like, BaseEstimatorOp, BinOp, CallOp, ChoiceOp, GetAttrOp, GetItemOp,
+from stratum.optimizer.ir._ops import (OperandRef, OutputType, is_frame_like, BaseEstimatorOp, BinOp, UnaryOp, CallOp, ChoiceOp, GetAttrOp, GetItemOp,
                                        MethodCallOp, Op, ValueOp)
 from pandas import DataFrame
 from polars import DataFrame as PolarsDataFrame
@@ -11,6 +11,9 @@ from stratum._config import FLAGS
 # `extract_dataframe_op` dispatcher below references them and so that existing
 # `from ..._dataframe_ops import X` import sites keep working (re-export hub).
 from stratum.optimizer.ir._source_ops import DataSourceOp, make_read_op
+from stratum.optimizer.ir._selection_ops import (
+    SelectionKind, SelectionOp, _SELECTION_METHODS, make_selection_op,
+    is_mask_selection, make_mask_selection_op)
 from stratum.optimizer.ir._aggregation_ops import (
     AggregateOp, GroupedDataframeOp, _AGG_METHODS, _AGG_FUNCS, _is_groupby_op,
     _is_aggregation, _extract_grouping, _extract_aggregations, make_aggregate_op)
@@ -67,7 +70,7 @@ def _getitem_output_type(op: GetItemOp) -> OutputType:
     return OutputType.FRAME
 
 
-def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
+def extract_dataframe_op(op: Op, root: Op, selection_op = True) -> tuple[Op, bool]:
     new_op = None
     # DataSource detection (directly passed dataframe)
     if len(op.inputs) == 0:
@@ -126,19 +129,29 @@ def extract_dataframe_op(op: Op, root: Op) -> tuple[Op, bool]:
                 op.replace_output_of_inputs(new_op)
             elif op.method_name in ["join", "merge"]:
                 new_op = make_join_op(op)
+            elif op.method_name in _SELECTION_METHODS:
+                new_op = make_selection_op(op)
 
         # GetAttr Fusing and conversion to GetAttrDataframeOp
         elif isinstance(op, GetAttrOp):
             new_op = make_frame_get_attr(new_op, op)
 
-        # Projection: a BinOp over tabular data -> same tabular kind as its operand
-        # (e.g. `df["a"] > 7` is a SERIES, `df + 1` is a FRAME).
-        elif isinstance(op, BinOp):
+        # Projection: BinOp/UnaryOp over tabular data -> same tabular kind as its
+        # operand (e.g. `df["a"] > 7` is a SERIES, `df + 1` is a FRAME, `~mask` is
+        # a SERIES).
+        elif isinstance(op, (BinOp, UnaryOp)):
             op.output_type = op.inputs[0].output_type
 
-        # GetItem: a column projection (SERIES) / sub-frame / row selection.
+        # GetItem: a mask selection df[bool_series] folds into a SelectionOp;
+        # otherwise it is a column projection (SERIES) / sub-frame / row selection.
         elif isinstance(op, GetItemOp):
-            op.output_type = _getitem_output_type(op)
+            if is_mask_selection(op):
+                op.is_filter = True
+                if selection_op:
+                    new_op = make_mask_selection_op(op)
+
+            if new_op is None:
+                op.output_type = _getitem_output_type(op)
 
         elif isinstance(op, BaseEstimatorOp):
             op.output_type = OutputType.FRAME

--- a/stratum/optimizer/ir/_ops.py
+++ b/stratum/optimizer/ir/_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from enum import Enum, auto
+from stratum._config import FLAGS
 from types import SimpleNamespace
 from typing import Callable
 
@@ -7,7 +8,7 @@ from joblib import parallel_config
 from sklearn import clone
 from sklearn.base import BaseEstimator
 from skrub._data_ops._choosing import Choice
-from skrub._data_ops._data_ops import DataOp, Apply, Value, CallMethod, Call, GetAttr, GetItem, BinOp as SkrubBinOp, Concat, Var, _wrap_estimator
+from skrub._data_ops._data_ops import DataOp, Apply, Value, CallMethod, Call, GetAttr, GetItem, BinOp as SkrubBinOp, UnaryOp as SkrubUnaryOp, Concat, Var, _wrap_estimator
 from skrub._utils import PassThrough
 from skrub.selectors._base import All
 from pandas import DataFrame
@@ -700,11 +701,12 @@ class GetAttrOp(Op):
             return getattr(inputs[0], self.attr_name)
 
 class GetItemOp(Op):
-    fields = ["key"]
+    fields = ["key", "is_filter"]
     
-    def __init__(self, key=None, name=None):
+    def __init__(self, key=None, name=None, is_filter=False):
         # key is either a constant or an OperandRef (when the key is graph-fed).
         self.key = key
+        self.is_filter = is_filter
         if name is None:
             name = str(key)
         super().__init__(name=name)
@@ -713,6 +715,8 @@ class GetItemOp(Op):
     def process(self, mode: str, inputs: list):
         # The container being indexed is the implicit primary operand (index 0).
         key = inputs[self.key.k] if isinstance(self.key, OperandRef) else self.key
+        if self.is_filter and FLAGS.force_polars:
+            return inputs[0].filter(key)
         return inputs[0][key]
 
 class BinOp(Op):
@@ -731,7 +735,20 @@ class BinOp(Op):
         right = inputs[self.right.k] if isinstance(self.right, OperandRef) else self.right
         return self.op(left, right)
 
-class SearchEvalOp(Op):    
+class UnaryOp(Op):
+    fields = ["op", "operand"]
+
+    def __init__(self, op: Callable, operand):
+        super().__init__(name=op.__name__.lstrip('__').rstrip('__'))
+        self.op = op
+        # operand is an OperandRef when graph-fed, otherwise a constant.
+        self.operand = operand
+
+    def process(self, mode: str, inputs: list):
+        operand = inputs[self.operand.k] if isinstance(self.operand, OperandRef) else self.operand
+        return self.op(operand)
+
+class SearchEvalOp(Op):
     def __init__(self, outcome_names: list[str], parent: Op = None):
         super().__init__()
         self.name = "evaluate gridsearch" 
@@ -870,6 +887,10 @@ def as_op(data_op: DataOp, ids_to_ops: dict, env: dict | None = None) -> Op:
         left = _bind_or_value(binder, impl.left)
         right = _bind_or_value(binder, impl.right)
         return_op = BinOp(op=impl.op, left=left, right=right)
+        return_op.inputs = binder.inputs
+    elif isinstance(impl, SkrubUnaryOp):
+        operand = _bind_or_value(binder, impl.operand)
+        return_op = UnaryOp(op=impl.op, operand=operand)
         return_op.inputs = binder.inputs
     elif isinstance(impl, Apply):
         if isinstance(impl.estimator, Choice):

--- a/stratum/optimizer/ir/_selection_ops.py
+++ b/stratum/optimizer/ir/_selection_ops.py
@@ -1,0 +1,152 @@
+from enum import Enum, auto
+from stratum.optimizer.ir._ops import (OperandRef, OutputType, GetItemOp,
+                                       MethodCallOp, Op, _resolve_args, _resolve_kwargs)
+from stratum.optimizer.ir._column_expr import ColumnExpr, fold_column_expr
+from stratum._config import FLAGS
+
+
+class SelectionKind(Enum):
+    """The kind of selection a :class:`SelectionOp` represents.
+
+    ``MASK``/``QUERY`` carry a predicate; the rest map 1:1 to a frame method.
+    """
+    MASK = auto()
+    QUERY = auto()
+    DROPNA = auto()
+    DROP_DUPLICATES = auto()
+    HEAD = auto()
+    TAIL = auto()
+    SAMPLE = auto()
+
+
+# Frame methods that are relational selections (restrict rows, keep columns).
+_SELECTION_METHODS = {
+    "dropna": SelectionKind.DROPNA,
+    "drop_duplicates": SelectionKind.DROP_DUPLICATES,
+    "head": SelectionKind.HEAD,
+    "tail": SelectionKind.TAIL,
+    "sample": SelectionKind.SAMPLE,
+}
+# Method name to call per backend for each method-based kind.
+_SELECTION_PANDAS_METHOD = {v: k for k, v in _SELECTION_METHODS.items()}
+_SELECTION_POLARS_METHOD = {
+    SelectionKind.DROPNA: "drop_nulls",
+    SelectionKind.DROP_DUPLICATES: "unique",
+    SelectionKind.HEAD: "head",
+    SelectionKind.TAIL: "tail",
+    SelectionKind.SAMPLE: "sample",
+}
+
+
+class SelectionOp(Op):
+    """A relational selection: restricts rows, keeps columns.
+
+    Method-based kinds use ``args``/``kwargs``; ``MASK``/``QUERY`` use ``predicate``.
+    """
+    fields = ["kind", "args", "kwargs", "predicate"]
+
+    def __init__(self, kind: SelectionKind, args: tuple | list = None, kwargs: dict = None,
+                 predicate: ColumnExpr = None, inputs: list[Op] = None, outputs: list[Op] = None):
+        super().__init__(name=kind.name.lower(), inputs=inputs, outputs=outputs)
+        if kwargs is not None:
+            self.check_kwargs(kwargs)
+        self.kind = kind
+        self.args = args
+        self.kwargs = kwargs
+        self.predicate = predicate
+        # A selection preserves its input's kind (a frame stays a frame, a series
+        # stays a series); extraction overrides this with the propagated type.
+        self.output_type = OutputType.FRAME
+
+    def __str__(self):
+        return f"SelectionOp({self.kind.name.lower()})"
+
+    def process(self, mode: str, inputs: list):
+        _obj = inputs[0]
+        if self.kind is SelectionKind.MASK:
+            if FLAGS.force_polars:
+                return _obj.filter(self.predicate.to_polars(inputs))
+            else:
+                if FLAGS.pandas_query:
+                    params = {}
+                    query = self.predicate.to_pandas_query(params)
+                    # None when the predicate isn't query-expressible (an OperandLeaf
+                    # or str accessor); fall through to boolean masking in that case.
+                    if query is not None:
+                        return _obj.query(query, local_dict=params)
+                predicate = self.predicate.to_pandas(_obj, inputs)
+                return _obj[predicate]
+        _args = _resolve_args(self.args, inputs) if self.args else []
+        _kwargs = _resolve_kwargs(self.kwargs, inputs) if self.kwargs else {}
+        table = _SELECTION_POLARS_METHOD if FLAGS.force_polars else _SELECTION_PANDAS_METHOD
+        method = table.get(self.kind)
+        if method is None:
+            raise NotImplementedError(
+                f"SelectionOp.process is not implemented for kind {self.kind.name}"
+                f"{' on the Polars backend' if FLAGS.force_polars else ''}.")
+        return getattr(_obj, method)(*_args, **_kwargs)
+
+
+def make_selection_op(op: MethodCallOp) -> SelectionOp:
+    """Convert a row-selection method call to a ``SelectionOp``."""
+    new_op = SelectionOp(kind=_SELECTION_METHODS[op.method_name],
+                         args=op.args, kwargs=op.kwargs,
+                         inputs=op.inputs, outputs=op.outputs)
+    new_op.output_type = op.inputs[0].output_type
+    op.replace_output_of_inputs(new_op)
+    return new_op
+
+
+# --- Mask selection: df[bool_series] -> SelectionOp(MASK, predicate) ----------
+
+def is_mask_selection(op: GetItemOp) -> bool:
+    """Return whether ``op`` is ``df[series]`` (e.g. a boolean mask).
+
+    Boolean-ness isn't tracked in the type lattice, so any series-keyed indexing
+    of a frame counts.
+
+    TODO: this misfires on a non-boolean series key (positional/label indexing,
+    ``df[int_or_label_series]``), which is not a filter -- the polars fast path
+    then calls ``.filter()`` on a non-boolean series. Gate on boolean dtype once
+    the type lattice tracks it.
+    """
+    if not isinstance(op.key, OperandRef):
+        return False
+    container = op.inputs[0]
+    key_op = op.inputs[op.key.k]
+    return (container.output_type is OutputType.FRAME
+            and key_op.output_type is OutputType.SERIES)
+
+
+def make_mask_selection_op(op: GetItemOp) -> SelectionOp:
+    """Fold ``df[mask]`` into a single ``SelectionOp(MASK, predicate)``.
+
+    Nodes private to the mask are absorbed into the predicate and detached; the
+    rest stay in the graph as ``OperandLeaf`` inputs (``inputs = [src, *leaf_ops]``).
+    """
+    src = op.inputs[0]
+    key_op = op.inputs[op.key.k]
+
+    predicate, absorbed, leaf_ops = fold_column_expr(key_op, src, root_consumer=op)
+
+    sel = SelectionOp(kind=SelectionKind.MASK, predicate=predicate,
+                      inputs=[src, *leaf_ops], outputs=list(op.outputs))
+    sel.output_type = OutputType.FRAME
+
+    # Detach every absorbed op from the graph (remove it from its inputs' output
+    # lists, then clear its edges).
+    for node in absorbed:
+        for inp in node.inputs:
+            inp.outputs = [o for o in inp.outputs if o is not node]
+        node.inputs = []
+        node.outputs = []
+
+    # The source and each kept leaf op now feed the selection in place of the mask
+    # GetItem / the detached expression nodes they used to feed. Other (external)
+    # consumers of a leaf op are left untouched. Downstream consumers of the mask
+    # are rewired by the caller via ``op.replace_input_of_outputs(sel)``.
+    for producer in (src, *leaf_ops):
+        producer.outputs = [o for o in producer.outputs if o is not op]
+        producer.add_output(sel)
+    op.inputs = []
+    return sel

--- a/stratum/optimizer/ir/_source_ops.py
+++ b/stratum/optimizer/ir/_source_ops.py
@@ -7,6 +7,13 @@ import polars as pl
 import numpy as np
 from stratum._config import FLAGS
 
+def rechunk_pl_frame(df, rows_per_chunk = 128_000):
+    n = len(df)
+    if rows_per_chunk <= 0 or n <= rows_per_chunk:
+        return df
+    parts = [df.slice(i, rows_per_chunk) for i in range(0, n, rows_per_chunk)]
+    return pl.concat(parts, rechunk=False)
+
 class DataSourceOp(Op):
     def __init__(self, data: DataFrame = None, file_path: str = None, _format: str = None,
                  read_args: tuple | list = None, read_kwargs: dict = None, is_X=False, is_y=False, outputs: list[Op] = None, inputs: list[Op] = None):
@@ -27,7 +34,8 @@ class DataSourceOp(Op):
     def process(self, mode: str, inputs: list):
         if self.data is not None:
             if FLAGS.force_polars:
-                return pl.DataFrame(self.data)
+                out = pl.DataFrame(self.data)
+                return rechunk_pl_frame(out) if FLAGS.rechunk else out
             else:
                 return self.data
         else:

--- a/stratum/tests/logical_optimizer/test_selection_ops.py
+++ b/stratum/tests/logical_optimizer/test_selection_ops.py
@@ -1,0 +1,533 @@
+import operator
+import unittest
+from contextlib import contextmanager
+
+import pytest
+import pandas as pd
+import polars as pl
+
+import stratum as st
+from stratum._config import FLAGS
+from stratum.optimizer._op_cse import _remap_refs
+from stratum.optimizer._optimize import OptConfig
+from stratum.optimizer.ir._dataframe_ops import SelectionKind, SelectionOp
+from stratum.optimizer.ir._ops import BinOp, GetItemOp, UnaryOp, Op, OperandRef, OutputType
+from stratum.optimizer.ir._column_expr import Col, Const, BinOpExpr, UnaryOpExpr, OperandLeaf, StrExpr
+from stratum.optimizer.ir._source_ops import rechunk_pl_frame
+from stratum.tests.logical_optimizer.test_dataframe_ops import (
+    optimize, run_op, force_polars)
+
+
+@contextmanager
+def pandas_query(enabled=True):
+    """Temporarily set `FLAGS.pandas_query`."""
+    orig = FLAGS.pandas_query
+    FLAGS.pandas_query = enabled
+    try:
+        yield
+    finally:
+        FLAGS.pandas_query = orig
+
+
+class TestSelectionExtraction(unittest.TestCase):
+    """Row-selection method calls are rewritten to SelectionOp."""
+
+    def setUp(self):
+        self.df = pd.DataFrame({"x": [1, 2, 2, None], "y": [4, 5, 5, 6]})
+
+    def _one_selection(self, ops):
+        sels = [o for o in ops if isinstance(o, SelectionOp)]
+        self.assertEqual(1, len(sels), "expected exactly one SelectionOp")
+        return sels[0]
+
+    def test_dropna_converts_to_selection(self):
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df).dropna(), OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.DROPNA, sel.kind)
+        self.assertIs(OutputType.FRAME, sel.output_type)
+
+    def test_drop_duplicates_converts_to_selection(self):
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df).drop_duplicates(), OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.DROP_DUPLICATES, sel.kind)
+
+    def test_head_converts_to_selection_with_args(self):
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df).head(2), OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.HEAD, sel.kind)
+        self.assertEqual((2,), tuple(sel.args))
+
+    def test_tail_converts_to_selection(self):
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df).tail(1), OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.TAIL, sel.kind)
+
+    def test_sample_converts_to_selection(self):
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df).sample(n=1, random_state=0),
+                     OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.SAMPLE, sel.kind)
+
+    def test_selection_on_column_is_series(self):
+        # df["x"].dropna() selects rows of a column -> the selection stays a SERIES.
+        sel = self._one_selection(
+            optimize(st.as_data_op(self.df)["x"].dropna(), OptConfig(dataframe_ops=True)))
+        self.assertIs(SelectionKind.DROPNA, sel.kind)
+        self.assertIs(OutputType.SERIES, sel.output_type)
+
+
+class TestSelectionProcess(unittest.TestCase):
+    """SelectionOp.process executes the underlying frame method per backend."""
+
+    def setUp(self):
+        self.df = pd.DataFrame({"x": [1, 2, 2, None], "y": [4, 5, 5, 6]})
+
+    def test_dropna_pandas(self):
+        op = SelectionOp(kind=SelectionKind.DROPNA)
+        result = run_op(op, self.df)
+        self.assertEqual(3, len(result))
+
+    def test_head_pandas(self):
+        op = SelectionOp(kind=SelectionKind.HEAD, args=(2,))
+        result = run_op(op, self.df)
+        self.assertEqual(2, len(result))
+
+    def test_drop_duplicates_pandas(self):
+        op = SelectionOp(kind=SelectionKind.DROP_DUPLICATES)
+        result = run_op(op, self.df.dropna())
+        self.assertEqual(2, len(result))
+
+    def test_dropna_polars_uses_drop_nulls(self):
+        with force_polars():
+            op = SelectionOp(kind=SelectionKind.DROPNA)
+            result = run_op(op, pl.DataFrame({"x": [1, None, 3]}))
+        self.assertEqual(2, len(result))
+
+    def test_query_kind_not_yet_executable(self):
+        # QUERY is produced by a later pass and has no method/predicate yet.
+        op = SelectionOp(kind=SelectionKind.QUERY)
+        with self.assertRaises(NotImplementedError):
+            run_op(op, self.df)
+
+    def test_mask_predicate_pandas(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt, Col("x"), Const(1)))
+        result = run_op(op, pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+        self.assertEqual([2, 3], result["x"].tolist())
+
+    def test_mask_predicate_boolop_pandas(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.and_,
+                                          BinOpExpr(operator.gt, Col("x"), Const(1)),
+                                          BinOpExpr(operator.lt, Col("y"), Const(6))))
+        result = run_op(op, pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+        self.assertEqual([2], result["x"].tolist())
+
+    def test_mask_predicate_polars(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt, Col("x"), Const(1)))
+        with force_polars():
+            result = run_op(op, pl.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+        self.assertEqual([2, 3], result["x"].to_list())
+
+    def test_mask_predicate_with_operand_leaf_pandas(self):
+        # OperandLeaf reads an external input (here input 1) at eval time.
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt, Col("x"),
+                                             OperandLeaf(OperandRef(1))))
+        result = run_op(op, pd.DataFrame({"x": [1, 2, 3]}), 1)
+        self.assertEqual([2, 3], result["x"].tolist())
+
+    def test_mask_str_predicate_pandas(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt,
+                                             StrExpr(Col("s"), "count", ("1",)), Const(0)))
+        result = run_op(op, pd.DataFrame({"s": ["a1", "bb", "c1"]}))
+        self.assertEqual(["a1", "c1"], result["s"].tolist())
+
+    def test_mask_str_predicate_polars(self):
+        # polars renames .str.count -> .str.count_matches (STR_POLARS_METHODS).
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt,
+                                             StrExpr(Col("s"), "count", ("1",)), Const(0)))
+        with force_polars():
+            result = run_op(op, pl.DataFrame({"s": ["a1", "bb", "c1"]}))
+        self.assertEqual(["a1", "c1"], result["s"].to_list())
+
+
+class TestMaskFolding(unittest.TestCase):
+    """df[bool_series] folds into a single SelectionOp(MASK, predicate)."""
+
+    def setUp(self):
+        self.df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6],
+                                "flag": [True, False, True]})
+
+    def _mask(self, ops):
+        masks = [o for o in ops if isinstance(o, SelectionOp)
+                 and o.kind is SelectionKind.MASK]
+        self.assertEqual(1, len(masks), "expected exactly one mask SelectionOp")
+        return masks[0]
+
+    def test_simple_comparison_folds(self):
+        data = st.as_data_op(self.df)
+        ops = optimize(data[data["x"] > 1], OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertEqual(BinOpExpr(operator.gt, Col("x"), Const(1)), sel.predicate)
+        self.assertIs(OutputType.FRAME, sel.output_type)
+        # the column GetItem and comparison BinOp are absorbed into the predicate
+        self.assertEqual([], [o for o in ops if isinstance(o, GetItemOp)])
+
+    def test_chained_comparison_folds_to_boolop(self):
+        data = st.as_data_op(self.df)
+        ops = optimize(data[(data["x"] > 1) & (data["y"] < 6)],
+                       OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertEqual(
+            BinOpExpr(operator.and_,
+                   BinOpExpr(operator.gt, Col("x"), Const(1)),
+                   BinOpExpr(operator.lt, Col("y"), Const(6))),
+            sel.predicate)
+
+    def test_boolean_column_mask_folds_to_col(self):
+        data = st.as_data_op(self.df)
+        ops = optimize(data[data["flag"]], OptConfig(dataframe_ops=True))
+        self.assertEqual(Col("flag"), self._mask(ops).predicate)
+
+    def test_negated_mask_folds_to_unaryop(self):
+        data = st.as_data_op(self.df)
+        ops = optimize(data[~(data["x"] > 1)], OptConfig(dataframe_ops=True))
+        self.assertEqual(
+            UnaryOpExpr(operator.invert, BinOpExpr(operator.gt, Col("x"), Const(1))),
+            self._mask(ops).predicate)
+
+    def test_arithmetic_in_mask_folds(self):
+        # df[df["x"] + df["y"] > 5] : arithmetic is still a BinOp during frame
+        # extraction (before the numeric pass), so it folds into the predicate.
+        data = st.as_data_op(self.df)
+        ops = optimize(data[data["x"] + data["y"] > 5], OptConfig(dataframe_ops=True))
+        self.assertEqual(
+            BinOpExpr(operator.gt,
+                      BinOpExpr(operator.add, Col("x"), Col("y")),
+                      Const(5)),
+            self._mask(ops).predicate)
+
+    def test_string_filter_in_mask_folds(self):
+        df = self.df.assign(s=["a1", "bb", "c1"])
+        data = st.as_data_op(df)
+        ops = optimize(data[data["s"].str.count("1") > 0], OptConfig(dataframe_ops=True))
+        self.assertEqual(
+            BinOpExpr(operator.gt, StrExpr(Col("s"), "count", ("1",)), Const(0)),
+            self._mask(ops).predicate)
+
+    def test_string_filter_in_mask_folds2(self):
+        df = self.df.assign(s=["a1", "bb", "c1"])
+        data = st.as_data_op(df)
+        col_s_transformed = data["s"].apply(lambda s: "row_" + s)
+        ops = optimize(data[col_s_transformed.str.count("1") > 0], OptConfig(dataframe_ops=True))
+        self.assertEqual(
+            BinOpExpr(operator.gt, StrExpr(OperandLeaf(OperandRef(1)), "count", ("1",)), Const(0)),
+            self._mask(ops).predicate)
+
+    def test_external_operand_folds_to_leaf(self):
+        # df[df["x"] > thr] where `thr` is another data-op: the column folds to Col,
+        # the external operand cannot, so it becomes an OperandLeaf input.
+        data = st.as_data_op(self.df)
+        thr = st.as_data_op(1)
+        ops = optimize(data[data["x"] > thr], OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertEqual(
+            BinOpExpr(operator.gt, Col("x"), OperandLeaf(OperandRef(1))),
+            sel.predicate)
+        self.assertEqual(2, len(sel.inputs))  # [src, thr]
+
+    def test_duplicate_masks_dedup_after_cse(self):
+        # Two independently-built identical masks fold to two SelectionOps, which
+        # CSE (now running after extraction) merges back into one.
+        data = st.as_data_op(self.df)
+        root = data[data["x"] > 1].skb.concat([data[data["x"] > 1]], axis=0)
+        ops = optimize(root, OptConfig(dataframe_ops=True))
+        masks = [o for o in ops if isinstance(o, SelectionOp)
+                 and o.kind is SelectionKind.MASK]
+        self.assertEqual(1, len(masks))
+
+    def test_shared_mask_folds_with_operand_leaf(self):
+        # The comparison series feeds both the selection and an assign, so it cannot
+        # be absorbed: it stays in the graph and the predicate references it via an
+        # OperandLeaf (the selection takes it as an input after the source frame).
+        data = st.as_data_op(self.df)
+        mask = data["x"] > 1
+        result = data[mask].assign(keep=mask)
+        ops = optimize(result, OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertIsInstance(sel.predicate, OperandLeaf)
+        self.assertEqual(2, len(sel.inputs))            # [src, shared comparison]
+        self.assertTrue(any(isinstance(o, BinOp) for o in ops))  # comparison kept
+
+    def test_get_item_multiple_consumers(self):
+        # The shared column df["x"] feeds two comparisons, but both live inside the
+        # mask -- every consumer of the column is absorbed -- so the column folds too
+        # (appearing as Col("x") in both branches) rather than becoming a leaf.
+        data = st.as_data_op(self.df)
+        col = data["x"]
+        mask = (col > 1) & (col < 4)
+        ops = optimize(data[mask], OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertEqual(
+            BinOpExpr(operator.and_,
+                      BinOpExpr(operator.gt, Col("x"), Const(1)),
+                      BinOpExpr(operator.lt, Col("x"), Const(4))),
+            sel.predicate)
+        self.assertEqual(1, len(sel.inputs))  # only the source frame; nothing kept
+        self.assertEqual([], [o for o in ops if isinstance(o, (GetItemOp, BinOp))])
+
+    def test_partially_shared_subgraph_folds_internal_keeps_external(self):
+        # df[(c > 1) & (c < 4)] but the inner column c = df["x"] also feeds an assign.
+        # c has a consumer outside the mask, so it stays as an OperandLeaf; the two
+        # comparisons are private to the mask and still fold around that leaf.
+        data = st.as_data_op(self.df)
+        col = data["x"]
+        mask = (col > 1) & (col < 4)
+        result = data[mask].assign(keep=col)
+        ops = optimize(result, OptConfig(dataframe_ops=True))
+        sel = self._mask(ops)
+        self.assertEqual(
+            BinOpExpr(operator.and_,
+                      BinOpExpr(operator.gt, OperandLeaf(OperandRef(1)), Const(1)),
+                      BinOpExpr(operator.lt, OperandLeaf(OperandRef(1)), Const(4))),
+            sel.predicate)
+        self.assertEqual(2, len(sel.inputs))  # [src, shared column]
+        self.assertTrue(any(isinstance(o, GetItemOp) for o in ops))  # column kept
+
+
+class TestColumnExprOperandRefs(unittest.TestCase):
+    """The ref-traversal contract validate_dag / CSE rely on to descend into exprs."""
+
+    def test_iter_operand_refs(self):
+        expr = BinOpExpr(operator.and_,
+                         OperandLeaf(OperandRef(1)),
+                         UnaryOpExpr(operator.invert, OperandLeaf(OperandRef(3))))
+        self.assertEqual([1, 3], [r.k for r in expr.iter_operand_refs()])
+
+    def test_iter_operand_refs_none_for_pure_expr(self):
+        expr = BinOpExpr(operator.gt, Col("x"), Const(1))
+        self.assertEqual([], list(expr.iter_operand_refs()))
+
+    def test_remap_operand_refs_rebuilds_tree(self):
+        expr = BinOpExpr(operator.gt, Col("x"), OperandLeaf(OperandRef(2)))
+        remapped = expr.remap_operand_refs({2: 1})
+        self.assertEqual(
+            BinOpExpr(operator.gt, Col("x"), OperandLeaf(OperandRef(1))), remapped)
+
+class TestSelectionStructureKey(unittest.TestCase):
+    """SelectionOp exposes a structural key so CSE can dedup identical selections."""
+
+    def test_equal_for_identical_selections(self):
+        src = Op()
+        a = SelectionOp(kind=SelectionKind.HEAD, args=(2,), inputs=[src])
+        b = SelectionOp(kind=SelectionKind.HEAD, args=(2,), inputs=[src])
+        self.assertEqual(a.structure_key(), b.structure_key())
+
+    def test_differs_on_args(self):
+        src = Op()
+        a = SelectionOp(kind=SelectionKind.HEAD, args=(2,), inputs=[src])
+        b = SelectionOp(kind=SelectionKind.HEAD, args=(3,), inputs=[src])
+        self.assertNotEqual(a.structure_key(), b.structure_key())
+
+    def test_differs_on_kind(self):
+        src = Op()
+        a = SelectionOp(kind=SelectionKind.HEAD, args=(2,), inputs=[src])
+        b = SelectionOp(kind=SelectionKind.TAIL, args=(2,), inputs=[src])
+        self.assertNotEqual(a.structure_key(), b.structure_key())
+
+
+class TestUnaryPredicateProcess(unittest.TestCase):
+    """A UnaryOpExpr predicate (e.g. ~mask) evaluates on both backends."""
+
+    def setUp(self):
+        self.predicate = UnaryOpExpr(operator.invert,
+                                     BinOpExpr(operator.gt, Col("x"), Const(1)))
+
+    def test_unary_mask_pandas(self):
+        op = SelectionOp(kind=SelectionKind.MASK, predicate=self.predicate)
+        result = run_op(op, pd.DataFrame({"x": [1, 2, 3]}))
+        self.assertEqual([1], result["x"].tolist())
+
+    def test_unary_mask_polars(self):
+        op = SelectionOp(kind=SelectionKind.MASK, predicate=self.predicate)
+        with force_polars():
+            result = run_op(op, pl.DataFrame({"x": [1, 2, 3]}))
+        self.assertEqual([1], result["x"].to_list())
+
+
+class TestPandasQuery(unittest.TestCase):
+    """With FLAGS.pandas_query, an expressible MASK runs through DataFrame.query()."""
+
+    def setUp(self):
+        self.df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    def test_query_simple_comparison(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt, Col("x"), Const(1)))
+        with pandas_query():
+            result = run_op(op, self.df)
+        self.assertEqual([2, 3], result["x"].tolist())
+
+    def test_query_boolop(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.and_,
+                                             BinOpExpr(operator.gt, Col("x"), Const(1)),
+                                             BinOpExpr(operator.lt, Col("y"), Const(6))))
+        with pandas_query():
+            result = run_op(op, self.df)
+        self.assertEqual([2], result["x"].tolist())
+
+    def test_query_unaryop(self):
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=UnaryOpExpr(operator.invert,
+                                               BinOpExpr(operator.gt, Col("x"), Const(1))))
+        with pandas_query():
+            result = run_op(op, self.df)
+        self.assertEqual([1], result["x"].tolist())
+
+    def test_query_falls_back_on_operand_leaf(self):
+        # An OperandLeaf isn't query-expressible (to_pandas_query -> None), so the
+        # predicate as a whole yields None and process falls back to boolean masking.
+        op = SelectionOp(kind=SelectionKind.MASK,
+                         predicate=BinOpExpr(operator.gt, Col("x"),
+                                             OperandLeaf(OperandRef(1))))
+        with pandas_query():
+            result = run_op(op, self.df, 1)
+        self.assertEqual([2, 3], result["x"].tolist())
+
+
+class TestColumnExprQueryStrings(unittest.TestCase):
+    """to_pandas_query builds a query string, binding literals into params."""
+
+    def test_col_backticks_name(self):
+        self.assertEqual("`x`", Col("x").to_pandas_query({}))
+
+    def test_const_binds_param(self):
+        params = {}
+        self.assertEqual("@p0", Const(7).to_pandas_query(params))
+        self.assertEqual({"p0": 7}, params)
+
+    def test_binop_unsupported_op_returns_none(self):
+        # matmul isn't in BINARY_SYMBOLS, so it isn't query-expressible.
+        expr = BinOpExpr(operator.matmul, Col("x"), Const(1))
+        self.assertIsNone(expr.to_pandas_query({}))
+
+    def test_unaryop_unsupported_op_returns_none(self):
+        # abs isn't in UNARY_SYMBOLS.
+        self.assertIsNone(UnaryOpExpr(operator.abs, Col("x")).to_pandas_query({}))
+
+    def test_operand_leaf_and_str_not_query_expressible(self):
+        self.assertIsNone(OperandLeaf(OperandRef(1)).to_pandas_query({}))
+        self.assertIsNone(StrExpr(Col("s"), "count", ("1",)).to_pandas_query({}))
+
+    def test_unaryop_over_non_expressible_operand_returns_none(self):
+        # A supported unary op whose operand isn't query-expressible -> None.
+        expr = UnaryOpExpr(operator.invert, OperandLeaf(OperandRef(1)))
+        self.assertIsNone(expr.to_pandas_query({}))
+
+
+class TestColumnExprMisc(unittest.TestCase):
+    """Assorted ColumnExpr node behaviour."""
+
+    def test_const_unhashable_value_key(self):
+        # An unhashable literal falls back to an identity-based key.
+        value = [1, 2]
+        c = Const(value)
+        self.assertEqual(("__id__", id(value)), c._key())
+        self.assertEqual(c, Const(value))  # same object -> equal
+        hash(c)  # does not raise
+
+    def test_remap_unaryop_expr(self):
+        expr = UnaryOpExpr(operator.invert, OperandLeaf(OperandRef(2)))
+        self.assertEqual(
+            UnaryOpExpr(operator.invert, OperandLeaf(OperandRef(1))),
+            expr.remap_operand_refs({2: 1}))
+
+    def test_remap_str_expr(self):
+        expr = StrExpr(OperandLeaf(OperandRef(2)), "count", ("1",))
+        self.assertEqual(
+            StrExpr(OperandLeaf(OperandRef(1)), "count", ("1",)),
+            expr.remap_operand_refs({2: 1}))
+
+    def test_remap_refs_descends_into_column_expr(self):
+        # _op_cse._remap_refs recognises a ColumnExpr and rebuilds it with remapped refs.
+        expr = BinOpExpr(operator.gt, Col("x"), OperandLeaf(OperandRef(2)))
+        self.assertEqual(
+            BinOpExpr(operator.gt, Col("x"), OperandLeaf(OperandRef(1))),
+            _remap_refs(expr, {2: 1}))
+
+
+class TestUnaryOpProcess(unittest.TestCase):
+    """UnaryOp.process applies the callable to its (graph-fed) operand."""
+
+    def test_invert_series(self):
+        op = UnaryOp(operator.invert, OperandRef(0))
+        result = run_op(op, pd.Series([True, False, True]))
+        self.assertEqual([False, True, False], result.tolist())
+
+
+class TestGetItemFilterFastPath(unittest.TestCase):
+    """A boolean-mask GetItem uses polars .filter() when is_filter is set."""
+
+    def test_filter_polars(self):
+        op = GetItemOp(key=OperandRef(1), is_filter=True)
+        with force_polars():
+            result = run_op(op, pl.DataFrame({"x": [1, 2, 3]}),
+                            pl.Series([True, False, True]))
+        self.assertEqual([1, 3], result["x"].to_list())
+
+
+class TestRechunkPlFrame(unittest.TestCase):
+    """rechunk_pl_frame slices a frame into fixed-size chunks."""
+
+    def test_splits_into_chunks(self):
+        df = pl.DataFrame({"x": list(range(5))})
+        out = rechunk_pl_frame(df, rows_per_chunk=2)
+        self.assertEqual(5, len(out))
+        self.assertEqual(list(range(5)), out["x"].to_list())
+
+    def test_no_split_when_below_threshold(self):
+        df = pl.DataFrame({"x": [1, 2]})
+        self.assertIs(df, rechunk_pl_frame(df, rows_per_chunk=10))
+
+
+"""End-to-end tests: A folded mask runs through the full optimize + execute path."""
+@pytest.fixture
+def df():
+    return pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [10, 20, 30, 40, 50]})
+
+@pytest.fixture(params=[False, True])
+def polars(request):
+    with force_polars(request.param):
+        yield request.param
+
+def test_mask_pipeline_evaluates(df, polars):
+        pred = st.as_data_op(df)
+        pred = pred[pred["x"] > 2]
+        result = st._api.evaluate(pred)
+        assert all(result["x"] > 2)
+
+def test_string_filter_pipeline_evaluates(df, polars):
+    data = st.as_data_op(df)
+    data = data.assign(s=["a1", "bb", "c2", "", "d1"])
+    col_s_transformed = data["s"].apply(lambda s: "row_" + s)
+    out = data[col_s_transformed.str.count("1") > 0]
+    result = st._api.evaluate(out)
+    assert len(result["x"]) == 2
+
+def test_complex_filter(df, polars):
+    with force_polars(polars):
+        data = st.as_data_op(df)
+        data = data.assign(s=["a1", "bb", "c2", "", "d1"])
+        col_s_transformed = data["s"].apply(lambda s: "row_" + s)
+        predicate = (col_s_transformed.str.count("1") > 0) | ((data["x"] > 2) & (data["x"] <= 4)) | (data["y"] == 50)
+        out = data[predicate]
+        result = st._api.evaluate(out)
+        assert len(result["x"]) == 4
+
+if __name__ == "__main__":
+    unittest.main()

--- a/stratum/tests/logical_optimizer/test_type_inference.py
+++ b/stratum/tests/logical_optimizer/test_type_inference.py
@@ -7,7 +7,7 @@ import stratum as st
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer.ir._dataframe_ops import (
     ApplyUDFOp, DataSourceOp, DatetimeConversionOp, GetAttrProjectionOp)
-from stratum.optimizer.ir._ops import GetItemOp, OutputType, BinOp, OperandRef
+from stratum.optimizer.ir._ops import GetItemOp, OutputType, BinOp
 from stratum.tests.logical_optimizer.test_dataframe_ops import optimize, npy_file
 
 
@@ -49,18 +49,6 @@ class TestOutputTypeInference(unittest.TestCase):
         self.assertEqual(1, len(binops))
         self.assertIs(OutputType.SERIES, binops[0].output_type)
 
-    def test_mask_selection_is_frame(self):
-        # df[df["x"] > 1] : the trailing GetItem is keyed by a (boolean) series and
-        # selects rows -> FRAME. The column GetItem feeding the mask is a SERIES.
-        data = st.as_data_op(self.df)
-        ops = optimize(data[data["x"] > 1], OptConfig(dataframe_ops=True))
-        getitems = self._find(ops, GetItemOp)
-        col_gets = [g for g in getitems if g.output_type is OutputType.SERIES]
-        row_sel = [g for g in getitems if g.output_type is OutputType.FRAME]
-        self.assertEqual(1, len(col_gets))   # df["x"]
-        self.assertEqual(1, len(row_sel))    # df[mask]
-        self.assertIsInstance(row_sel[0].key, OperandRef)
-
     def test_npy_source_is_matrix(self):
         with npy_file(np.array([1, 2, 3])) as path:
             data = st.as_data_op(path).skb.apply_func(np.load)
@@ -74,16 +62,6 @@ class TestOutputTypeInference(unittest.TestCase):
         # (Arithmetic BinOps are consumed by the numeric path; comparisons stay.)
         ops = optimize(st.as_data_op(self.df) > 1, OptConfig(dataframe_ops=True))
         self.assertIs(OutputType.FRAME, self._one(ops, BinOp).output_type)
-
-    def test_chained_mask_comparison_is_series(self):
-        # (df["x"] > 1) & (df["y"] < 6) : both comparisons and their logical-and
-        # are columns -> every BinOp is a SERIES (the mask fed to df[...]).
-        data = st.as_data_op(self.df)
-        ops = optimize(data[(data["x"] > 1) & (data["y"] < 6)],
-                       OptConfig(dataframe_ops=True))
-        binops = self._find(ops, BinOp)
-        self.assertEqual(3, len(binops))  # >, <, &
-        self.assertTrue(all(b.output_type is OutputType.SERIES for b in binops))
 
     def test_datetime_conversion_on_column_is_series(self):
         # X["datetime"] is a SERIES; pd.to_datetime over it produces a


### PR DESCRIPTION
Add SelectionOp for relational selections -- operations that restrict rows while keeping columns intact -- in two flavors:

- Method-based kinds (DROPNA, DROP_DUPLICATES, HEAD, TAIL, SAMPLE): the five row-selection frame methods convert via make_selection_op and dispatch to the matching backend method (pandas names, with polars drop_nulls/unique).
- Predicate-based kinds (MASK/QUERY): df[bool_series] folds the predicate subgraph into a backend-agnostic ColumnExpr tree (_column_expr.py). Nodes private to the predicate are absorbed and detached; shared nodes / values from other frames stay in the graph behind an OperandLeaf. On pandas, an expressible MASK can run through DataFrame.query() (pandas_query flag, numexpr-backed); otherwise it falls back to boolean masking.

Supporting changes:
- _ops.py: add UnaryOp and GetItemOp.is_filter (polars filter fast-path).
- _optimize.py: run Op-IR CSE *after* frame extraction so it can dedup whole specialized ops; running it earlier gave a mask's shared sub-expressions multiple consumers and blocked folding. Thread FLAGS.make_selection_op.
- _op_cse.py / _op_utils.py: descend into ColumnExpr trees for operand-ref remapping and validation.
- _config.py: add pandas_query / make_selection_op / rechunk flags; drop the unused _env_str helper and simplify get_config to vars(FLAGS).copy().
- StringMethodOp folds into a StrExpr inside predicates.
- Add test_selection_ops.py; drop the now-obsolete mask test from test_type_inference.

### Micro Benchmark

to support cuDF I had to downgrade pandas to 2.3.3, which slows down stratum (we need to investigate this). 

<img width="901" height="230" alt="Screenshot 2026-06-30 at 15 33 46" src="https://github.com/user-attachments/assets/9484f7e7-d2f3-4b3e-91f0-59e3390d2a6f" />

With pandas 3.0.2 we get these numbers:
(Note: that these numbers are from a different machine)
<img width="936" height="255" alt="Screenshot 2026-06-25 at 15 54 38" src="https://github.com/user-attachments/assets/10478bcf-ba76-46e4-8855-4859f50aa2cd" />

