### PR TITLE
[Rewrite] Optimize exp(x) - 1 to expm1(x)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -33,6 +33,10 @@ class AlgebraicRewritesConfig:
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
     """Run all enabled algebraic rewrites, one pass per rewrite."""
     start = start_time()
+    if config.identity_op:
+        root = eliminate_identity_operation(root)
+    if config.add_zero:
+        root = eliminate_add_zero(root)
     if config.log_exp:
         root = eliminate_log_exp(root)
     if config.exp_log:
@@ -41,15 +45,11 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_abs_abs(root)
     if config.sqrt_square:
         root = eliminate_sqrt_square(root)
+    if config.exp_minus_one:
+        root = eliminate_exp_minus_one(root)
     if config.log1p_expm1:
         root = eliminate_log1p_expm1(root)
     if config.expm1_log1p:
         root = eliminate_expm1_log1p(root)
-    if config.identity_op:
-        root = eliminate_identity_operation(root)
-    if config.add_zero:
-        root = eliminate_add_zero(root)
-    if config.exp_minus_one:
-        root = eliminate_exp_minus_one(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -7,7 +7,8 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_sqrt_square,
     eliminate_identity_operation,
     eliminate_abs_abs,
-    eliminate_add_zero
+    eliminate_add_zero,
+    eliminate_exp_minus_one
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -26,6 +27,7 @@ class AlgebraicRewritesConfig:
     identity_op: bool = True
     abs_abs: bool = True
     add_zero: bool = True
+    exp_minus_one: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -47,5 +49,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_identity_operation(root)
     if config.add_zero:
         root = eliminate_add_zero(root)
+    if config.exp_minus_one:
+        root = eliminate_exp_minus_one(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -78,6 +78,16 @@ def make_replace_two_op_chain_root_safe(make_replacement):
     return action
 
 
+def match_exp_minus_one(op):
+    """Match exp(x) - 1"""
+    if isinstance(op, NumericOp) and op.type is NumericOpType.EXP and len(op.outputs) == 1:
+        op2 = op.outputs[0]
+        if (isinstance(op2, NumericOp) and op2.type is NumericOpType.SUBTRACT
+                and op2.opt_operand is None and op2.constant == 1 and not op2.reversed):
+            return (op, op2)
+    return None
+
+
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -121,3 +131,9 @@ eliminate_add_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.ADD, 0),
     eliminate_single_op_chain_root_safe,
 )
+
+_replace_with_expm1 = make_replace_two_op_chain_root_safe(
+    lambda: NumericOp(inputs=[], outputs=[], type=NumericOpType.EXPM1)
+)
+
+eliminate_exp_minus_one = rewrite_pass(match_exp_minus_one, _replace_with_expm1)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -376,3 +376,54 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 2)
+
+    def test_exp_minus_one(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = t1 - 1
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)                                  # source + expm1 (was 3)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.EXPM1)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 0)     # expm1(0) == 0
+
+    def test_no_rewrite_one_minus_exp(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = 1 - t1                                                     # reversed: NOT expm1
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.EXP)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 1)
+
+    def test_no_rewrite_exp_minus_two(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = t1 - 2                                                     # constant != 1
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 3)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.EXP)
+
+    def test_disable_exp_minus_one(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = t1 - 1
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(exp_minus_one=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.EXP)
+    def test_exp_minus_one_and_identity_operation(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = t1 + 0
+        t3 = t2 - 1
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 2)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.EXPM1)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -418,6 +418,7 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(len(out), 3)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXP)
+
     def test_exp_minus_one_and_identity_operation(self):
         df = st.as_data_op(0)
         t1 = df.skb.apply_func(np.exp)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -428,3 +428,22 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXPM1)
+
+    def test_log1p_of_exp_minus_one_reduces_to_input(self):
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+        t2 = t1 - 1
+        t3 = t2.skb.apply_func(np.log1p)  # log1p(exp(df)-1)
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 1)  # -> log1p(expm1(df)) -> df
+        self.assertEqual(out[0].value, 0)
+
+    def test_exp_log_minus_one_not_fused(self):
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+        t3 = t2 - 1  # exp(log(x)) - 1
+        out, *_ = optimize(t3)
+        self.assertEqual(len(out), 2)  # exp/log cancel -> x - 1
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.SUBTRACT)


### PR DESCRIPTION
- Add an exp_minus_one rewrite rule to fuse exp(x) - 1 into expm1(x).
- Enable the new rule by default.
- Add strict guards to prevent matching incorrect constants or reversed operations.
- Add tests for edge cases, disabled configuration, and rewrite-ordering sensitivity.