### PR TITLE
[Rewrite] Add constant folding for numeric operations (#136)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -6,7 +6,8 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_log1p_expm1,
     eliminate_sqrt_square,
     eliminate_identity_operation,
-    eliminate_abs_abs
+    eliminate_abs_abs,
+    eliminate_constant_folding,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -24,6 +25,7 @@ class AlgebraicRewritesConfig:
     expm1_log1p: bool = True
     identity_op: bool = True
     abs_abs: bool = True
+    constant_folding: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -43,5 +45,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_expm1_log1p(root)
     if config.identity_op:
         root = eliminate_identity_operation(root)
+    if config.constant_folding:
+        root = eliminate_constant_folding(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,6 +1,6 @@
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
-from stratum.optimizer.ir._ops import Op
+from stratum.optimizer.ir._ops import Op, ValueOp
 
 
 def match_two_op_chain(op_cls, type1, type2):
@@ -78,6 +78,40 @@ def make_replace_two_op_chain_root_safe(make_replacement):
     return action
 
 
+def match_constant_foldable(op):
+    """Match a NumericOp whose variable inputs are all ValueOps (constants).
+
+    For binary ops with a constant operand (``opt_operand is None``) only the
+    primary input must be a ValueOp; the constant side is already a Python scalar.
+    For var-var binary ops both inputs must be ValueOps.
+    """
+    if not isinstance(op, NumericOp):
+        return None
+    if not op.inputs:
+        return None
+    if op.opt_operand is not None:
+        # var-var binary: every input must be a ValueOp
+        if not all(isinstance(inp, ValueOp) for inp in op.inputs):
+            return None
+    else:
+        # unary or var-const binary: only the primary input must be a ValueOp
+        if not isinstance(op.inputs[0], ValueOp):
+            return None
+    return (op,)
+
+
+def fold_constant_op_root_safe(op, root):
+    """Evaluate *op* with its constant inputs and replace it with a ValueOp."""
+    input_values = [inp.value for inp in op.inputs]
+    result = op.process("fit", input_values)
+    new_op = ValueOp(result)
+    replace_op_in_outputs(op, new_op)
+    if op is root:
+        root = new_op
+    return root
+
+
+
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -115,4 +149,9 @@ eliminate_identity_operation = rewrite_pass(
 eliminate_abs_abs = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.ABS, NumericOpType.ABS),
     _replace_with_abs,
+)
+
+eliminate_constant_folding = rewrite_pass(
+    match_constant_foldable,
+    fold_constant_op_root_safe,
 )

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -163,7 +163,7 @@ def extract_numeric_op(op: Op, root: Op) -> tuple[Op, bool]:
         elif op.func in _NUMPY_BINARY_MAP:
             new_op = make_binary_numeric_op(op, _NUMPY_BINARY_MAP[op.func])
         # if op is some other function from np package, make a generic numeric op
-        elif op.func.__module__ == "numpy" and op.func not in _BINARY_NUMPY_FUNCS:
+        elif getattr(op.func, '__module__', op.func.__class__.__module__) == "numpy" and op.func not in _BINARY_NUMPY_FUNCS:
             new_op = make_unary_numeric_op(op)
 
     if new_op is None:

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -317,3 +317,142 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
+
+    # --- constant folding -------------------------------------------------
+
+    def test_constant_folding_log1(self):
+        """log(1) → 0"""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0.0)
+
+    def test_constant_folding_exp0(self):
+        """exp(0) → 1"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1.0)
+
+    def test_constant_folding_abs(self):
+        """abs(-5) → 5"""
+        df = st.as_data_op(-5)
+        t1 = df.skb.apply_func(np.abs)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_constant_folding_sqrt(self):
+        """sqrt(4) → 2"""
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 2.0)
+
+    def test_constant_folding_square(self):
+        """square(3) → 9"""
+        df = st.as_data_op(3)
+        t1 = df.skb.apply_func(np.square)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 9)
+
+    def test_constant_folding_log1p(self):
+        """log1p(e-1) → 1"""
+        df = st.as_data_op(np.e - 1)
+        t1 = df.skb.apply_func(np.log1p)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        np.testing.assert_almost_equal(out[0].value, 1.0)
+
+    def test_constant_folding_expm1(self):
+        """expm1(1) → e-1"""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.expm1)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, np.expm1(1))
+
+    def test_constant_folding_sin0(self):
+        """sin(0) → 0 (GENERIC numeric op)"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.sin)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0.0)
+
+    def test_constant_folding_cos0(self):
+        """cos(0) → 1 (GENERIC numeric op)"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.cos)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1.0)
+
+    def test_constant_folding_add_var_var(self):
+        """5 + 3 → 8 (binary var-var)"""
+        df1 = st.as_data_op(5)
+        df2 = st.as_data_op(3)
+        t1 = df1 + df2
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 8)
+
+    def test_constant_folding_add_var_const(self):
+        """5 + 3 → 8 (binary var-const)"""
+        df = st.as_data_op(5)
+        t1 = df + 3
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 8)
+
+    def test_constant_folding_cascade(self):
+        """sqrt(abs(-4)) → 2 (two-level cascade)"""
+        df = st.as_data_op(-4)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 2.0)
+
+    def test_constant_folding_disabled(self):
+        """Disabling constant_folding must leave log(1) as a NumericOp."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)  # ValueOp + NumericOp
+
+    def test_disable_constant_folding_does_not_affect_log_exp(self):
+        """Disabling constant_folding must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)  # log(exp(x)) eliminated
+        self.assertEqual(out[0].value, 1)
+

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -23,7 +23,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.exp)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 1)
 
@@ -42,7 +43,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.log)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 1)
 
@@ -70,14 +72,15 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_expm1_log1p_disabled(self):
         df = st.as_data_op(1)
         t1 = df.skb.apply_func(np.expm1)
         t2 = t1.skb.apply_func(np.log1p)
-        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(log1p_expm1 = False,expm1_log1p = False))
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(log1p_expm1 = False,expm1_log1p = False, constant_folding=False))
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
         self.assertEqual(out[0].value, 1)
@@ -88,7 +91,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.log1p)
         t3 = t2.skb.apply_func(np.exp)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 4)
 
     def test_log1p_log1p_exp(self):
@@ -97,7 +101,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log1p)
         t2 = t1.skb.apply_func(np.log1p)
         t3 = t2.skb.apply_func(np.exp)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 4)
 
     def test_disable_log_exp_rewrite1(self):
@@ -107,7 +112,7 @@ class TestCSE(unittest.TestCase):
 
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(log_exp=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(log_exp=False, constant_folding=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -129,7 +134,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         # abs(4) = 4
         self.assertEqual(out[0].value, 4)
@@ -139,7 +145,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 2
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         # abs(-3) = 3
         self.assertEqual(out[0].value, -3)
@@ -150,7 +157,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.sqrt)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 3)
         self.assertEqual(out[0].value, 4)
 
@@ -161,7 +169,7 @@ class TestCSE(unittest.TestCase):
 
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False, constant_folding=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -170,7 +178,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(4)
         t1 = df.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t1)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
 
     def test_sqrt_square_produces_abs_op(self):
@@ -179,7 +188,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ABS)
@@ -190,7 +200,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 2
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ABS)
@@ -200,7 +211,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.log)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_sqrt_exp(self):
@@ -208,7 +220,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.sqrt)
         t2 = t1.skb.apply_func(np.exp)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_pow3_sqrt(self):
@@ -217,7 +230,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 3
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_disable_sqrt_square_does_not_affect_log_exp(self):
@@ -238,7 +252,8 @@ class TestCSE(unittest.TestCase):
         t1 = df * 1
         t2 = t1 + 3
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 5)
 
@@ -246,7 +261,7 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(2)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_op=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_op=False, constant_folding=False),
         )
         t1 = df * 1
         t2 = t1 + 3
@@ -269,7 +284,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(-3)
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.abs)
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
 
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
@@ -278,7 +294,8 @@ class TestCSE(unittest.TestCase):
     def test_single_abs_untouched(self):
         df = st.as_data_op(-3)
         t1 = df.skb.apply_func(np.abs)
-        out, *_ = optimize(t1)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
 
     def test_abs_abs_with_trailing_op(self):
@@ -286,14 +303,16 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.abs)
         t3 = t2.skb.apply_func(np.log1p)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_abs_sqrt(self):
         df = st.as_data_op(4)
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.sqrt)
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_abs_abs_disabled(self):
@@ -302,7 +321,7 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.abs)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False)
+            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False, constant_folding=False)
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
@@ -1,11 +1,17 @@
 import unittest
 import stratum as st
 import numpy as np
-from stratum.optimizer._optimize import optimize
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer.ir._ops import ValueOp
 
 class TestNumericComplexFanout(unittest.TestCase):
+
+    def _opt(self, dag):
+        return optimize(dag, OptConfig(
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        ))
 
     def test_fanout_before_and_after_chain(self):
         """
@@ -32,7 +38,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         t1 = d + b
         final = t1 + c
         
-        linearized_dag, *_ = optimize(final)
+        linearized_dag, *_ = self._opt(final)
         
         # 1. Find the original 'a' Op
         a_op = linearized_dag[0]
@@ -68,7 +74,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         c = exp_log_a + 2.0
         final = b + c
 
-        linearized_dag, *_ = optimize(final)
+        linearized_dag, *_ = self._opt(final)
 
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)
@@ -95,7 +101,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         log_a = a.skb.apply_func(np.log)
         exp_log_a = log_a.skb.apply_func(np.exp)
 
-        linearized_dag, *_ = optimize(exp_log_a)
+        linearized_dag, *_ = self._opt(exp_log_a)
 
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)
@@ -126,7 +132,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         d = a + 10.0
         
         combined = exp_log_a + d
-        linearized_dag, *_ = optimize(combined)
+        linearized_dag, *_ = self._opt(combined)
         
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -6,9 +6,15 @@ import numpy as np
 from sklearn.dummy import DummyRegressor
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType, make_binary_numeric_op
 from stratum.optimizer.ir._ops import CallOp, OperandRef
-from stratum.optimizer._optimize import optimize
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 
 class TestNumericOps(unittest.TestCase):
+    def _opt(self, dag):
+        return optimize(dag, OptConfig(
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        ))
+
     def setUp(self):
         self.df = pd.DataFrame({
             "x": [1, 2, 3],
@@ -121,7 +127,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_add_var_const(self):
         df = st.as_data_op(5)
         t1 = df + 3
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ADD)
@@ -131,7 +137,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_add_const_var(self):
         df = st.as_data_op(5)
         t1 = 3 + df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ADD)
@@ -141,7 +147,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_subtract_var_const(self):
         df = st.as_data_op(5)
         t1 = df - 2
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.SUBTRACT)
@@ -149,7 +155,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_multiply_var_const(self):
         df = st.as_data_op(5)
         t1 = df * 4
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.MULTIPLY)
@@ -157,7 +163,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_divide_var_const(self):
         df = st.as_data_op(10)
         t1 = df / 2
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.DIVIDE)
@@ -195,35 +201,35 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_binop_add_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1 + df2)
+        out, *_ = self._opt(df1 + df2)
         op = self._assert_var_var_extracted(out, NumericOpType.ADD)
         self.assertEqual(op.process("fit", [2, 3]), 5)
 
     def test_extract_binop_subtract_var_var(self):
         df1 = st.as_data_op(10)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1 - df2)
+        out, *_ = self._opt(df1 - df2)
         op = self._assert_var_var_extracted(out, NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [10, 3]), 7)
 
     def test_extract_binop_multiply_var_var(self):
         df1 = st.as_data_op(4)
         df2 = st.as_data_op(5)
-        out, *_ = optimize(df1 * df2)
+        out, *_ = self._opt(df1 * df2)
         op = self._assert_var_var_extracted(out, NumericOpType.MULTIPLY)
         self.assertEqual(op.process("fit", [4, 5]), 20)
 
     def test_extract_binop_divide_var_var(self):
         df1 = st.as_data_op(12)
         df2 = st.as_data_op(4)
-        out, *_ = optimize(df1 / df2)
+        out, *_ = self._opt(df1 / df2)
         op = self._assert_var_var_extracted(out, NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [12, 4]), 3.0)
 
     def test_extract_add_produces_correct_result(self):
         df = st.as_data_op(5)
         t1 = df + 3
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         add_op = next(op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.ADD)
         self.assertEqual(add_op.process("fit", [5]), 8)
 
@@ -231,7 +237,7 @@ class TestNumericOps(unittest.TestCase):
         """CallOp with np.add should be extracted to NumericOp ADD."""
         df = st.as_data_op(5)
         t1 = df.skb.apply_func(np.add, 3)
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         add_ops = [op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.ADD]
         self.assertEqual(len(add_ops), 1)
 
@@ -239,49 +245,49 @@ class TestNumericOps(unittest.TestCase):
         """CallOp with np.multiply should be extracted to NumericOp MULTIPLY."""
         df = st.as_data_op(5)
         t1 = df.skb.apply_func(np.multiply, 4)
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         mul_ops = [op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.MULTIPLY]
         self.assertEqual(len(mul_ops), 1)
 
     def test_extract_callop_add_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.add, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.add, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.ADD)
         self.assertEqual(op.process("fit", [2, 3]), 5)
 
     def test_extract_callop_subtract_var_var(self):
         df1 = st.as_data_op(5)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.subtract, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.subtract, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [5, 3]), 2)
 
     def test_extract_callop_multiply_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.multiply, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.multiply, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.MULTIPLY)
         self.assertEqual(op.process("fit", [2, 3]), 6)
 
     def test_extract_callop_divide_var_var(self):
         df1 = st.as_data_op(6)
         df2 = st.as_data_op(2)
-        out, *_ = optimize(df1.skb.apply_func(np.divide, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.divide, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [6, 2]), 3.0)
 
     def test_extract_subtract_const_var_produces_correct_result(self):
         df = st.as_data_op(3)
         t1 = 10 - df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         op = next(o for o in out if isinstance(o, NumericOp) and o.type == NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [3]), 7)
 
     def test_extract_divide_const_var_produces_correct_result(self):
         df = st.as_data_op(4)
         t1 = 12 / df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         op = next(o for o in out if isinstance(o, NumericOp) and o.type == NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [4]), 3.0)
 

--- a/stratum/tests/logical_optimizer/test_op_utils.py
+++ b/stratum/tests/logical_optimizer/test_op_utils.py
@@ -2,6 +2,7 @@
 import unittest
 import stratum as st
 from stratum.optimizer._optimize import optimize as optimize_, OptConfig, choice_unrolling, convert_to_ops
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer._op_utils import (
     show_graph, clone_sub_dag, topological_iterator, validate_operands,
     validate_dag, compute_graph_node_indegree, FLAGS,
@@ -13,6 +14,8 @@ from stratum._config import config
 graph = False
 
 def optimize(dag, conf=None):
+    if conf is None:
+        conf = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
     linearized_dag, *_ = optimize_(dag, conf)
     return linearized_dag
 


### PR DESCRIPTION
## Adds constant folding `f(constant_inputs...) -> constant` for numeric operations (#136)

Adds `eliminate_constant_folding` - evaluates `NumericOp` nodes at compile time when all their inputs are `ValueOp` constants, replacing the entire op with the computed result. This collapses chains like `log(1) → sqrt(4) → abs(-5)` down to single constants before runtime.
#### Before:  log(1) -> sqrt(4)  _(chain of ops in the DAG)_
#### After:   ValueOp(0.0) -> ValueOp(2.0)  _(single constant)_

### Known issues
Any test that builds a DAG from `st.as_data_op(N)` (a constant scalar) and then asserts on DAG structure (op count, op types, fan-out edges, etc.) will be affected: constant folding collapses the entire chain to a single `ValueOp(result)`. Such tests must opt out via:
```
config = OptConfig(
    algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
)
out, *_ = optimize(dag, config=config)
```

This is the main reason for the conflicts.