### PR TITLE
[Rewrite] eliminate add-zero identity (x+0 -> x, 0+x -> x)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -6,7 +6,8 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_log1p_expm1,
     eliminate_sqrt_square,
     eliminate_identity_operation,
-    eliminate_abs_abs
+    eliminate_abs_abs,
+    eliminate_add_zero
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -24,6 +25,7 @@ class AlgebraicRewritesConfig:
     expm1_log1p: bool = True
     identity_op: bool = True
     abs_abs: bool = True
+    add_zero: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -43,5 +45,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_expm1_log1p(root)
     if config.identity_op:
         root = eliminate_identity_operation(root)
+    if config.add_zero:
+        root = eliminate_add_zero(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -116,3 +116,8 @@ eliminate_abs_abs = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.ABS, NumericOpType.ABS),
     _replace_with_abs,
 )
+
+eliminate_add_zero = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.ADD, 0),
+    eliminate_single_op_chain_root_safe,
+)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -317,3 +317,62 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
+
+    def test_eliminate_add_zero(self):
+        df = st.as_data_op(2)
+        t1 = df + 0
+        t2 = t1 + 3
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 5)
+
+    def test_eliminate_zero_add(self):
+        df = st.as_data_op(2)
+        t1 = 0 + df
+        t2 = t1 + 3
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 5)
+
+    def test_eliminate_add_zero_root_safe(self):
+        df = st.as_data_op(2)
+        root = df + 0
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].process("fit", [out[0].value]), 2)
+
+    def test_disable_eliminate_add_zero(self):
+        df = st.as_data_op(2)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(add_zero=False),
+        )
+        t1 = 0 + df
+        t2 = t1 + 3
+        out, *_ = optimize(t2, config=config)
+        print(out)
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 2)
+
+    def test_no_rewrite_add_nonzero(self):
+        df = st.as_data_op(2)
+        t1 = df + 1
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 3)
+
+    def test_add_zero_with_trailing_op(self):
+        df = st.as_data_op(2)
+        t1 = df + 0
+        t2 = t1 + 3
+        t3 = t2.skb.apply_func(np.log1p)
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 3)
+
+    def test_add_zero_and_identity_operation(self):
+        df = st.as_data_op(2)
+        t1 = df * 1
+        t2 = t1 + 0
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 2)


### PR DESCRIPTION
- Add algebraic rewrite removing additive-identity ops: x+0 and 0+x both reduce to x. Matches NumericOp(ADD) with constant 0.
- Reuses match_identity_operation + eliminate_single_op_chain_root_safe.
- Tests: both operand orders, root-safe, disabled flag, and with other ops.  