### PR TITLE
[Rewrite] Eliminate subtract zero identity (#134)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -9,8 +9,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_add_zero,
     eliminate_exp_minus_one,
     eliminate_identity_subtract,
-    eliminate_abs_abs,
-    eliminate_constant_folding,
+    eliminate_abs_abs
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -31,7 +30,6 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     identity_subtract: bool = True
-    constant_folding: bool = False
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -57,7 +55,5 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_expm1_log1p(root)
     if config.identity_subtract:
         root = eliminate_identity_subtract(root)
-    if config.constant_folding:
-        root = eliminate_constant_folding(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -8,7 +8,9 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_identity_operation,
     eliminate_abs_abs,
     eliminate_add_zero,
-    eliminate_exp_minus_one
+    eliminate_exp_minus_one,
+    eliminate_abs_abs,
+    eliminate_identity_subtract
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -28,6 +30,7 @@ class AlgebraicRewritesConfig:
     abs_abs: bool = True
     add_zero: bool = True
     exp_minus_one: bool = True
+    identity_subtract: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -51,5 +54,9 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_log1p_expm1(root)
     if config.expm1_log1p:
         root = eliminate_expm1_log1p(root)
+    if config.identity_op:
+        root = eliminate_identity_operation(root)
+    if config.identity_subtract:
+        root = eliminate_identity_subtract(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -6,6 +6,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_log1p_expm1,
     eliminate_sqrt_square,
     eliminate_identity_operation,
+    eliminate_identity_subtract,
     eliminate_abs_abs
 )
 from stratum.optimizer.ir._ops import Op
@@ -24,6 +25,7 @@ class AlgebraicRewritesConfig:
     expm1_log1p: bool = True
     identity_op: bool = True
     abs_abs: bool = True
+    identity_subtract: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -43,5 +45,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_expm1_log1p(root)
     if config.identity_op:
         root = eliminate_identity_operation(root)
+    if config.identity_subtract:
+        root = eliminate_identity_subtract(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -14,11 +14,21 @@ def match_two_op_chain(op_cls, type1, type2):
     return match
 
 
-def match_identity_operation(op_cls, type1, const):
+def match_identity_operation(op_cls, type1, const, reversed=None):
+    """Match a var-const NumericOp that performs an identity transformation.
+
+    Parameters
+    ----------
+    reversed : bool or None
+        If None, the ``reversed`` flag is not checked (e.g. multiplication is
+        commutative so ``x*1`` and ``1*x`` are both identities).  Set to
+        ``True`` / ``False`` for non-commutative operations like subtraction.
+    """
     def match(op1):
         if isinstance(op1, op_cls) and op1.type == type1:
             if op1.opt_operand is None and op1.constant == const:
-                return (op1,)
+                if reversed is None or op1.reversed == reversed:
+                    return (op1,)
         return None
     return match
 

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -137,3 +137,8 @@ _replace_with_expm1 = make_replace_two_op_chain_root_safe(
 )
 
 eliminate_exp_minus_one = rewrite_pass(match_exp_minus_one, _replace_with_expm1)
+
+eliminate_identity_subtract = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.SUBTRACT, 0, reversed=False),
+    eliminate_single_op_chain_root_safe,
+)

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -14,11 +14,21 @@ def match_two_op_chain(op_cls, type1, type2):
     return match
 
 
-def match_identity_operation(op_cls, type1, const):
+def match_identity_operation(op_cls, type1, const, reversed=None):
+    """Match a var-const NumericOp that performs an identity transformation.
+
+    Parameters
+    ----------
+    reversed : bool or None
+        If None, the ``reversed`` flag is not checked (e.g. multiplication is
+        commutative so ``x*1`` and ``1*x`` are both identities).  Set to
+        ``True`` / ``False`` for non-commutative operations like subtraction.
+    """
     def match(op1):
         if isinstance(op1, op_cls) and op1.type == type1:
             if op1.opt_operand is None and op1.constant == const:
-                return (op1,)
+                if reversed is None or op1.reversed == reversed:
+                    return (op1,)
         return None
     return match
 
@@ -115,4 +125,9 @@ eliminate_identity_operation = rewrite_pass(
 eliminate_abs_abs = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.ABS, NumericOpType.ABS),
     _replace_with_abs,
+)
+
+eliminate_identity_subtract = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.SUBTRACT, 0, reversed=False),
+    eliminate_single_op_chain_root_safe,
 )

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,6 +1,6 @@
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
-from stratum.optimizer.ir._ops import Op, ValueOp
+from stratum.optimizer.ir._ops import Op
 
 
 def match_two_op_chain(op_cls, type1, type2):
@@ -98,38 +98,6 @@ def match_exp_minus_one(op):
     return None
 
 
-def match_constant_foldable(op):
-    """Match a NumericOp whose variable inputs are all ValueOps (constants).
-
-    For binary ops with a constant operand (``opt_operand is None``) only the
-    primary input must be a ValueOp; the constant side is already a Python scalar.
-    For var-var binary ops both inputs must be ValueOps.
-    """
-    if not isinstance(op, NumericOp):
-        return None
-    if not op.inputs:
-        return None
-    if op.opt_operand is not None:
-        # var-var binary: every input must be a ValueOp
-        if not all(isinstance(inp, ValueOp) for inp in op.inputs):
-            return None
-    else:
-        # unary or var-const binary: only the primary input must be a ValueOp
-        if not isinstance(op.inputs[0], ValueOp):
-            return None
-    return (op,)
-
-
-def fold_constant_op_root_safe(op, root):
-    """Evaluate *op* with its constant inputs and replace it with a ValueOp."""
-    input_values = [inp.value for inp in op.inputs]
-    result = op.process("fit", input_values)
-    new_op = ValueOp(result)
-    replace_op_in_outputs(op, new_op)
-    if op is root:
-        root = new_op
-    return root
-
 
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
@@ -184,9 +152,4 @@ eliminate_exp_minus_one = rewrite_pass(match_exp_minus_one, _replace_with_expm1)
 eliminate_identity_subtract = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.SUBTRACT, 0, reversed=False),
     eliminate_single_op_chain_root_safe,
-)
-
-eliminate_constant_folding = rewrite_pass(
-    match_constant_foldable,
-    fold_constant_op_root_safe,
 )

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -317,3 +317,48 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
+
+    def test_eliminate_identity_subtract(self):
+        """x - 0  →  x"""
+        df = st.as_data_op(5)
+        t1 = df - 0
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 8)
+
+    def test_eliminate_identity_subtract_root_safe(self):
+        """When x - 0 is the root, the rewrite must not break the DAG."""
+        value = st.as_data_op(7)
+        root = value - 0
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].process("fit", [out[0].value]), 7)
+
+    def test_disable_eliminate_identity_subtract(self):
+        """Disabling identity_subtract must leave x - 0 untouched."""
+        df = st.as_data_op(5)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_subtract=False),
+        )
+        t1 = df - 0
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+        subtract_result = out[1].process("fit", [out[0].value])
+        self.assertEqual(subtract_result, 5)
+        self.assertEqual(out[2].process("fit", [subtract_result]), 8)
+
+    def test_no_rewrite_const_minus_var(self):
+        """0 - x  should NOT be rewritten (it is not an identity)."""
+        df = st.as_data_op(5)
+        t1 = 0 - df
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        # x - 0 would collapse to 2 ops; 0 - x stays as 3 ops
+        self.assertEqual(len(out), 3)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -447,3 +447,48 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(len(out), 2)  # exp/log cancel -> x - 1
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.SUBTRACT)
+
+    def test_eliminate_identity_subtract(self):
+        """x - 0  →  x"""
+        df = st.as_data_op(5)
+        t1 = df - 0
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 8)
+
+    def test_eliminate_identity_subtract_root_safe(self):
+        """When x - 0 is the root, the rewrite must not break the DAG."""
+        value = st.as_data_op(7)
+        root = value - 0
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].process("fit", [out[0].value]), 7)
+
+    def test_disable_eliminate_identity_subtract(self):
+        """Disabling identity_subtract must leave x - 0 untouched."""
+        df = st.as_data_op(5)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_subtract=False),
+        )
+        t1 = df - 0
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 3)
+        subtract_result = out[1].process("fit", [out[0].value])
+        self.assertEqual(subtract_result, 5)
+        self.assertEqual(out[2].process("fit", [subtract_result]), 8)
+
+    def test_no_rewrite_const_minus_var(self):
+        """0 - x  should NOT be rewritten (it is not an identity)."""
+        df = st.as_data_op(5)
+        t1 = 0 - df
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        # x - 0 would collapse to 2 ops; 0 - x stays as 3 ops
+        self.assertEqual(len(out), 3)


### PR DESCRIPTION
### Add algebraic rewrites `x-0 -> 0` (#134).

- Eliminates `NumericOp(SUBTRACT)` where the right-hand constant is `0`. Only matches `x-0` (not `0-x`) — uses the new `reversed` parameter on `match_identity_operation`

