### PR TITLE
[Rewrite] abs(abs(x)) -> abs(x)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -6,6 +6,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_log1p_expm1,
     eliminate_sqrt_square,
     eliminate_identity_operation,
+    eliminate_abs_abs
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -22,6 +23,7 @@ class AlgebraicRewritesConfig:
     log1p_expm1: bool = True
     expm1_log1p: bool = True
     identity_op: bool = True
+    abs_abs: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -31,6 +33,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_log_exp(root)
     if config.exp_log:
         root = eliminate_exp_log(root)
+    if config.abs_abs:
+        root = eliminate_abs_abs(root)
     if config.sqrt_square:
         root = eliminate_sqrt_square(root)
     if config.log1p_expm1:

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -111,3 +111,8 @@ eliminate_identity_operation = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 1),
     eliminate_single_op_chain_root_safe,
 )
+
+eliminate_abs_abs = rewrite_pass(
+    match_two_op_chain(NumericOp, NumericOpType.ABS, NumericOpType.ABS),
+    _replace_with_abs,
+)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -264,3 +264,30 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(root)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].process("fit", [out[0].value]), 2)
+
+    def test_abs_abs_collapses_to_single_abs(self):
+        df = st.as_data_op(-3)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.abs)
+        out, *_ = optimize(t2)
+
+        self.assertEqual(len(out), 2)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.ABS)
+
+    def test_abs_abs_disabled(self):
+        df = st.as_data_op(-3)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.abs)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+
+    def test_single_abs_untouched(self):
+        df = st.as_data_op(-3)
+        t1 = df.skb.apply_func(np.abs)
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -275,19 +275,45 @@ class TestCSE(unittest.TestCase):
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ABS)
 
+    def test_single_abs_untouched(self):
+        df = st.as_data_op(-3)
+        t1 = df.skb.apply_func(np.abs)
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_abs_abs_with_trailing_op(self):
+        df = st.as_data_op(-3)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.abs)
+        t3 = t2.skb.apply_func(np.log1p)
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_abs_sqrt(self):
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.sqrt)
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+
     def test_abs_abs_disabled(self):
         df = st.as_data_op(-3)
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.abs)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False)
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
-    def test_single_abs_untouched(self):
-        df = st.as_data_op(-3)
-        t1 = df.skb.apply_func(np.abs)
-        out, *_ = optimize(t1)
-        self.assertEqual(len(out), 2)
+    def test_disable_abs_abs_does_not_affect_log_exp(self):
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False)
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)


### PR DESCRIPTION
1. Add a rewrite rule that simplifies nested abs: abs(abs(x)) becomes abs(x). 
2. Add this rewrite to AlgebraicRewritesConfig under the flag abs_abs (enabled by default).
3. Add tests to check that:
- abs(abs(x)) collapses to abs(x).
- The rule does nothing when the abs_abs flag is turned off.
- A single abs(x) is left unchanged.
- The rule also works when abs(abs(x)) appears as part of a larger expression (not just at the root).
- Mixed chains like abs(sqrt(x)) are not rewritten.
- Turning off abs_abs does not affect other rewrites, such as eliminating log/exp.