### PR TITLE
[Fix] deduplicate Op inputs during rewiring

### DIFF
--- a/stratum/optimizer/_op_utils.py
+++ b/stratum/optimizer/_op_utils.py
@@ -17,10 +17,7 @@ FLAGS = IteratorFlags()
 def replace_op_in_outputs(op: Op, replacement: Op):
     """Replace op in all its outputs with a replacement op."""
     for out_ in op.outputs:
-        for i,in_ in enumerate(out_.inputs):
-            if in_ is op:
-                out_.inputs[i] = replacement
-                break
+        out_.replace_input(op, replacement)
         replacement.add_output(out_)
 
 

--- a/stratum/optimizer/ir/_ops.py
+++ b/stratum/optimizer/ir/_ops.py
@@ -267,24 +267,79 @@ class Op():
     def num_input_operands(self) -> int:
         return len(self.inputs)
 
-    def add_output(self, output: Op):
-        """Add an output edge, de-duplicating so an op appears at most once."""
-        for out_ in self.outputs:
-            if out_ is output:
-                return
-        self.outputs.append(output)
-
-    def add_input(self, input: Op) -> int:
-        """Add an input edge, de-duplicating. Returns the operand index of `input`."""
+    def _check_dup_in_inputs(self, input: Op) -> int | None:
+        """Return the input index if already present, otherwise None."""
         for i, in_ in enumerate(self.inputs):
             if in_ is input:
                 return i
+        return None
+
+    def _check_dup_in_outputs(self, output: Op) -> int | None:
+        """Return the output index if already present, otherwise None."""
+        for i, out_ in enumerate(self.outputs):
+            if out_ is output:
+                return i
+        return None
+
+    def add_output(self, output: Op) -> int:
+        """Add an output edge, de-duplicating. Returns the output index."""
+        idx = self._check_dup_in_outputs(output)
+        if idx is not None:
+            return idx
+        self.outputs.append(output)
+        return len(self.outputs) - 1
+
+    def add_input(self, input: Op) -> int:
+        """Add an input edge, de-duplicating. Returns the operand index of `input`."""
+        idx = self._check_dup_in_inputs(input)
+        if idx is not None:
+            return idx
         self.inputs.append(input)
         return len(self.inputs) - 1
 
+    def _remap_refs(self, value, old_ref, new_ref):
+        """Recursively update OperandRefs after removing an input slot."""
+        if isinstance(value, OperandRef):
+            if value.k == old_ref:
+                return OperandRef(new_ref)
+            elif value.k > old_ref:
+                return OperandRef(value.k - 1)
+        if isinstance(value, tuple):
+            return tuple(self._remap_refs(v, old_ref, new_ref) for v in value)
+        if isinstance(value, list):
+            return [self._remap_refs(v, old_ref, new_ref) for v in value]
+        if isinstance(value, dict):
+            return {k: self._remap_refs(v, old_ref, new_ref) for k, v in value.items()}
+        return value
+
+    def _dedupe_input_refs(self, old_ref, new_ref):
+        """Remove input slot old_ref and redirect its OperandRefs to new_ref.
+
+        OperandRefs pointing after the removed slot are shifted left by one.
+        """
+        self.inputs.pop(old_ref)
+        for field in getattr(type(self), "fields", []):
+            value = getattr(self, field)
+            correct_value = self._remap_refs(value, old_ref, new_ref)
+            if correct_value is not value:
+                setattr(self, field, correct_value)
+
     def replace_input(self, old_input: Op, new_input: Op):
+        """Replace an input edge, deduplicating OperandRef-based inputs when needed.
+
+        If replacing old_input with new_input would create a duplicate input, keep
+        the leftmost slot and remap OperandRefs away from the removed slot.
+        """
         for i, in_ in enumerate(self.inputs):
             if in_ is old_input:
+                idx = self._check_dup_in_inputs(new_input)
+                if idx is not None and not self.is_choice():
+                    if idx < i:
+                        self._dedupe_input_refs(old_ref=i, new_ref=idx)
+                    else:
+                        self.inputs[i] = new_input
+                        self._dedupe_input_refs(old_ref=idx, new_ref=i)
+                    return
                 self.inputs[i] = new_input
                 return
         raise ValueError(f"Input {old_input} not found in {self.__class__.__name__}.")

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -5,6 +5,7 @@ from stratum.optimizer._optimize import  optimize
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
+from stratum.optimizer.ir._ops import OperandRef
 
 class TestCSE(unittest.TestCase):
 
@@ -264,6 +265,22 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(root)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].process("fit", [out[0].value]), 2)
+
+    def test_eliminate_identity_operation_dedups_repeated_input(self):
+        value = st.as_data_op(2)
+        a = value + (value * 1)
+        b = (value * 1) + value
+        root = a + b
+
+        out, *_ = optimize(root)
+
+        self.assertEqual(len(out), 4)
+        self.assertEqual(out[1].inputs, [out[0]])
+        self.assertEqual(out[2].inputs, [out[0]])
+        self.assertEqual(out[2].opt_operand, OperandRef(0))
+        left_sum = out[1].process("fit", [out[0].value])
+        right_sum = out[2].process("fit", [out[0].value])
+        self.assertEqual(out[3].process("fit", [left_sum, right_sum]), 8)
 
     def test_abs_abs_collapses_to_single_abs(self):
         df = st.as_data_op(-3)

--- a/stratum/tests/logical_optimizer/test_ops.py
+++ b/stratum/tests/logical_optimizer/test_ops.py
@@ -16,6 +16,7 @@ from stratum.optimizer.ir._ops import (
     VariableOp, check_estm_inputs, estimator_parallel_config,
     estm_supports_polars, process_estimator_task, process_transformer_task,
 )
+from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._optimize import optimize as optimize_
 
 
@@ -325,3 +326,29 @@ class TestEdgeDedup(unittest.TestCase):
         op.add_output(out)
         op.add_output(out)
         self.assertEqual(op.outputs, [out])
+
+    def test_replace_input_dedups_existing_input_before_old_input(self):
+        value, old = ValueOp(1), ValueOp(2)
+        op = NumericOp(
+            type=NumericOpType.ADD,
+            inputs=[value, old],
+            opt_operand=OperandRef(1),
+        )
+
+        op.replace_input(old, value)
+
+        self.assertEqual(op.inputs, [value])
+        self.assertEqual(op.opt_operand, OperandRef(0))
+
+    def test_replace_input_dedups_existing_input_after_old_input(self):
+        old, value = ValueOp(1), ValueOp(2)
+        op = NumericOp(
+            type=NumericOpType.ADD,
+            inputs=[old, value],
+            opt_operand=OperandRef(0),
+        )
+
+        op.replace_input(old, value)
+
+        self.assertEqual(op.inputs, [value])
+        self.assertEqual(op.opt_operand, OperandRef(0))


### PR DESCRIPTION
- Helper methods _check_dup_in_inputs() and _check_dup_in_outputs() were introduced, which, in case our input/output list contains the node in question, return its index. Otherwise, None is returned.

- replace_op_in_outputs() now uses our replace_input() method.

- Many optimization methods relied on the use of replace_input(), which had no checks for whether the newly inserted node already existed in our input list. This is now checked with the new helper methods, and the duplicate with the highest index is removed.

- Any old reference to the slot of the removed node now points to the slot containing the remaining node, and any reference to a slot to the right of the removed node is shifted one position to the left.