### PR TITLE
[Rewrite] Adds power of zero annihilator (#135)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -9,6 +9,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_abs_abs,
     eliminate_add_zero,
     eliminate_exp_minus_one,
+    eliminate_pow_zero,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
 )
@@ -30,6 +31,7 @@ class AlgebraicRewritesConfig:
     abs_abs: bool = True
     add_zero: bool = True
     exp_minus_one: bool = True
+    pow_zero: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
 
@@ -57,6 +59,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_expm1_log1p(root)
     if config.identity_subtract:
         root = eliminate_identity_subtract(root)
+    if config.pow_zero:
+        root = eliminate_pow_zero(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
     log_time("algebraic_rewrite", start)

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,7 +1,6 @@
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
-from stratum.optimizer.ir._ops import Op, ValueOp, BinOp, OperandRef
-import operator
+from stratum.optimizer.ir._ops import Op, ValueOp
 
 
 def match_two_op_chain(op_cls, type1, type2):
@@ -176,29 +175,20 @@ eliminate_any_mul_zero = rewrite_pass(
 )
 
 
-def match_pow_zero(op):
-    """Match ``x ** 0`` (a variable raised to the power zero).
+def fold_to_one(op: Op, root: Op) -> Op:
+    """Constant-fold ``x ** 0`` to ``1``.
 
-    Only matches when the base is a variable (OperandRef), not a constant,
-    so that ``0 ** 0`` is *not* rewritten — the ``x != 0`` semantics are
-    the caller's responsibility.
+    Parallels :func:`fold_to_zero`: drops the pow op and its dead operand edges
+    and rewires downstream consumers to a :class:`ValueOp` holding ``1``.
     """
-    if isinstance(op, BinOp) and op.op is operator.pow:
-        if op.right == 0 and isinstance(op.left, OperandRef):
-            return (op,)
-    return None
-
-
-def annihilate_pow_zero_root_safe(op, root):
-    """Replace ``x ** 0`` with ``ValueOp(1)``."""
-    new_op = ValueOp(1)
-    replace_op_in_outputs(op, new_op)
-    if op is root:
-        root = new_op
-    return root
+    one_op = ValueOp(1)
+    for operand in op.inputs:
+        operand.outputs = [out for out in operand.outputs if out is not op]
+    replace_op_in_outputs(op, one_op)
+    return one_op if op is root else root
 
 
 eliminate_pow_zero = rewrite_pass(
-    match_pow_zero,
-    annihilate_pow_zero_root_safe,
+    match_identity_operation(NumericOp, NumericOpType.POW, 0, reversed=False),
+    fold_to_one,
 )

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -97,6 +97,7 @@ def match_exp_minus_one(op):
             return (op, op2)
     return None
 
+
 def fold_to_zero(op: Op, root: Op) -> Op:
     """Constant-fold ``x * 0`` (or ``0 * x``) to ``0``.
 
@@ -111,6 +112,19 @@ def fold_to_zero(op: Op, root: Op) -> Op:
         operand.outputs = [out for out in operand.outputs if out is not op]
     replace_op_in_outputs(op, zero_op)
     return zero_op if op is root else root
+
+
+def fold_to_one(op: Op, root: Op) -> Op:
+    """Constant-fold ``x ** 0`` to ``1``.
+
+    Parallels :func:`fold_to_zero`: drops the pow op and its dead operand edges
+    and rewires downstream consumers to a :class:`ValueOp` holding ``1``.
+    """
+    one_op = ValueOp(1)
+    for operand in op.inputs:
+        operand.outputs = [out for out in operand.outputs if out is not op]
+    replace_op_in_outputs(op, one_op)
+    return one_op if op is root else root
 
 
 eliminate_log_exp = rewrite_pass(
@@ -173,20 +187,6 @@ eliminate_any_mul_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 0),
     fold_to_zero,
 )
-
-
-def fold_to_one(op: Op, root: Op) -> Op:
-    """Constant-fold ``x ** 0`` to ``1``.
-
-    Parallels :func:`fold_to_zero`: drops the pow op and its dead operand edges
-    and rewires downstream consumers to a :class:`ValueOp` holding ``1``.
-    """
-    one_op = ValueOp(1)
-    for operand in op.inputs:
-        operand.outputs = [out for out in operand.outputs if out is not op]
-    replace_op_in_outputs(op, one_op)
-    return one_op if op is root else root
-
 
 eliminate_pow_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.POW, 0, reversed=False),

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,6 +1,7 @@
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
-from stratum.optimizer.ir._ops import Op, ValueOp
+from stratum.optimizer.ir._ops import Op, ValueOp, BinOp, OperandRef
+import operator
 
 
 def match_two_op_chain(op_cls, type1, type2):
@@ -172,4 +173,32 @@ eliminate_identity_subtract = rewrite_pass(
 eliminate_any_mul_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 0),
     fold_to_zero,
+)
+
+
+def match_pow_zero(op):
+    """Match ``x ** 0`` (a variable raised to the power zero).
+
+    Only matches when the base is a variable (OperandRef), not a constant,
+    so that ``0 ** 0`` is *not* rewritten — the ``x != 0`` semantics are
+    the caller's responsibility.
+    """
+    if isinstance(op, BinOp) and op.op is operator.pow:
+        if op.right == 0 and isinstance(op.left, OperandRef):
+            return (op,)
+    return None
+
+
+def annihilate_pow_zero_root_safe(op, root):
+    """Replace ``x ** 0`` with ``ValueOp(1)``."""
+    new_op = ValueOp(1)
+    replace_op_in_outputs(op, new_op)
+    if op is root:
+        root = new_op
+    return root
+
+
+eliminate_pow_zero = rewrite_pass(
+    match_pow_zero,
+    annihilate_pow_zero_root_safe,
 )

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -16,12 +16,14 @@ class NumericOpType(Enum):
     SUBTRACT = "subtract"
     MULTIPLY = "multiply"
     DIVIDE = "divide"
+    POW = "pow"
 
 _ARITH_OP_MAP = {
     operator.add: NumericOpType.ADD,
     operator.sub: NumericOpType.SUBTRACT,
     operator.mul: NumericOpType.MULTIPLY,
     operator.truediv: NumericOpType.DIVIDE,
+    operator.pow: NumericOpType.POW,
 }
 
 _NUMPY_BINARY_MAP = {
@@ -29,6 +31,7 @@ _NUMPY_BINARY_MAP = {
     np.subtract: NumericOpType.SUBTRACT,
     np.multiply: NumericOpType.MULTIPLY,
     np.divide: NumericOpType.DIVIDE,
+    np.power: NumericOpType.POW,
 }
 
 _NUMPY_UNARY_MAP = {
@@ -105,6 +108,8 @@ class NumericOp(Op):
                 return np.multiply(left, right)
             elif self.type == NumericOpType.DIVIDE:
                 return np.divide(left, right)
+            elif self.type == NumericOpType.POW:
+                return np.power(left, right)
             else:
                 raise ValueError(f"Unsupported binary numeric operation type: {self.type}")
         else:

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -509,3 +509,75 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2)
         # x - 0 would collapse to 2 ops; 0 - x stays as 3 ops
         self.assertEqual(len(out), 3)
+
+    # --- pow-zero annihilator --------------------------------------------
+
+    def test_pow_zero_annihilates_to_one(self):
+        """x ** 0  →  1"""
+        df = st.as_data_op(5)
+        t1 = df ** 0
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)
+
+    def test_pow_zero_with_trailing_op(self):
+        """(x ** 0) + 3  →  1 + 3  →  4"""
+        df = st.as_data_op(5)
+        t1 = df ** 0
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 4)
+
+    def test_pow_zero_root_safe(self):
+        """When x ** 0 is the root, the DAG must not break."""
+        value = st.as_data_op(7)
+        root = value ** 0
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)
+
+    def test_pow_zero_disabled(self):
+        """Disabling pow_zero must leave x ** 0 untouched."""
+        df = st.as_data_op(5)
+        t1 = df ** 0
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_zero=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)
+
+    def test_pow_nonzero_untouched(self):
+        """x ** 2 must not be affected by pow_zero."""
+        df = st.as_data_op(5)
+        t1 = df ** 2
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_pow_one_untouched(self):
+        """x ** 1 must not be affected (identity, not annihilator)."""
+        df = st.as_data_op(5)
+        t1 = df ** 1
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_disable_pow_zero_does_not_affect_log_exp(self):
+        """Disabling pow_zero must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_zero=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -183,6 +183,16 @@ class TestNumericOps(unittest.TestCase):
         result = op.process("fit", [np.array([6.0, 8.0, 9.0]), np.array([2.0, 4.0, 3.0])])
         np.testing.assert_array_almost_equal(result, np.array([3.0, 2.0, 3.0]))
 
+    def test_process_pow_var_const(self):
+        op = NumericOp([], [], type=NumericOpType.POW, constant=3, reversed=False)
+        result = op.process("fit", [np.array([1.0, 2.0, 3.0])])
+        np.testing.assert_array_almost_equal(result, np.array([1.0, 8.0, 27.0]))
+
+    def test_process_pow_var_var(self):
+        op = NumericOp([], [], type=NumericOpType.POW, opt_operand=OperandRef(1), reversed=False)
+        result = op.process("fit", [np.array([2.0, 3.0, 4.0]), np.array([3.0, 2.0, 1.0])])
+        np.testing.assert_array_almost_equal(result, np.array([8.0, 9.0, 4.0]))
+
     def _assert_var_var_extracted(self, out, numeric_type):
         ops = [op for op in out if isinstance(op, NumericOp) and op.type == numeric_type]
         self.assertEqual(len(ops), 1)


### PR DESCRIPTION
### Adds `x ** 0 -> 1` annihilator rewrite (#135) 

- Matches `BinOp(pow)` where the right operand is `0` and the left is a variable (`OperandRef`), not a constant - so `0**0` is deliberately not rewritten.
- Replaces the entire `BinOp` node with `ValueOp(1)`, removing the computation from the DAG entirely.
- Controlled by the `pow_zero` flag in `AlgebraicRewritesConfig`.