### PR TITLE
[OperatorSelection] Add physical implementation registries (#125)

### DIFF
--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -70,7 +70,8 @@ buffer_pool_memory_budget: int = 0
     -----------
 
         rust_backend: bool, default false
-            Enable/disable rust backend. It is a feature flag for the Rust backend.
+            Legacy feature flag for Rust execution. The physical
+            operator selector should choose Rust through the registry instead.
 
         num_threads: int >= 0 (0 lets backend decide), default 0
             Set the number of threads for the multithreaded rust operations.
@@ -79,8 +80,8 @@ buffer_pool_memory_budget: int = 0
             Print the timing in standard output.
 
         allow_patch: bool, default true
-            Allows disabling runtime backend swapping in sensitive contexts. This is a soft
-            kill-switch for disabling all non-sklearn backends, even if their flags are set.
+            Legacy kill-switch for direct adapter Rust execution. It does not
+            control physical operator registration.
 
         scheduler: bool, default false
             Enable/disable stratum's scheduler instead of skrub's make_grid_search.
@@ -121,7 +122,7 @@ buffer_pool_memory_budget: int = 0
         os.environ["SKRUB_RUST_DEBUG_TIMING"] = "1" if FLAGS.debug_timing else "0"
     if allow_patch is not None:
         FLAGS.allow_patch = bool(allow_patch)
-        os.environ["SKRUB_RUST_ALLOW_MONKEYPATCH"] = "1" if FLAGS.allow_patch else "0"
+        os.environ["SKRUB_RUST_ALLOW_PATCH"] = "1" if FLAGS.allow_patch else "0"
     if stats is not None:
         FLAGS.stats = bool(stats)
     if stats_top_k is not None:

--- a/stratum/adapters/one_hot_encoder.py
+++ b/stratum/adapters/one_hot_encoder.py
@@ -12,6 +12,29 @@ from .._rust_backend import _to_list
 # File-internal config flags
 _DEBUG_INFO = False
 
+
+def _rust_runtime_available() -> bool:
+    return (
+        rb.HAVE_RUST
+        and getattr(rb, "ohe_transform", None) is not None
+        and getattr(rb, "csr_to_dense", None) is not None
+    )
+
+
+def supports_rust_one_hot_encoder(estimator) -> tuple[bool, str]:
+    if not isinstance(estimator, _SKOneHot):
+        return False, "estimator is not a sklearn OneHotEncoder"
+    if not _rust_runtime_available():
+        return False, "Rust OneHotEncoder runtime is not available"
+    if getattr(estimator, "drop", None) != "if_binary":
+        return False, "drop must be 'if_binary'"
+    if np.dtype(getattr(estimator, "dtype", np.float64)) != np.dtype(np.float32):
+        return False, "dtype must be float32"
+    if getattr(estimator, "handle_unknown", None) != "ignore":
+        return False, "handle_unknown must be 'ignore'"
+    return True, ""
+
+
 def _iter_columns(X):
     if hasattr(X, "ndim") and getattr(X, "ndim", 1) == 2 and hasattr(X, "shape"):
         n_cols = X.shape[1]
@@ -75,7 +98,8 @@ class RustyOneHotEncoder(_SKOneHot):
     def transform(self, X):
         # Check kill-switch and feature flag at call time
         rc = get_config()
-        if not (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST):
+        force_rust = getattr(self, "_stratum_force_rust", False)
+        if not (force_rust or (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST)):
             return super().transform(X)
         # Check if the rust modules are available
         if getattr(rb, "ohe_transform", None) is None or getattr(rb, "csr_to_dense", None) is None:

--- a/stratum/adapters/string_encoder.py
+++ b/stratum/adapters/string_encoder.py
@@ -3,13 +3,21 @@ import numpy as np
 
 from skrub import StringEncoder as _SE  # base class from vanilla skrub
 from .. import _rust_backend as rb
-from .. _config import get_config
+from .._config import get_config
 from skrub._string_encoder import scaling_factor
 from skrub import _dataframe as sbd
 
 # File-internal config flags
 _DEBUG_INFO = False
 _FD_PATH = True
+
+
+def _rust_runtime_available() -> bool:
+    return (
+        rb.HAVE_RUST
+        and getattr(rb, "hashing_tfidf_fit", None) is not None
+        and getattr(rb, "tfidf_fit", None) is not None
+    )
 
 def _rust_supported_subset(enc: _SE) ->tuple[bool, str]:
     # Supports vectorizer="hashing/tfidf" with char/char_wb analyzer, no stopwords.
@@ -23,6 +31,15 @@ def _rust_supported_subset(enc: _SE) ->tuple[bool, str]:
     if not (isinstance(ngr, tuple) and len(ngr) == 2 and 1 <= ngr[0] <= ngr[1]):
         return False, f"invalid ngram_range {ngr!r}"
     return True, ""
+
+
+def supports_rust_string_encoder(estimator) -> tuple[bool, str]:
+    if not isinstance(estimator, _SE):
+        return False, "estimator is not a skrub StringEncoder"
+    if not _rust_runtime_available():
+        return False, "Rust StringEncoder runtime is not available"
+    return _rust_supported_subset(estimator)
+
 
 def _clean_strings(x_list):
     # Fill null/NaN → "", and coerce to str
@@ -71,11 +88,12 @@ class RustyStringEncoder(_SE):
 
     def fit_transform(self, X, y=None):
         # Check supported parameters
-        if not _rust_supported_subset(_SE):
+        if not _rust_supported_subset(self)[0]:
             return super().fit_transform(X, y)
         # Check kill-switch and feature flag at call time
         rc = get_config()
-        if not (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST):
+        force_rust = getattr(self, "_stratum_force_rust", False)
+        if not (force_rust or (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST)):
             return super().fit_transform(X, y)
 
         # Prepare inputs for Rust
@@ -153,7 +171,8 @@ class RustyStringEncoder(_SE):
     def transform(self, X):
         # Check kill-switch and feature flag at call time
         rc = get_config()
-        if not (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST):
+        force_rust = getattr(self, "_stratum_force_rust", False)
+        if not (force_rust or (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST)):
             return super().transform(X)
         # Check if we have stored state from fit_transform
         if not hasattr(self, "_rust_state_") or self._rust_state_ is None:

--- a/stratum/optimizer/physical/__init__.py
+++ b/stratum/optimizer/physical/__init__.py
@@ -1,0 +1,19 @@
+from ._registry import (
+    CURRENT_BACKENDS,
+    CURRENT_LOGICAL_OPERATOR_TYPES,
+    BackendSpec,
+    OperatorFamily,
+    PhysicalImpl,
+    PhysicalRegistry,
+    build_default_physical_registry,
+)
+
+__all__ = [
+    "CURRENT_BACKENDS",
+    "CURRENT_LOGICAL_OPERATOR_TYPES",
+    "BackendSpec",
+    "OperatorFamily",
+    "PhysicalImpl",
+    "PhysicalRegistry",
+    "build_default_physical_registry",
+]

--- a/stratum/optimizer/physical/_registry.py
+++ b/stratum/optimizer/physical/_registry.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+from stratum.optimizer.ir._aggregation_ops import AggregateOp, GroupedDataframeOp
+from stratum.optimizer.ir._dataframe_ops import (
+    ApplyUDFOp,
+    AssignOp,
+    ConcatOp,
+    DatetimeConversionOp,
+    DropOp,
+    GetAttrProjectionOp,
+    MetadataOp,
+    ProjectionOp,
+    SplitOp,
+    SplitOutput,
+    StringMethodOp,
+)
+from stratum.optimizer.ir._join_ops import JoinOp
+from stratum.optimizer.ir._numeric_ops import NumericOp
+from stratum.optimizer.ir._ops import (
+    BaseEstimatorOp,
+    BinOp,
+    CallOp,
+    ChoiceOp,
+    GetAttrOp,
+    GetItemOp,
+    ImplOp,
+    MethodCallOp,
+    Op,
+    SearchEvalOp,
+    ValueOp,
+    VariableOp,
+    EstimatorOp,
+    TransformerOp,
+)
+BackendName = str
+
+
+"""Descriptor for one physical implementation of a logical operator."""
+@dataclass(frozen=True, slots=True)
+class PhysicalImpl:
+    logical_op_type: type[Op]
+    backend_name: BackendName
+    input_format: str
+    output_format: str
+    supports: Callable[[Op], bool]
+    cost: Callable[[Op, Any], float]
+    exec_mem: Callable[[Op, Any], int]
+    execute: Callable[[Op, str, list[Any]], Any]
+
+
+"""Logical operator family used to keep the registry extensible."""
+@dataclass(frozen=True, slots=True)
+class OperatorFamily:
+    name: str
+    logical_op_types: tuple[type[Op], ...]
+    default_backends: tuple[BackendName, ...] = ()
+    notes: str = ""
+
+
+"""A physical execution backend understood by the registry."""
+@dataclass(frozen=True, slots=True)
+class BackendSpec:
+    name: str
+    notes: str = ""
+
+
+# FIXME: Only list the stratum's logical operators after compilation from skrub IR
+CURRENT_LOGICAL_OPERATOR_TYPES: tuple[type[Op], ...] = (
+    AggregateOp,
+    ApplyUDFOp,
+    AssignOp,
+    BaseEstimatorOp,
+    BinOp,
+    CallOp,
+    ChoiceOp,
+    ConcatOp,
+    DatetimeConversionOp,
+    DropOp,
+    EstimatorOp,
+    GetAttrOp,
+    GetAttrProjectionOp,
+    GetItemOp,
+    GroupedDataframeOp,
+    ImplOp,
+    JoinOp,
+    MetadataOp,
+    MethodCallOp,
+    NumericOp,
+    ProjectionOp,
+    SearchEvalOp,
+    SplitOp,
+    SplitOutput,
+    StringMethodOp,
+    TransformerOp,
+    ValueOp,
+    VariableOp,
+)
+
+
+CURRENT_BACKENDS: tuple[BackendSpec, ...] = (
+    BackendSpec("pandas", "Pandas dataframe implementation."),
+    BackendSpec("polars", "Polars dataframe implementation."),
+    BackendSpec("numpy", "NumPy array implementation."),
+    BackendSpec("sklearn-skrub", "Existing sklearn/skrub implementation."),
+    BackendSpec("rust", "Native Rust implementation selected like any other backend."),
+)
+
+
+CURRENT_OPERATOR_FAMILIES: tuple[OperatorFamily, ...] = (
+    OperatorFamily(
+        name="logical",
+        logical_op_types=CURRENT_LOGICAL_OPERATOR_TYPES,
+        default_backends=tuple(backend.name for backend in CURRENT_BACKENDS),
+        notes="Current logical IR surface; backends are attached later by the planner.",
+    ),
+)
+
+
+def _unsupported_supports(op: Op) -> bool:
+    return False
+
+
+def _unsupported_cost(op: Op, stats: Any) -> float:
+    raise NotImplementedError("No physical cost model has been registered for this operator yet.")
+
+
+def _unsupported_exec_mem(op: Op, stats: Any) -> int:
+    raise NotImplementedError("No execution-memory model has been registered for this operator yet.")
+
+
+def _unsupported_execute(op: Op, mode: str, inputs: list[Any]) -> Any:
+    raise NotImplementedError("No physical implementation has been registered for this operator yet.")
+
+
+def _current_process_execute(op: Op, mode: str, inputs: list[Any]) -> Any:
+    return op.process(mode, inputs)
+
+
+def _placeholder_cost(op: Op, stats: Any) -> float:
+    return 1.0
+
+
+def _placeholder_exec_mem(op: Op, stats: Any) -> int:
+    return 0
+
+
+"""Container for physical implementations and their logical families."""
+class PhysicalRegistry:
+    def __init__(
+        self,
+        families: Iterable[OperatorFamily] = (),
+        implementations: Iterable[PhysicalImpl] = (),
+    ) -> None:
+        self._families: list[OperatorFamily] = list(families)
+        self._implementations: dict[type[Op], list[PhysicalImpl]] = {}
+        self._implementations_by_backend: dict[BackendName, list[PhysicalImpl]] = {}
+        for impl in implementations:
+            self.register(impl)
+
+    def register_family(self, family: OperatorFamily) -> None:
+        self._families.append(family)
+
+    def register(self, impl: PhysicalImpl) -> PhysicalImpl:
+        self._implementations.setdefault(impl.logical_op_type, []).append(impl)
+        self._implementations_by_backend.setdefault(impl.backend_name, []).append(impl)
+        return impl
+
+    def families(self) -> tuple[OperatorFamily, ...]:
+        return tuple(self._families)
+
+    def logical_op_types(self) -> tuple[type[Op], ...]:
+        types: list[type[Op]] = []
+        seen: set[type[Op]] = set()
+        for family in self._families:
+            for logical_type in family.logical_op_types:
+                if logical_type not in seen:
+                    seen.add(logical_type)
+                    types.append(logical_type)
+        for logical_type in self._implementations:
+            if logical_type not in seen:
+                seen.add(logical_type)
+                types.append(logical_type)
+        return tuple(types)
+
+    def candidates_for(
+        self,
+        logical_op: type[Op] | Op,
+        backend_name: BackendName | None = None,
+    ) -> tuple[PhysicalImpl, ...]:
+        logical_type = logical_op if isinstance(logical_op, type) else type(logical_op)
+        candidates = self._implementations.get(logical_type, ())
+        if backend_name is not None:
+            candidates = [impl for impl in candidates if impl.backend_name == backend_name]
+        return tuple(candidates)
+
+    """Return the physical implementations available for a given logical operator."""
+    def candidates_for_op(
+        self,
+        op: Op,
+        backend_name: BackendName | None = None,
+    ) -> tuple[PhysicalImpl, ...]:
+        return self.candidates_for(op, backend_name=backend_name)
+
+    def backends_for(self, logical_op: type[Op] | Op) -> tuple[BackendName, ...]:
+        return tuple(impl.backend_name for impl in self.candidates_for(logical_op))
+
+    def has_candidates(self, logical_op: type[Op] | Op) -> bool:
+        return len(self.candidates_for(logical_op)) > 0
+
+    def candidates_by_backend(self, backend_name: BackendName) -> tuple[PhysicalImpl, ...]:
+        return tuple(self._implementations_by_backend.get(backend_name, ()))
+
+    def empty(self) -> bool:
+        return not self._implementations
+
+
+def _register_current_estimator_impls(registry: PhysicalRegistry) -> None:
+    for logical_op_type in (TransformerOp, EstimatorOp):
+        registry.register(
+            PhysicalImpl(
+                logical_op_type=logical_op_type,
+                backend_name="sklearn-skrub",
+                input_format="frame",
+                output_format="frame",
+                supports=lambda op: True,
+                cost=_placeholder_cost,
+                exec_mem=_placeholder_exec_mem,
+                execute=_current_process_execute,
+            )
+        )
+
+
+"""Create the registry skeleton without registering any operators yet."""
+def build_default_physical_registry() -> PhysicalRegistry:
+    registry = PhysicalRegistry(families=CURRENT_OPERATOR_FAMILIES)
+
+    from stratum.optimizer.physical._rust_registry import register_rust_physical_operators
+
+    _register_current_estimator_impls(registry)
+    register_rust_physical_operators(registry)
+    return registry

--- a/stratum/optimizer/physical/_rust_registry.py
+++ b/stratum/optimizer/physical/_rust_registry.py
@@ -1,0 +1,159 @@
+"""
+Rust physical operator registration.
+
+How to add a new Rust kernel:
+
+1. Keep the Python/Rust bridge in `stratum/adapters/<name>.py`.
+   The adapter file should expose a small Python class or function that calls the
+   compiled Rust backend and a support check such as:
+   `supports_rust_<name>(estimator_or_op) -> tuple[bool, str]`.
+
+2. Add an execution wrapper in this file.
+   The wrapper receives the logical op, runtime mode, and resolved inputs:
+   `execute(op, mode, inputs)`. It should adapt the logical op to the Rust bridge
+   and then call the existing op execution path or the Rust bridge directly.
+
+3. Add one `RustKernelRegistration` entry to `RUST_KERNELS`.
+   The entry must name the logical op type, input/output formats, support check,
+   and execute wrapper. Use `backend_name="rust"` only through this file.
+
+4. Keep fallback behavior out of the Rust `execute` wrapper.
+   `supports` decides whether a Rust candidate is valid. If `execute` is called,
+   the selector has chosen Rust and unexpected fallback should be treated as a
+   bug unless the adapter has a documented numerical fallback.
+"""
+
+#TODO: Cost and memory are placeholders for now. Replace `default_cost`
+# and `default_exec_mem` with kernel-specific estimates as the cost model lands.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from stratum.adapters.one_hot_encoder import (
+    RustyOneHotEncoder,
+    supports_rust_one_hot_encoder,
+)
+from stratum.adapters.string_encoder import (
+    RustyStringEncoder,
+    supports_rust_string_encoder,
+)
+from stratum.optimizer.ir._ops import Op, TransformerOp
+from stratum.optimizer.physical._registry import PhysicalImpl, PhysicalRegistry
+
+
+CostFn = Callable[[Op, Any], float]
+ExecMemFn = Callable[[Op, Any], int]
+ExecuteFn = Callable[[Op, str, list[Any]], Any]
+SupportsFn = Callable[[Op], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class RustKernelRegistration:
+    name: str
+    logical_op_type: type[Op]
+    input_format: str
+    output_format: str
+    supports: SupportsFn # Function to check if the kernel supports the input parameters
+    execute: ExecuteFn   # Function to execute the kernel
+    cost: CostFn
+    exec_mem: ExecMemFn
+
+    def as_physical_impl(self) -> PhysicalImpl:
+        return PhysicalImpl(
+            logical_op_type=self.logical_op_type,
+            backend_name="rust",
+            input_format=self.input_format,
+            output_format=self.output_format,
+            supports=self.supports,
+            cost=self.cost,
+            exec_mem=self.exec_mem,
+            execute=self.execute,
+        )
+
+
+def default_cost(op: Op, stats: Any) -> float:
+    return 1.0
+
+
+def default_exec_mem(op: Op, stats: Any) -> int:
+    return 0
+
+
+def _as_rusty_one_hot_encoder(estimator):
+    if isinstance(estimator, RustyOneHotEncoder):
+        rusty = estimator
+    else:
+        params = estimator.get_params(deep=False)
+        rusty = RustyOneHotEncoder(**params)
+    rusty._stratum_force_rust = True
+    return rusty
+
+
+def _supports_one_hot_encoder_op(op: Op) -> bool:
+    if not isinstance(op, TransformerOp):
+        return False
+    supported, _ = supports_rust_one_hot_encoder(op.original_estimator)
+    return supported
+
+
+def _execute_one_hot_encoder(op: Op, mode: str, inputs: list[Any]) -> Any:
+    if mode == "fit_transform":
+        op.original_estimator = _as_rusty_one_hot_encoder(op.original_estimator)
+        op.estimator = _as_rusty_one_hot_encoder(op.estimator)
+    return op.process(mode, inputs)
+
+
+def _as_rusty_string_encoder(estimator):
+    if isinstance(estimator, RustyStringEncoder):
+        rusty = estimator
+    else:
+        params = estimator.get_params(deep=False)
+        rusty = RustyStringEncoder(**params)
+    rusty._stratum_force_rust = True
+    return rusty
+
+
+def _supports_string_encoder_op(op: Op) -> bool:
+    if not isinstance(op, TransformerOp):
+        return False
+    supported, _ = supports_rust_string_encoder(op.original_estimator)
+    return supported
+
+
+def _execute_string_encoder(op: Op, mode: str, inputs: list[Any]) -> Any:
+    if mode == "fit_transform":
+        op.original_estimator = _as_rusty_string_encoder(op.original_estimator)
+        op.estimator = _as_rusty_string_encoder(op.estimator)
+    return op.process(mode, inputs)
+
+
+RUST_KERNELS: tuple[RustKernelRegistration, ...] = (
+    RustKernelRegistration(
+        name="one_hot_encoder",
+        logical_op_type=TransformerOp,
+        input_format="frame",
+        output_format="matrix",
+        supports=_supports_one_hot_encoder_op,
+        execute=_execute_one_hot_encoder,
+        cost=default_cost,
+        exec_mem=default_exec_mem,
+    ),
+    RustKernelRegistration(
+        name="string_encoder",
+        logical_op_type=TransformerOp,
+        input_format="frame",
+        output_format="frame",
+        supports=_supports_string_encoder_op,
+        execute=_execute_string_encoder,
+        cost=default_cost,
+        exec_mem=default_exec_mem,
+    ),
+)
+
+
+def register_rust_physical_operators(registry: PhysicalRegistry) -> PhysicalRegistry:
+    for kernel in RUST_KERNELS:
+        registry.register(kernel.as_physical_impl())
+    return registry

--- a/stratum/patching/_patching.py
+++ b/stratum/patching/_patching.py
@@ -1,21 +1,8 @@
-"""
-Automatic monkey-patching of selected classes inside upstream skrub
-so that internal imports like `from ._string_encoder import StringEncoder` and
-usage in `TableVectorizer` resolve to Stratum adapters.
+"""Small upstream patches that are not physical-operator choices.
 
-Design notes:
-- Runs once, idempotent, without config flags.
-- Maintains a manual registry. Add to it when a new adapter is implemented in stratum.
-- Patches:
-  (1) the *defining modules* (e.g., `skrub._string_encoder.StringEncoder`),
-  (2) relevant *usage modules* that may already have bound names, and
-  (3) the top-level `skrub` package symbols for user-facing imports.
-
-Special case: OneHotEncoder
-- `skrub` uses `sklearn.preprocessing.OneHotEncoder` internally.
-- We therefore *cannot* patch a `skrub`-defined class. Instead, we override the
-  names `OneHotEncoder` in `skrub`'s usage modules and also expose our
-  `OneHotEncoder` at `skrub.OneHotEncoder` for convenience.
+Rust estimator implementations are registered with the physical operator
+registry. They are no longer installed by replacing upstream skrub or sklearn
+classes at import time.
 """
 from __future__ import annotations
 
@@ -24,9 +11,6 @@ import threading
 from types import ModuleType
 from typing import Dict, Tuple, List
 
-# --- Import adapters (raises at import time if not available) ---
-from stratum.adapters.string_encoder import RustyStringEncoder
-from stratum.adapters.one_hot_encoder import RustyOneHotEncoder
 from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSearch
 
 # ------------------------
@@ -34,9 +18,6 @@ from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSear
 # ------------------------
 # Definition: (module, symbol) -> adapter
 _DEFINITION_REPLACEMENTS: Dict[Tuple[str, str], object] = {
-    ("skrub._string_encoder", "StringEncoder"): RustyStringEncoder,
-    ("sklearn.preprocessing", "OneHotEncoder"): RustyOneHotEncoder,
-    # Note: There is no skrub-defined OneHotEncoder to replace at definition site.
 }
 
 # Method-level replacements (for methods on classes)
@@ -48,16 +29,11 @@ _METHOD_REPLACEMENTS: Dict[Tuple[str, str, str], object] = {
 # Replace/override names in these upstream usage modules if present.
 # Keep this list manually maintained. Add to it if skrub adds new direct imports.
 _USAGE_MODULES: List[str] = [
-    "skrub._table_vectorizer",
-    "skrub._tabular_pipeline",
-    # Add other skrub modules here if they import our adapters (e.g., StringEncoder, OneHotEncoder) directly.
 ]
 
 # Symbol-level overrides for usage modules and top-level exposure on `skrub`
 # (symbol name) -> adapter
 _SYMBOL_OVERRIDES: Dict[str, object] = {
-    "StringEncoder": RustyStringEncoder,
-    "OneHotEncoder": RustyOneHotEncoder,  # our adapter extends sklearn's
 }
 
 # Idempotence sentinel + lock
@@ -126,7 +102,7 @@ def _symbol_OVERRIDES_ITEMS():
     return _SYMBOL_OVERRIDES.items()
 
 def patch_skrub() -> None:
-    """Patch upstream `skrub` in-place so its internals use Stratum adapters.
+    """Patch upstream `skrub` in-place for non-operator-selector hooks.
 
     This function is safe to call multiple times (idempotent).
     """

--- a/stratum/tests/physical/test_registry.py
+++ b/stratum/tests/physical/test_registry.py
@@ -1,0 +1,89 @@
+from stratum.optimizer.ir._dataframe_ops import ConcatOp
+from stratum.optimizer.ir._numeric_ops import NumericOp
+from stratum.optimizer.ir._ops import EstimatorOp, Op, TransformerOp
+from stratum.optimizer.physical import (
+    CURRENT_BACKENDS,
+    CURRENT_LOGICAL_OPERATOR_TYPES,
+    OperatorFamily,
+    PhysicalImpl,
+    PhysicalRegistry,
+    build_default_physical_registry,
+)
+from stratum.optimizer.physical._rust_registry import RUST_KERNELS
+
+
+def test_default_registry_has_logical_surface_and_adapter_candidates():
+    registry = build_default_physical_registry()
+
+    assert not registry.empty()
+    assert registry.logical_op_types()
+    assert ConcatOp in CURRENT_LOGICAL_OPERATOR_TYPES
+    assert NumericOp in CURRENT_LOGICAL_OPERATOR_TYPES
+    assert "rust" in {backend.name for backend in CURRENT_BACKENDS}
+    rust_candidates = registry.candidates_for(TransformerOp, backend_name="rust")
+    sklearn_candidates = registry.candidates_for(TransformerOp, backend_name="sklearn-skrub")
+    assert len(rust_candidates) == 2
+    assert all(candidate.backend_name == "rust" for candidate in rust_candidates)
+    assert len(sklearn_candidates) == 1
+    assert len(registry.candidates_for(EstimatorOp, backend_name="sklearn-skrub")) == 1
+
+
+def test_rust_kernel_registration_list_is_the_source_of_rust_candidates():
+    registry = build_default_physical_registry()
+
+    rust_candidates = registry.candidates_for(TransformerOp, backend_name="rust")
+
+    assert len(rust_candidates) == len(RUST_KERNELS)
+    assert {kernel.name for kernel in RUST_KERNELS} == {"one_hot_encoder", "string_encoder"}
+
+
+def test_registry_registers_and_queries_impls_by_logical_type():
+    registry = PhysicalRegistry()
+
+    class DummyOp(Op):
+        pass
+
+    pandas_impl = PhysicalImpl(
+        logical_op_type=DummyOp,
+        backend_name="pandas",
+        input_format="frame",
+        output_format="frame",
+        supports=lambda op: isinstance(op, DummyOp),
+        cost=lambda op, stats: 1.0,
+        exec_mem=lambda op, stats: 1,
+        execute=lambda op, mode, inputs: ("concat", mode, len(inputs)),
+    )
+    rust_impl = PhysicalImpl(
+        logical_op_type=DummyOp,
+        backend_name="rust",
+        input_format="frame",
+        output_format="frame",
+        supports=lambda op: isinstance(op, DummyOp),
+        cost=lambda op, stats: 0.5,
+        exec_mem=lambda op, stats: 1,
+        execute=lambda op, mode, inputs: ("rust-concat", mode, len(inputs)),
+    )
+
+    registry.register(pandas_impl)
+    registry.register(rust_impl)
+
+    assert registry.candidates_for(DummyOp) == (pandas_impl, rust_impl)
+    assert registry.candidates_for_op(DummyOp()) == (pandas_impl, rust_impl)
+    assert registry.candidates_for(DummyOp, backend_name="rust") == (rust_impl,)
+    assert registry.backends_for(DummyOp) == ("pandas", "rust")
+    assert registry.candidates_by_backend("pandas") == (pandas_impl,)
+    assert registry.candidates_by_backend("rust") == (rust_impl,)
+
+
+def test_register_family_tracks_known_logical_types():
+    registry = PhysicalRegistry()
+
+    family = OperatorFamily(
+        name="custom",
+        logical_op_types=(ConcatOp,),
+        default_backends=("pandas",),
+    )
+    registry.register_family(family)
+
+    assert registry.families() == (family,)
+    assert ConcatOp in registry.logical_op_types()

--- a/stratum/tests/test_import_patch.py
+++ b/stratum/tests/test_import_patch.py
@@ -1,41 +1,25 @@
-import sys
-import pandas as pd
-import stratum as st
 from sklearn.preprocessing import OneHotEncoder
-from skrub import TableVectorizer, StringEncoder
+from skrub import StringEncoder
 
-def capture_std_out(capfd):
-    # Capture timing output
-    sys.stdout.flush()
-    sys.stderr.flush()
-    captured = capfd.readouterr()
-    combined_output = (captured.out or "") + (captured.err or "")
-    return combined_output
+import stratum as st
+from stratum.optimizer.ir._ops import TransformerOp
+from stratum.optimizer.physical import build_default_physical_registry
 
-def test_tablevectorizer_stringencoder(capfd):
-    df = pd.DataFrame({
-        'A': ['one', 'two', 'two', 'three'],
-        'B': ['02/02/2024', '23/02/2024', '12/03/2024', '13/03/2024'],
-        'C': ['1.5', 'N/A', '12.2', 'N/A'],
-    })
-    with st.config(rust_backend=True, debug_timing=True):
-        vectorizer = TableVectorizer(low_cardinality=StringEncoder())
-        _ = vectorizer.fit_transform(df)
-        # Assert if the fitted transformers is RustyStringEncoder
-        assert repr(vectorizer.transformers_['A']).startswith('RustyStringEncoder')
-        # Assert if the Rust code is executed
-        assert "[rust]" in capture_std_out(capfd)
 
-def test_tablevectorizer_onehotencoder(capfd):
-    df = pd.DataFrame({
-        'A': ['one', 'two', 'two', 'three'],
-        'B': ['02/02/2024', '23/02/2024', '12/03/2024', '13/03/2024'],
-        'C': ['1.5', 'N/A', '12.2', 'N/A'],
-    })
-    with st.config(rust_backend=True, debug_timing=True):
-        vectorizer = TableVectorizer(low_cardinality=OneHotEncoder())
-        _ = vectorizer.fit_transform(df)
-        # Assert if the fitted transformers is RustyStringEncoder
-        assert repr(vectorizer.transformers_['A']).startswith('RustyOneHotEncoder')
-        # Assert if the Rust code is executed
-        assert "[rust]" in capture_std_out(capfd)
+def test_skrub_and_sklearn_estimators_are_not_monkey_patched():
+    assert StringEncoder.__module__.startswith("skrub")
+    assert OneHotEncoder.__module__.startswith("sklearn")
+
+
+def test_rust_estimators_are_registered_as_physical_operators():
+    registry = build_default_physical_registry()
+
+    rust_candidates = registry.candidates_for(TransformerOp, backend_name="rust")
+
+    assert len(rust_candidates) == 2
+    assert {candidate.backend_name for candidate in rust_candidates} == {"rust"}
+
+
+def test_stratum_still_exposes_adapter_classes_for_direct_legacy_use():
+    assert st.StringEncoder.__name__ == "RustyStringEncoder"
+    assert st.OneHotEncoder.__name__ == "RustyOneHotEncoder"


### PR DESCRIPTION
This patch introduces the initial registries for physical implementations and Rust kernels, laying the foundation for operator selection. It also replaces Rust kernel monkey-patching with explicit registration through the new implementation registry.