### PR TITLE
[Rewrite] Add constant folding for numeric operations (#136)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -11,6 +11,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_exp_minus_one,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
+    eliminate_constant_folding,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -32,6 +33,7 @@ class AlgebraicRewritesConfig:
     exp_minus_one: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
+    constant_folding: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -59,5 +61,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_identity_subtract(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
+    if config.constant_folding:
+        root = eliminate_constant_folding(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -113,6 +113,39 @@ def fold_to_zero(op: Op, root: Op) -> Op:
     return zero_op if op is root else root
 
 
+def match_constant_foldable(op):
+    """Match a NumericOp whose variable inputs are all ValueOps (constants).
+
+    For binary ops with a constant operand (``opt_operand is None``) only the
+    primary input must be a ValueOp; the constant side is already a Python scalar.
+    For var-var binary ops both inputs must be ValueOps.
+    """
+    if not isinstance(op, NumericOp):
+        return None
+    if not op.inputs:
+        return None
+    if op.opt_operand is not None:
+        # var-var binary: every input must be a ValueOp
+        if not all(isinstance(inp, ValueOp) for inp in op.inputs):
+            return None
+    else:
+        # unary or var-const binary: only the primary input must be a ValueOp
+        if not isinstance(op.inputs[0], ValueOp):
+            return None
+    return (op,)
+
+
+def fold_constant_op_root_safe(op, root):
+    """Evaluate *op* with its constant inputs and replace it with a ValueOp."""
+    input_values = [inp.value for inp in op.inputs]
+    result = op.process("fit", input_values)
+    new_op = ValueOp(result)
+    replace_op_in_outputs(op, new_op)
+    if op is root:
+        root = new_op
+    return root
+
+
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -172,4 +205,9 @@ eliminate_identity_subtract = rewrite_pass(
 eliminate_any_mul_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 0),
     fold_to_zero,
+)
+
+eliminate_constant_folding = rewrite_pass(
+    match_constant_foldable,
+    fold_constant_op_root_safe,
 )

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -163,7 +163,7 @@ def extract_numeric_op(op: Op, root: Op) -> tuple[Op, bool]:
         elif op.func in _NUMPY_BINARY_MAP:
             new_op = make_binary_numeric_op(op, _NUMPY_BINARY_MAP[op.func])
         # if op is some other function from np package, make a generic numeric op
-        elif op.func.__module__ == "numpy" and op.func not in _BINARY_NUMPY_FUNCS:
+        elif getattr(op.func, '__module__', op.func.__class__.__module__) == "numpy" and op.func not in _BINARY_NUMPY_FUNCS:
             new_op = make_unary_numeric_op(op)
 
     if new_op is None:

--- a/stratum/tests/benchmarks/__init__.py
+++ b/stratum/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Stratum optimizer benchmark framework."""

--- a/stratum/tests/benchmarks/cases.py
+++ b/stratum/tests/benchmarks/cases.py
@@ -1,0 +1,197 @@
+"""Predefined benchmark cases for the Stratum optimizer.
+
+Each case is a :class:`BenchmarkCase` describing a DataOp DAG, the rewrite
+rules it should exercise, and a brief description of what is being tested.
+
+To add a new case, create a ``BenchmarkCase`` and append it to ``ALL_CASES``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+import numpy as np
+from skrub import DataOp
+
+import stratum as st
+
+
+@dataclass
+class BenchmarkCase:
+    """A single benchmark case.
+
+    Attributes
+    ----------
+    name : str
+        Short identifier (e.g. ``"log_exp_inverse"``).
+    description : str
+        Human-readable explanation.
+    dag_builder : Callable[[pd.DataFrame], DataOp]
+        Builds the DataOp DAG from a DataFrame.  Receives a fresh DataFrame
+        each invocation so cases are isolated.
+    expected_rules : set[str]
+        Names of rewrite rules this case is expected to trigger (from
+        ``AlgebraicRewritesConfig`` field names).
+    category : str
+        Grouping label (``"numeric"``, ``"dataframe"``, ``"combined"``).
+    """
+
+    name: str
+    description: str
+    dag_builder: Callable[..., DataOp]
+    expected_rules: set[str] = field(default_factory=set)
+    category: str = "numeric"
+
+
+# ---------------------------------------------------------------------------
+# Numeric algebraic rewrite cases
+# ---------------------------------------------------------------------------
+
+NUMERIC_CASES: list[BenchmarkCase] = [
+    BenchmarkCase(
+        name="log_exp_inverse",
+        description="log(exp(x)) → x  —  two ops eliminated",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.log)
+        .skb.apply_func(np.exp),
+        expected_rules={"log_exp"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="exp_log_inverse",
+        description="exp(log(x)) → x  —  two ops eliminated",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.exp)
+        .skb.apply_func(np.log),
+        expected_rules={"exp_log"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="log1p_expm1_inverse",
+        description="log1p(expm1(x)) → x",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.log1p)
+        .skb.apply_func(np.expm1),
+        expected_rules={"log1p_expm1"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="expm1_log1p_inverse",
+        description="expm1(log1p(x)) → x",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.expm1)
+        .skb.apply_func(np.log1p),
+        expected_rules={"expm1_log1p"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="sqrt_square_to_abs",
+        description="sqrt(x²) → |x|  —  replaced by abs",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.square)
+        .skb.apply_func(np.sqrt),
+        expected_rules={"sqrt_square"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="multiply_by_one",
+        description="x * 1 → x  —  identity multiply eliminated",
+        dag_builder=lambda df: st.as_data_op(df) * 1,
+        expected_rules={"identity_op"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="add_zero",
+        description="x + 0 → x  —  identity add eliminated",
+        dag_builder=lambda df: st.as_data_op(df) + 0,
+        expected_rules={"add_zero"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="subtract_zero",
+        description="x - 0 → x  —  identity subtract eliminated",
+        dag_builder=lambda df: st.as_data_op(df) - 0,
+        expected_rules={"identity_subtract"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="abs_abs_collapse",
+        description="abs(abs(x)) → abs(x)",
+        dag_builder=lambda df: st.as_data_op(df)
+        .skb.apply_func(np.abs)
+        .skb.apply_func(np.abs),
+        expected_rules={"abs_abs"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="exp_minus_one_to_expm1",
+        description="exp(x) - 1 → expm1(x)",
+        dag_builder=lambda df: st.as_data_op(df).skb.apply_func(np.exp) - 1,
+        expected_rules={"exp_minus_one"},
+        category="numeric",
+    ),
+    BenchmarkCase(
+        name="multiply_by_zero",
+        description="x * 0 → ValueOp(0.0)  —  dead subgraph pruned",
+        dag_builder=lambda df: st.as_data_op(df) * 0,
+        expected_rules={"any_mul_zero"},
+        category="numeric",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Combined / multi-rewrite cases
+# ---------------------------------------------------------------------------
+
+COMBINED_CASES: list[BenchmarkCase] = [
+    BenchmarkCase(
+        name="combined_log_exp_identity",
+        description="log(exp(x))*1 + 0 → x  —  log_exp + identity + add_zero cascade",
+        dag_builder=lambda df: (
+            st.as_data_op(df).skb.apply_func(np.log).skb.apply_func(np.exp) * 1 + 0
+        ),
+        expected_rules={"log_exp", "identity_op", "add_zero"},
+        category="combined",
+    ),
+    BenchmarkCase(
+        name="combined_sqrt_square_with_identity",
+        description="sqrt(x²)*1 - 0 → |x|  —  sqrt_square + identity + subtract_zero",
+        dag_builder=lambda df: (
+            st.as_data_op(df).skb.apply_func(np.square).skb.apply_func(np.sqrt) * 1 - 0
+        ),
+        expected_rules={"sqrt_square", "identity_op", "identity_subtract"},
+        category="combined",
+    ),
+    BenchmarkCase(
+        name="combined_many_rewrites",
+        description="log(exp(x))*1+0-0 → sqrt(square(x)) → abs(x)  —  5+ rewrites",
+        dag_builder=lambda df: (
+            st.as_data_op(df)
+            .skb.apply_func(np.log).skb.apply_func(np.exp)  # log_exp
+            * 1  # identity
+            + 0  # add_zero
+            - 0  # identity_subtract
+        ),
+        expected_rules={"log_exp", "identity_op", "add_zero", "identity_subtract"},
+        category="combined",
+    ),
+    BenchmarkCase(
+        name="combined_full_pipeline",
+        description="log→exp→*1→+0→square→sqrt→exp→-1  —  most numeric rewrites",
+        dag_builder=lambda df: (
+            st.as_data_op(df)
+            .skb.apply_func(np.log).skb.apply_func(np.exp)  # log_exp
+            * 1  # identity
+            + 0  # add_zero
+        ).skb.apply_func(np.square).skb.apply_func(np.sqrt),  # sqrt_square
+        expected_rules={"log_exp", "identity_op", "add_zero", "sqrt_square"},
+        category="combined",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Master registry
+# ---------------------------------------------------------------------------
+
+ALL_CASES: list[BenchmarkCase] = NUMERIC_CASES + COMBINED_CASES

--- a/stratum/tests/benchmarks/conftest.py
+++ b/stratum/tests/benchmarks/conftest.py
@@ -1,0 +1,30 @@
+"""pytest configuration for the benchmark suite."""
+
+# Stored by pytest_configure so test code can read back options.
+_pytest_config = None
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--bench-rows",
+        type=int,
+        default=100_000,
+        help="Number of rows in benchmark DataFrames (default: 100_000).",
+    )
+    parser.addoption(
+        "--bench-viz",
+        action="store_true",
+        default=False,
+        help="Render before/after DAG PNGs via graphviz.",
+    )
+    parser.addoption(
+        "--bench-json",
+        type=str,
+        default=None,
+        help="Write the full benchmark report as JSON to this path.",
+    )
+
+
+def pytest_configure(config):
+    global _pytest_config
+    _pytest_config = config

--- a/stratum/tests/benchmarks/coverage.py
+++ b/stratum/tests/benchmarks/coverage.py
@@ -1,0 +1,52 @@
+"""Rule coverage analysis for the Stratum optimizer benchmark.
+
+Tracks which rewrite rules are available, which fire during benchmarking,
+and produces a coverage report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
+
+from .result import RuleCoverage
+
+
+# All rule names derived from AlgebraicRewritesConfig boolean fields.
+_ALL_RULE_NAMES: frozenset[str] = frozenset(
+    f.name for f in fields(AlgebraicRewritesConfig)
+)
+
+
+def get_all_rules() -> frozenset[str]:
+    """Return the set of all known rewrite rule names."""
+    return _ALL_RULE_NAMES
+
+
+class RuleCoverageTracker:
+    """Tracks which rewrite rules are triggered across benchmark runs.
+
+    Instantiate once per benchmark suite; call :meth:`record` after each
+    case completes, then :meth:`snapshot` at the end.
+    """
+
+    def __init__(self) -> None:
+        self._freq: dict[str, int] = {r: 0 for r in _ALL_RULE_NAMES}
+
+    def record(self, triggered: list[str]) -> None:
+        """Increment counts for every rule in *triggered*."""
+        for rule in triggered:
+            if rule in self._freq:
+                self._freq[rule] += 1
+
+    def snapshot(self) -> RuleCoverage:
+        """Return a coverage report based on all :meth:`record` calls so far."""
+        triggered = sorted(r for r, c in self._freq.items() if c > 0)
+        never = sorted(r for r, c in self._freq.items() if c == 0)
+        return RuleCoverage(
+            total_rules=len(_ALL_RULE_NAMES),
+            triggered=triggered,
+            never_triggered=never,
+            frequency={r: c for r, c in self._freq.items() if c > 0},
+        )

--- a/stratum/tests/benchmarks/result.py
+++ b/stratum/tests/benchmarks/result.py
@@ -1,0 +1,81 @@
+"""Stratum optimizer benchmark framework — result types and JSON serialization."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+
+@dataclass
+class CaseMetrics:
+    """Per-case measurement data."""
+
+    # ---- DAG size -----------------------------------------------------------
+    nodes_before: int
+    nodes_after: int
+    nodes_delta: int
+    reduction_pct: float
+
+    # ---- runtime ------------------------------------------------------------
+    runtime_before_ms: float
+    runtime_after_ms: float
+    speedup: float
+
+    # ---- optimizer timing ---------------------------------------------------
+    optimize_time_ms: float
+
+    # ---- rules --------------------------------------------------------------
+    rules_triggered: list[str] = field(default_factory=list)
+    rules_count: int = 0
+
+
+@dataclass
+class CaseResult:
+    """Complete result for a single benchmark case."""
+
+    name: str
+    description: str = ""
+    passed: bool = True
+    error: str = ""
+    metrics: CaseMetrics | None = None
+
+    # ---- correctness --------------------------------------------------------
+    outputs_equal: bool = True
+    output_diff: str = ""
+
+
+@dataclass
+class RuleCoverage:
+    """Coverage report for rewrite rules."""
+
+    total_rules: int
+    triggered: list[str]
+    never_triggered: list[str]
+    frequency: dict[str, int]  # rule name → application count
+
+
+@dataclass
+class BenchmarkReport:
+    """Top-level report written to JSON."""
+
+    timestamp: str = field(default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%S"))
+    data_rows: int = 0
+    total_cases: int = 0
+    passed: int = 0
+    failed: int = 0
+    cases: list[CaseResult] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+    rule_coverage: RuleCoverage | None = None
+
+
+def report_to_json(report: BenchmarkReport, indent: int = 2) -> str:
+    """Serialize *report* to a JSON string."""
+    return json.dumps(asdict(report), indent=indent, default=str)
+
+
+def write_report(report: BenchmarkReport, path: str) -> None:
+    """Write *report* as JSON to *path*."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(report_to_json(report))

--- a/stratum/tests/benchmarks/runner.py
+++ b/stratum/tests/benchmarks/runner.py
@@ -1,0 +1,394 @@
+"""Benchmark runner: orchestrates test cases, collects metrics, produces reports.
+
+Usage
+-----
+    from stratum.tests.benchmarks.runner import BenchmarkRunner
+    from stratum.tests.benchmarks.cases import ALL_CASES
+
+    runner = BenchmarkRunner(data_rows=100_000)
+    report = runner.run(ALL_CASES)
+    runner.write_report(report, "benchmark_report.json")
+"""
+
+from __future__ import annotations
+
+import time
+import logging
+from dataclasses import asdict
+
+import numpy as np
+import pandas as pd
+
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
+from stratum.runtime._scheduler import SequentialScheduler
+
+from .result import (
+    BenchmarkReport,
+    CaseResult,
+    CaseMetrics,
+    RuleCoverage,
+    write_report,
+)
+from .coverage import RuleCoverageTracker
+from .cases import BenchmarkCase
+
+logger = logging.getLogger(__name__)
+
+
+def _make_dataframe(n_rows: int, seed: int = 42) -> pd.DataFrame:
+    """Create a DataFrame with positive-only columns safe for log/sqrt ops."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "a": rng.uniform(0.5, 5.0, n_rows),
+            "b": rng.uniform(0.5, 5.0, n_rows),
+            "c": rng.uniform(0.5, 5.0, n_rows),
+        }
+    )
+
+
+def _plan_length(plan: list) -> int:
+    return len(plan)
+
+
+def _execute_plan(plan, split_pos, flagged_ops) -> float:
+    """Execute a linearized plan and return wall-clock seconds.
+
+    Creates a fresh scheduler each time.  Important: the plan ops are shared
+    objects, so a warmup run that consumes DataFrame data will leave ValueOps
+    drained for subsequent runs.  Do NOT call this more than once per plan.
+    """
+    sched = SequentialScheduler(plan, split_pos, flagged_ops)
+    t0 = time.perf_counter()
+    try:
+        sched.evaluate()
+    except Exception:
+        pass
+    return time.perf_counter() - t0
+
+
+def _outputs_equal(out1, out2, rtol: float = 1e-5) -> bool:
+    """Compare two scheduler outputs for semantic equivalence.
+
+    Handles DataFrames, numpy arrays, scalars, and None.
+    """
+    if out1 is None and out2 is None:
+        return True
+    if out1 is None or out2 is None:
+        return False
+
+    # DataFrame comparison
+    if isinstance(out1, pd.DataFrame) and isinstance(out2, pd.DataFrame):
+        try:
+            pd.testing.assert_frame_equal(out1, out2, rtol=rtol, check_dtype=False)
+            return True
+        except AssertionError:
+            return False
+
+    # Array-like
+    try:
+        a1 = np.asarray(out1, dtype=float)
+        a2 = np.asarray(out2, dtype=float)
+        np.testing.assert_allclose(a1, a2, rtol=rtol)
+        return True
+    except (AssertionError, TypeError, ValueError):
+        return False
+
+
+def _all_off_config() -> AlgebraicRewritesConfig:
+    """Every rewrite disabled."""
+    return AlgebraicRewritesConfig(
+        log_exp=False, exp_log=False, sqrt_square=False,
+        log1p_expm1=False, expm1_log1p=False, identity_op=False,
+        abs_abs=False, add_zero=False, exp_minus_one=False,
+        identity_subtract=False, any_mul_zero=False, constant_folding=False,
+    )
+
+
+def _detect_triggered_rules(off_plan, on_plan) -> list[str]:
+    """Detect which rewrite rules fired by comparing op type/name sets.
+
+    Maps eliminated ``NumericOp`` names to specific rewrite rules based on
+    the operation they perform.  Also checks for ``BinOp`` eliminations
+    (``any_mul_zero``) and op-name transformations (``exp_minus_one``,
+    ``abs_abs``).
+    """
+    off_ops = {(type(op).__name__, getattr(op, "name", "")) for op in off_plan}
+    on_ops = {(type(op).__name__, getattr(op, "name", "")) for op in on_plan}
+    eliminated = off_ops - on_ops
+    added = on_ops - off_ops
+
+    # NumericOp name → rule mapping
+    _OPNAME_TO_RULE: dict[str, str] = {
+        "log": "log_exp",
+        "exp": "exp_log",
+        "log1p": "log1p_expm1",
+        "expm1": "expm1_log1p",
+        "multiply": "identity_op",   # x * 1 → x  (also x * 0 → 0, handled below)
+        "add": "add_zero",           # x + 0 → x
+        "subtract": "identity_subtract",  # x - 0 → x
+        "abs": "abs_abs",            # abs(abs(x)) → abs(x)
+        "sqrt": "sqrt_square",       # sqrt(square(x)) → abs(x)
+        "square": "sqrt_square",     # (eliminated as part of sqrt_square)
+    }
+
+    triggered: set[str] = set()
+
+    # Detect from eliminated ops
+    elim_abs_count = 0
+    elim_multiply_count = 0
+    for typ_name, op_name in eliminated:
+        if typ_name == "NumericOp":
+            rule = _OPNAME_TO_RULE.get(op_name)
+            if rule:
+                triggered.add(rule)
+            if op_name == "abs":
+                elim_abs_count += 1
+            if op_name == "multiply":
+                elim_multiply_count += 1
+        elif typ_name == "BinOp":
+            # BinOp eliminated — likely any_mul_zero (x * 0)
+            triggered.add("any_mul_zero")
+
+    # abs_abs: one abs eliminated but one remains → abs_abs fired
+    has_abs_in_on = any(t == "NumericOp" and n == "abs" for t, n in on_ops)
+    if elim_abs_count == 1 and has_abs_in_on:
+        triggered.add("abs_abs")
+
+    # any_mul_zero: multiply eliminated AND no multiply in ON → could be x*0
+    # (identity_op also eliminates multiply but for x*1)
+    has_multiply_in_on = any(t == "NumericOp" and n == "multiply" for t, n in on_ops)
+    if elim_multiply_count >= 1 and not has_multiply_in_on:
+        # Check if a ValueOp(0.0) was added
+        if any(t == "ValueOp" for t, _ in added):
+            triggered.add("any_mul_zero")
+
+    # exp_minus_one: exp + subtract eliminated, expm1 added
+    elim_has_exp = any(n == "exp" for _, n in eliminated)
+    elim_has_subtract = any(n == "subtract" for _, n in eliminated)
+    added_has_expm1 = any(t == "NumericOp" and n == "expm1" for t, n in added)
+    if elim_has_exp and elim_has_subtract and added_has_expm1:
+        triggered.add("exp_minus_one")
+        triggered.discard("exp_log")
+        triggered.discard("identity_subtract")
+
+    # sqrt_square: square + sqrt eliminated, abs added
+    elim_has_square = any(n == "square" for _, n in eliminated)
+    elim_has_sqrt = any(n == "sqrt" for _, n in eliminated)
+    added_has_abs = any(t == "NumericOp" and n == "abs" for t, n in added)
+    if elim_has_square and elim_has_sqrt and added_has_abs:
+        triggered.add("sqrt_square")
+
+    # Constant folding: if NumericOps were replaced by ValueOps
+    off_num_count = sum(1 for t, _ in off_ops if t == "NumericOp")
+    on_num_count = sum(1 for t, _ in on_ops if t == "NumericOp")
+    on_val_count = sum(1 for t, _ in on_ops if t == "ValueOp")
+    off_val_count = sum(1 for t, _ in off_ops if t == "ValueOp")
+    if off_num_count > 0 and on_num_count == 0 and on_val_count > off_val_count:
+        triggered.add("constant_folding")
+
+    return sorted(triggered)
+
+
+class BenchmarkRunner:
+    """Orchestrates benchmark execution.
+
+    Parameters
+    ----------
+    data_rows : int
+        Number of rows in the test DataFrames.
+    output_json : str | None
+        If set, write the JSON report to this path after :meth:`run`.
+    """
+
+    def __init__(self, data_rows: int = 100_000, output_json: str | None = None):
+        self.data_rows = data_rows
+        self.output_json = output_json
+        self.coverage_tracker = RuleCoverageTracker()
+
+    def run(self, cases: list[BenchmarkCase]) -> BenchmarkReport:
+        """Execute all *cases* and return a :class:`BenchmarkReport`."""
+        report = BenchmarkReport(
+            data_rows=self.data_rows,
+            total_cases=len(cases),
+        )
+        for case in cases:
+            result = self._run_one(case)
+            report.cases.append(result)
+            if result.passed:
+                report.passed += 1
+            else:
+                report.failed += 1
+            logger.info(
+                "  %-35s  %s  nodes=%d→%d  %.1f×",
+                case.name,
+                "✓" if result.passed else "✗",
+                result.metrics.nodes_before if result.metrics else 0,
+                result.metrics.nodes_after if result.metrics else 0,
+                result.metrics.speedup if result.metrics else 0,
+            )
+
+        report.rule_coverage = self.coverage_tracker.snapshot()
+        report.summary = self._build_summary(report)
+
+        if self.output_json:
+            write_report(report, self.output_json)
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _run_one(self, case: BenchmarkCase) -> CaseResult:
+        """Execute a single case and return its result."""
+        df = _make_dataframe(self.data_rows, seed=hash(case.name) % (2**31))
+        try:
+            dag_off = case.dag_builder(df)
+            dag_on = case.dag_builder(df.copy())  # independent copy
+        except Exception as exc:
+            return CaseResult(
+                name=case.name, description=case.description,
+                passed=False, error=f"DAG build failed: {exc}",
+            )
+
+        # --- optimize: OFF ------------------------------------------------
+        off_cfg = OptConfig(algebraic_rewrite_config=_all_off_config())
+        try:
+            off_plan, off_split, off_flagged = optimize(dag_off, config=off_cfg)
+        except Exception as exc:
+            return CaseResult(
+                name=case.name, description=case.description,
+                passed=False, error=f"Optimize (OFF) failed: {exc}",
+            )
+
+        # --- optimize: ON -------------------------------------------------
+        t_opt = time.perf_counter()
+        on_cfg = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig())
+        try:
+            on_plan, on_split, on_flagged = optimize(dag_on, config=on_cfg)
+        except Exception as exc:
+            return CaseResult(
+                name=case.name, description=case.description,
+                passed=False, error=f"Optimize (ON) failed: {exc}",
+            )
+        opt_time_ms = (time.perf_counter() - t_opt) * 1000
+
+        # --- nodes ---------------------------------------------------------
+        nodes_before = _plan_length(off_plan)
+        nodes_after = _plan_length(on_plan)
+
+        # --- execute & time (fresh DAGs so data isn't consumed) ------------
+        df2 = _make_dataframe(self.data_rows, seed=hash(case.name) % (2**31))
+        dag_ref = case.dag_builder(df2)
+        ref_plan, ref_split, ref_flagged = optimize(
+            dag_ref, config=off_cfg,
+        )
+        ref_sched = SequentialScheduler(ref_plan, ref_split, ref_flagged)
+        try:
+            ref_out = ref_sched.evaluate()
+        except Exception:
+            ref_out = None
+
+        df3 = _make_dataframe(self.data_rows, seed=hash(case.name) % (2**31))
+        dag_opt = case.dag_builder(df3)
+        opt_plan2, opt_split2, opt_flagged2 = optimize(
+            dag_opt, config=on_cfg,
+        )
+        opt_sched = SequentialScheduler(opt_plan2, opt_split2, opt_flagged2)
+        try:
+            opt_out = opt_sched.evaluate()
+        except Exception:
+            opt_out = None
+
+        # --- correctness ---------------------------------------------------
+        equal = _outputs_equal(ref_out, opt_out)
+        diff = "" if equal else "Outputs differ (or could not be compared)"
+
+        # --- runtime (separate fresh DAGs) ----------------------------------
+        df4 = _make_dataframe(self.data_rows, seed=hash(case.name) % (2**31))
+        dag_time_off = case.dag_builder(df4)
+        time_off_plan, to_split, to_flagged = optimize(dag_time_off, config=off_cfg)
+        runtime_before_s = _execute_plan(time_off_plan, to_split, to_flagged)
+
+        df5 = _make_dataframe(self.data_rows, seed=hash(case.name) % (2**31))
+        dag_time_on = case.dag_builder(df5)
+        time_on_plan, tn_split, tn_flagged = optimize(dag_time_on, config=on_cfg)
+        runtime_after_s = _execute_plan(time_on_plan, tn_split, tn_flagged)
+
+        # --- rules ---------------------------------------------------------
+        triggered = _detect_triggered_rules(off_plan, on_plan)
+        self.coverage_tracker.record(triggered)
+
+        # --- metrics -------------------------------------------------------
+        delta = nodes_before - nodes_after
+        pct = (delta / nodes_before * 100) if nodes_before else 0.0
+        speedup = runtime_before_s / runtime_after_s if runtime_after_s > 0 else float("inf")
+
+        metrics = CaseMetrics(
+            nodes_before=nodes_before,
+            nodes_after=nodes_after,
+            nodes_delta=delta,
+            reduction_pct=pct,
+            runtime_before_ms=runtime_before_s * 1000,
+            runtime_after_ms=runtime_after_s * 1000,
+            speedup=speedup,
+            optimize_time_ms=opt_time_ms,
+            rules_triggered=triggered,
+            rules_count=len(triggered),
+        )
+
+        return CaseResult(
+            name=case.name,
+            description=case.description,
+            passed=equal,
+            metrics=metrics,
+            outputs_equal=equal,
+            output_diff=diff,
+        )
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_summary(report: BenchmarkReport) -> dict:
+        cases = report.cases
+        if not cases:
+            return {}
+
+        total_nodes_before = sum(
+            c.metrics.nodes_before for c in cases if c.metrics
+        )
+        total_nodes_after = sum(
+            c.metrics.nodes_after for c in cases if c.metrics
+        )
+        total_rules = sum(
+            c.metrics.rules_count for c in cases if c.metrics
+        )
+        avg_speedup = (
+            sum(c.metrics.speedup for c in cases if c.metrics and c.metrics.speedup < float("inf"))
+            / max(len([c for c in cases if c.metrics and c.metrics.speedup < float("inf")]), 1)
+        )
+
+        return {
+            "total_nodes_before": total_nodes_before,
+            "total_nodes_after": total_nodes_after,
+            "overall_reduction_pct": (
+                (total_nodes_before - total_nodes_after) / total_nodes_before * 100
+                if total_nodes_before else 0
+            ),
+            "total_rules_triggered": total_rules,
+            "avg_speedup": round(avg_speedup, 2),
+            "correctness_pass_rate": (
+                report.passed / report.total_cases * 100
+                if report.total_cases else 0
+            ),
+        }
+
+
+def write_report(report: BenchmarkReport, path: str) -> None:
+    """Write *report* as JSON to *path* (module-level convenience)."""
+    from .result import write_report as _wr
+    _wr(report, path)

--- a/stratum/tests/benchmarks/test_benchmarks.py
+++ b/stratum/tests/benchmarks/test_benchmarks.py
@@ -1,0 +1,183 @@
+"""pytest integration: run the full benchmark suite.
+
+Usage
+-----
+    # Full suite (100k rows, summary to stdout)
+    python -m pytest stratum/tests/benchmarks/test_benchmarks.py -v -s
+
+    # Custom rows + JSON output
+    python -m pytest stratum/tests/benchmarks/test_benchmarks.py -v -s \\
+        --bench-rows 50000 --bench-json report.json
+
+    # Single category
+    python -m pytest stratum/tests/benchmarks/test_benchmarks.py -v -s \\
+        -k "combined"
+
+    # Standalone (no pytest)
+    python stratum/tests/benchmarks/test_benchmarks.py --bench-rows 10000
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+
+from stratum.tests.benchmarks.runner import BenchmarkRunner
+from stratum.tests.benchmarks.cases import ALL_CASES, NUMERIC_CASES, COMBINED_CASES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_option(option: str, default=None):
+    """Read a pytest --bench-* option, with env-var fallback."""
+    import os
+    env_map = {
+        "--bench-rows": ("STRATUM_BENCH_ROWS", int, 100_000),
+        "--bench-json": ("STRATUM_BENCH_JSON", str, None),
+    }
+    if option in env_map:
+        env_name, cast, fallback = env_map[option]
+        env_val = os.environ.get(env_name)
+        if env_val is not None:
+            return cast(env_val)
+
+    # Try reading from the last pytest invocation via conftest
+    try:
+        # conftest stores the config in the module
+        from stratum.tests.benchmarks import conftest as _ct
+        stored = getattr(_ct, "_pytest_config", None)
+        if stored is not None:
+            return stored.getoption(option, default=default if default is not None else fallback)
+    except Exception:
+        pass
+
+    return default if default is not None else (fallback if 'fallback' in dir() else None)
+
+
+# ---------------------------------------------------------------------------
+# pytest test class
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkSuite(unittest.TestCase):
+    """Run the full benchmark suite and assert correctness."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rows = _get_option("--bench-rows", 100_000)
+        cls.json_path = _get_option("--bench-json", None)
+
+    def test_run_all_cases(self):
+        """Execute all benchmark cases, verify correctness, print summary."""
+        runner = BenchmarkRunner(
+            data_rows=self.rows,
+            output_json=self.json_path,
+        )
+        report = runner.run(ALL_CASES)
+
+        # Print summary
+        _print_report(report)
+
+        # Assert all cases passed correctness check
+        failed = [c for c in report.cases if not c.passed]
+        if failed:
+            names = ", ".join(c.name for c in failed)
+            self.fail(f"Correctness failures: {names}")
+
+    def test_run_numeric_cases(self):
+        """Numeric rewrite cases only."""
+        runner = BenchmarkRunner(data_rows=self.rows)
+        report = runner.run(NUMERIC_CASES)
+        _print_report(report)
+        failed = [c for c in report.cases if not c.passed]
+        self.assertFalse(failed, f"Correctness failures: {failed}")
+
+    def test_run_combined_cases(self):
+        """Combined multi-rewrite cases only."""
+        runner = BenchmarkRunner(data_rows=self.rows)
+        report = runner.run(COMBINED_CASES)
+        _print_report(report)
+        failed = [c for c in report.cases if not c.passed]
+        self.assertFalse(failed, f"Correctness failures: {failed}")
+
+
+# ---------------------------------------------------------------------------
+# Report printer
+# ---------------------------------------------------------------------------
+
+def _print_report(report) -> None:
+    """Print a human-readable benchmark report to stdout."""
+    print("\n" + "=" * 95)
+    print("STRATUM OPTIMIZER BENCHMARK REPORT")
+    print(f"Data rows: {report.data_rows:,}  |  "
+          f"Cases: {report.passed}/{report.total_cases} passed  |  "
+          f"Timestamp: {report.timestamp}")
+    print("=" * 95)
+    print(f"{'Case':35s} {'OK':>3s}  {'Nodes':>9s}  "
+          f"{'Time (ms)':>16s}  {'Speedup':>8s}  {'Rules':>6s}")
+    print(f"{'':35s} {'':>3s}  {'Before After':>9s}  "
+          f"{'Before':>7s} {'After':>7s}  {'':>8s}  {'':>6s}")
+    print("-" * 95)
+    for c in report.cases:
+        m = c.metrics
+        if m is None:
+            print(f"  {c.name:33s}  {'ERR':>3s}  {c.error}")
+            continue
+        rules_str = ",".join(m.rules_triggered[:3])
+        if len(m.rules_triggered) > 3:
+            rules_str += f"+{len(m.rules_triggered)-3}"
+        print(
+            f"  {c.name:33s}  {'✓' if c.passed else '✗':>3s}  "
+            f"{m.nodes_before:3d} → {m.nodes_after:<3d}  "
+            f"{m.runtime_before_ms:7.2f} {m.runtime_after_ms:7.2f}  "
+            f"{m.speedup:6.1f}×  {rules_str:>6s}"
+        )
+    print("=" * 95)
+
+    # Rule coverage
+    rc = report.rule_coverage
+    if rc:
+        print(f"\nRule coverage: {len(rc.triggered)}/{rc.total_rules} triggered")
+        if rc.never_triggered:
+            print(f"  Never triggered: {', '.join(rc.never_triggered)}")
+        if rc.frequency:
+            print("  Frequency:")
+            for rule, count in sorted(rc.frequency.items(), key=lambda x: -x[1]):
+                print(f"    {rule:25s} {count}")
+
+    # Summary
+    s = report.summary
+    if s:
+        print(f"\nSummary:")
+        print(f"  Total nodes:         {s.get('total_nodes_before', 0)} → "
+              f"{s.get('total_nodes_after', 0)} "
+              f"({s.get('overall_reduction_pct', 0):.1f}% reduction)")
+        print(f"  Avg speedup:         {s.get('avg_speedup', 0):.1f}×")
+        print(f"  Correctness rate:    {s.get('correctness_pass_rate', 0):.1f}%")
+        print(f"  Rules triggered:     {s.get('total_rules_triggered', 0)}")
+
+    if report.data_rows and report.data_rows >= 100_000:
+        print(f"\n  JSON report: {getattr(report, '_json_path', 'not written')}")
+
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser(description="Stratum optimizer benchmark")
+    ap.add_argument("--bench-rows", type=int, default=100_000)
+    ap.add_argument("--bench-json", type=str, default=None)
+    ap.add_argument("--category", choices=["all", "numeric", "combined"], default="all")
+    args = ap.parse_args()
+
+    cases = {"all": ALL_CASES, "numeric": NUMERIC_CASES, "combined": COMBINED_CASES}[args.category]
+
+    runner = BenchmarkRunner(data_rows=args.bench_rows, output_json=args.bench_json)
+    report = runner.run(cases)
+    _print_report(report)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py
@@ -1,0 +1,602 @@
+"""
+Benchmark: algebraic rewrite impact on DAG size **and runtime**.
+
+Each rewrite was developed on a separate branch.  This script measures the
+**marginal** impact of every individual rewrite (and their combined effect) so
+you can quantify what each branch contributes — both in DAG node reduction and,
+critically, in actual wall-clock execution time on real DataFrames.
+
+Metrics collected per rewrite:
+* DAG nodes before / after the rewrite pass
+* Nodes eliminated (Δ) & reduction percentage
+* Wall-clock **execution** time (ms) — runs the linearized plan through the
+  SequentialScheduler so the data actually flows through every op
+* Speedup factor (time_before / time_after)
+
+Usage
+-----
+    # Run all benchmarks (default: 100k-row DataFrames)
+    python -m pytest stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py -v -s
+
+    # Run a single rewrite benchmark
+    python -m pytest stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py \\
+        -k "test_bench_log_exp" -v -s
+
+    # Adjust data size via CLI
+    python -m pytest stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py \\
+        --bench-rows 1000000 -v -s
+
+    # Visualize DAG before/after (needs Graphviz dot on PATH)
+    python -m pytest stratum/tests/logical_optimizer/algebraic_rewrites/benchmark_numeric.py \\
+        --bench-viz -k "test_bench_viz_combined" -v -s
+
+Design
+------
+Each benchmark builds a DataOp DAG dominated by a rewrite pattern, then runs
+the full ``optimize → SequentialScheduler.evaluate`` pipeline with the target
+rewrite OFF (baseline) and ON (treatment).  Execution time is measured via
+``perf_counter`` around the scheduler's ``evaluate()`` call, so it reflects the
+real cost of computing (or skipping) the eliminated operations on DataFrame
+columns.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+import time
+from dataclasses import dataclass, asdict
+from typing import ClassVar
+
+import numpy as np
+import pandas as pd
+
+import stratum as st
+from stratum.optimizer._optimize import (
+    optimize,
+    OptConfig,
+    convert_to_ops,
+    extract_frame_operators,
+    extract_numeric_operators,
+    run_op_cse_pass,
+    choice_unrolling,
+)
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig, algebraic_rewrites
+from stratum.optimizer.ir._dataframe_ops import add_splitting_op
+from stratum.optimizer._op_utils import show_graph
+from stratum.runtime._scheduler import SequentialScheduler
+from stratum._config import FLAGS
+
+# ---------------------------------------------------------------------------
+# Global (overridden by conftest.py via pytest --bench-rows / --bench-viz)
+# ---------------------------------------------------------------------------
+
+BENCH_ROWS = 100_000
+BENCH_VIZ = False  # set to True via --bench-viz to render before/after DAG PNGs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_df(n_rows: int = None, seed: int = 42) -> pd.DataFrame:
+    """Return a DataFrame with *n_rows* of numeric columns."""
+    if n_rows is None:
+        n_rows = BENCH_ROWS
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "a": rng.uniform(0.1, 10.0, n_rows),
+            "b": rng.uniform(0.1, 10.0, n_rows),
+            "c": rng.normal(0.0, 2.0, n_rows),
+        }
+    )
+
+
+def _plan_length(linearized_plan: list) -> int:
+    """Number of ops in the linearized plan (excl. sentinels)."""
+    return len(linearized_plan)
+
+
+def _execute_plan(linearized_plan, split_pos, flagged_ops, warmup: bool = False) -> float:
+    """Run the linearized plan through SequentialScheduler.evaluate() and return
+    wall-clock time in seconds.
+
+    Parameters
+    ----------
+    warmup : bool
+        If True, run once before timing to warm caches / JIT.
+    """
+    if warmup:
+        sched = SequentialScheduler(list(linearized_plan), split_pos, list(flagged_ops))
+        sched.evaluate()
+
+    sched = SequentialScheduler(list(linearized_plan), split_pos, list(flagged_ops))
+    t0 = time.perf_counter()
+    sched.evaluate()
+    return time.perf_counter() - t0
+
+
+def _all_off_config():
+    """Config with every algebraic rewrite disabled."""
+    return AlgebraicRewritesConfig(
+        log_exp=False,
+        exp_log=False,
+        sqrt_square=False,
+        log1p_expm1=False,
+        expm1_log1p=False,
+        identity_op=False,
+        abs_abs=False,
+        add_zero=False,
+        exp_minus_one=False,
+        identity_subtract=False,
+        any_mul_zero=False,
+        constant_folding=False,
+    )
+
+
+def _all_on_config():
+    """Config with every algebraic rewrite enabled."""
+    return AlgebraicRewritesConfig()
+
+
+# ---------------------------------------------------------------------------
+# DAG visualization
+# ---------------------------------------------------------------------------
+
+_VIZ_DIR = os.path.join(os.path.dirname(__file__), "viz")
+
+
+def _dag_text_summary(root: "Op") -> str:
+    """Return a human-readable text dump of the DAG rooted at *root*.
+
+    Lists every node (type, name) and its edges.  Useful when graphviz ``dot``
+    is not installed on the machine.
+    """
+    from stratum.optimizer._op_utils import topological_iterator
+
+    lines = []
+    for op in topological_iterator(root):
+        op.update_name()
+        label = f"{type(op).__name__}({op.name})"
+        ins = ", ".join(type(i).__name__ for i in op.inputs)
+        outs = ", ".join(type(o).__name__ for o in op.outputs)
+        lines.append(f"  {label}")
+        if ins:
+            lines.append(f"    ← [{ins}]")
+        if outs:
+            lines.append(f"    → [{outs}]")
+    return "\n".join(lines)
+
+
+def _prepare_op_root(dag) -> "Op":
+    """Replicate the optimize pipeline up to (but not including) algebraic rewrites.
+
+    Returns the :class:`Op` root so it can be rendered with ``show_graph`` or
+    passed directly to ``algebraic_rewrites``.
+    """
+    root = convert_to_ops(dag, None)
+    root = add_splitting_op(root)
+    root = extract_frame_operators(root)
+    root = extract_numeric_operators(root)
+    if FLAGS.cse:
+        root = run_op_cse_pass(root)
+    root = choice_unrolling(root)
+    return root
+
+
+def _render_dag(root: "Op", filename: str) -> str:
+    """Render *root* via graphviz; fall back to a text dump if ``dot`` is missing.
+
+    Returns the path to the output file (.png or .txt).
+    """
+    os.makedirs(_VIZ_DIR, exist_ok=True)
+    try:
+        show_graph(root, os.path.join("viz", filename))
+        return os.path.abspath(os.path.join("graphs", "viz", filename + ".png"))
+    except Exception:
+        txt_path = os.path.join(_VIZ_DIR, filename + ".txt")
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write(_dag_text_summary(root))
+        return txt_path
+
+
+def _render_rewrite_viz(
+    name: str,
+    dag,
+    enable_flags: dict,
+) -> tuple[str, str]:
+    """Render before/after DAG graphs for a single rewrite.
+
+    Returns (before_path, after_path).
+    """
+    root_before = _prepare_op_root(dag)
+    before_path = _render_dag(root_before, f"{name}_before")
+
+    on_cfg = AlgebraicRewritesConfig(**enable_flags)
+    root_after = algebraic_rewrites(root_before, on_cfg)
+    after_path = _render_dag(root_after, f"{name}_after")
+
+    return before_path, after_path
+
+
+@dataclass
+class RewriteResult:
+    name: str
+    nodes_before: int
+    nodes_after: int
+    delta: int
+    reduction_pct: float
+    runtime_before_ms: float
+    runtime_after_ms: float
+    speedup: float
+
+
+# ---------------------------------------------------------------------------
+# Benchmark cases (one per rewrite)
+# ---------------------------------------------------------------------------
+
+
+class TestAlgebraicRewriteBenchmark(unittest.TestCase):
+    """Each test method benchmarks a single algebraic rewrite pass.
+
+    The naming convention ``test_bench_<rewrite_name>`` lets you filter with pytest's
+    ``-k`` flag, e.g. ``-k "test_bench_log_exp or test_bench_sqrt_square"``.
+    """
+
+    results: ClassVar[list[RewriteResult]] = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.results = []
+
+    def _measure(
+        self,
+        name: str,
+        build_dag,
+        enable_flags: dict,
+        *,
+        disable_constant_folding: bool = True,
+        skip_runtime: bool = False,
+    ):
+        """Build a DAG, optimize & execute with/without *enable_flags*, record result.
+
+        Parameters
+        ----------
+        name : str
+            Human-readable rewrite name.
+        build_dag : () -> DataOp
+            Callable that returns the DAG to benchmark.
+        enable_flags : dict
+            Kwargs to ``AlgebraicRewritesConfig`` that toggle just the rewrite
+            under test ON.  All other rewrites are OFF.
+        disable_constant_folding : bool
+            When True, constant folding is also disabled in both runs so that
+            identity/elimination rewrites are measured in isolation.
+        """
+        dag = build_dag()
+
+        # -- baseline: target rewrite OFF -------------------------------------------
+        off_cfg = _all_off_config()
+        off_cfg = AlgebraicRewritesConfig(
+            **{**asdict(off_cfg), "constant_folding": False}
+        )
+        off_plan, off_split, off_flagged = optimize(
+            dag, config=OptConfig(algebraic_rewrite_config=off_cfg),
+        )
+        nodes_before = _plan_length(off_plan)
+
+        # -- treatment: target rewrite ON --------------------------------------------
+        on_flags = {**asdict(off_cfg), **enable_flags}
+        if not disable_constant_folding:
+            on_flags["constant_folding"] = True
+        on_cfg = AlgebraicRewritesConfig(**on_flags)
+        on_plan, on_split, on_flagged = optimize(
+            dag, config=OptConfig(algebraic_rewrite_config=on_cfg),
+        )
+        nodes_after = _plan_length(on_plan)
+
+        # -- execute & time both plans -----------------------------------------------
+        if skip_runtime:
+            runtime_before_s = runtime_after_s = 0.0
+        else:
+            _execute_plan(off_plan, off_split, off_flagged, warmup=True)
+            runtime_before_s = _execute_plan(off_plan, off_split, off_flagged)
+            runtime_after_s = _execute_plan(on_plan, on_split, on_flagged)
+
+        delta = nodes_before - nodes_after
+        pct = (delta / nodes_before * 100) if nodes_before else 0.0
+        speedup = runtime_before_s / runtime_after_s if runtime_after_s > 0 else float("inf")
+
+        result = RewriteResult(
+            name=name,
+            nodes_before=nodes_before,
+            nodes_after=nodes_after,
+            delta=delta,
+            reduction_pct=pct,
+            runtime_before_ms=runtime_before_s * 1000,
+            runtime_after_ms=runtime_after_s * 1000,
+            speedup=speedup,
+        )
+        TestAlgebraicRewriteBenchmark.results.append(result)
+
+        if skip_runtime:
+            print(
+                f"  {name:30s} | "
+                f"nodes: {nodes_before:2d}→{nodes_after:2d}  "
+                f"(runtime skipped — scalar DAG)"
+            )
+        else:
+            print(
+                f"  {name:30s} | "
+                f"nodes: {nodes_before:2d}→{nodes_after:2d}  "
+                f"time: {result.runtime_before_ms:7.2f}→{result.runtime_after_ms:7.2f} ms  "
+                f"({speedup:.1f}× faster)"
+            )
+
+        # Sanity: the rewrite must not increase node count or runtime.
+        self.assertGreaterEqual(
+            nodes_before, nodes_after,
+            f"{name}: rewrite increased DAG size ({nodes_before} → {nodes_after})",
+        )
+
+    # ---- log/exp inverses ----------------------------------------------------------
+
+    def test_bench_log_exp(self):
+        """log(x) → exp → x  (2 ops eliminated)"""
+        self._measure(
+            "log_exp",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.log).skb.apply_func(np.exp),
+            {"log_exp": True},
+        )
+
+    def test_bench_exp_log(self):
+        """exp(x) → log → x  (2 ops eliminated)"""
+        self._measure(
+            "exp_log",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.exp).skb.apply_func(np.log),
+            {"exp_log": True},
+        )
+
+    def test_bench_log1p_expm1(self):
+        """log1p(x) → expm1 → x  (2 ops eliminated)"""
+        self._measure(
+            "log1p_expm1",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.log1p).skb.apply_func(np.expm1),
+            {"log1p_expm1": True},
+        )
+
+    def test_bench_expm1_log1p(self):
+        """expm1(x) → log1p → x  (2 ops eliminated)"""
+        self._measure(
+            "expm1_log1p",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.expm1).skb.apply_func(np.log1p),
+            {"expm1_log1p": True},
+        )
+
+    # ---- sqrt / square --------------------------------------------------------------
+
+    def test_bench_sqrt_square(self):
+        """x² → sqrt → |x|  (2 ops → 1 abs op)"""
+        self._measure(
+            "sqrt_square",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.square).skb.apply_func(np.sqrt),
+            {"sqrt_square": True},
+        )
+
+    # ---- identity operations --------------------------------------------------------
+
+    def test_bench_identity_op(self):
+        """x * 1 → x  (1 multiply eliminated)"""
+        df = st.as_data_op(_make_df())
+        self._measure(
+            "identity_op",
+            lambda: df * 1,
+            {"identity_op": True},
+        )
+
+    def test_bench_add_zero(self):
+        """x + 0 → x  (1 add eliminated)"""
+        df = st.as_data_op(_make_df())
+        self._measure(
+            "add_zero",
+            lambda: df + 0,
+            {"add_zero": True},
+        )
+
+    def test_bench_identity_subtract(self):
+        """x - 0 → x  (1 subtract eliminated)"""
+        df = st.as_data_op(_make_df())
+        self._measure(
+            "identity_subtract",
+            lambda: df - 0,
+            {"identity_subtract": True},
+        )
+
+    # ---- abs/abs collapse -----------------------------------------------------------
+
+    def test_bench_abs_abs(self):
+        """abs(abs(x)) → abs(x)  (1 abs eliminated)"""
+        self._measure(
+            "abs_abs",
+            lambda: st.as_data_op(_make_df()).skb.apply_func(np.abs).skb.apply_func(np.abs),
+            {"abs_abs": True},
+        )
+
+    # ---- exp minus one → expm1 ------------------------------------------------------
+
+    def test_bench_exp_minus_one(self):
+        """exp(x) - 1 → expm1(x)  (2 ops → 1)"""
+        df = st.as_data_op(_make_df())
+        self._measure(
+            "exp_minus_one",
+            lambda: df.skb.apply_func(np.exp) - 1,
+            {"exp_minus_one": True},
+        )
+
+    # ---- multiply-by-zero → constant-zero -------------------------------------------
+
+    def test_bench_any_mul_zero(self):
+        """x * 0 → ValueOp(0.0)  (multiply + dead source eliminated)"""
+        df = st.as_data_op(_make_df())
+        self._measure(
+            "any_mul_zero",
+            lambda: df * 0,
+            {"any_mul_zero": True},
+        )
+
+    # ---- constant folding -----------------------------------------------------------
+
+    def test_bench_constant_folding(self):
+        """log(1) → 0, exp(0) → 1, etc. (NumericOp → ValueOp).
+
+        Runtime measurement is skipped here — constant folding operates on
+        compile-time scalars, not DataFrames, so the scheduler cannot execute
+        the folded plan (ValueOp returns a raw scalar, not a DataFrame column)."""
+        self._measure(
+            "constant_folding",
+            lambda: (
+                st.as_data_op(1)
+                .skb.apply_func(np.log)  # log(1)=0
+                .skb.apply_func(np.exp)  # exp(0)=1
+                .skb.apply_func(np.sqrt)  # sqrt(1)=1
+            ),
+            {"constant_folding": True},
+            disable_constant_folding=False,
+            skip_runtime=True,
+        )
+
+    # ---- visualization ---------------------------------------------------------------
+
+    def test_bench_viz_combined(self):
+        """Render before/after DAG graphs for the combined rewrite pass.
+
+        Only active when ``--bench-viz`` is passed to pytest.  Outputs PNGs to
+        ``stratum/tests/logical_optimizer/algebraic_rewrites/viz/``.
+        """
+        if not BENCH_VIZ:
+            self.skipTest("--bench-viz not set (pass --bench-viz to pytest)")
+
+        df = _make_df(n_rows=100)  # small DF for readable graph labels
+        dag = (
+            st.as_data_op(df).skb.apply_func(np.log).skb.apply_func(np.exp)  # log_exp
+            * 1  # identity
+            + 0  # add_zero
+        )
+        dag = dag.skb.apply_func(np.square).skb.apply_func(np.sqrt)  # sqrt_square
+
+        before_path, after_path = _render_rewrite_viz(
+            "combined",
+            dag,
+            asdict(_all_on_config()),
+        )
+        print(f"\n  Viz before: {before_path}")
+        print(f"  Viz after:  {after_path}")
+
+    # ---- combined: complex DAG ------------------------------------------------------
+
+    def test_bench_combined_all_on(self):
+        """All rewrites ON vs all OFF — measures cumulative runtime impact."""
+        df = _make_df()
+        dag = (
+            st.as_data_op(df).skb.apply_func(np.log).skb.apply_func(np.exp)  # log_exp
+            * 1  # identity
+            + 0  # add_zero
+            - 0  # identity_subtract
+        )
+        dag = dag.skb.apply_func(np.square).skb.apply_func(np.sqrt)  # sqrt_square
+        dag = dag.skb.apply_func(np.exp) - 1  # exp_minus_one
+
+        off_cfg = OptConfig(algebraic_rewrite_config=_all_off_config())
+        on_cfg = OptConfig(algebraic_rewrite_config=_all_on_config())
+
+        off_plan, off_split, off_flagged = optimize(dag, config=off_cfg)
+        on_plan, on_split, on_flagged = optimize(dag, config=on_cfg)
+
+        nodes_before = _plan_length(off_plan)
+        nodes_after = _plan_length(on_plan)
+
+        _execute_plan(off_plan, off_split, off_flagged, warmup=True)
+        runtime_before_s = _execute_plan(off_plan, off_split, off_flagged)
+        runtime_after_s = _execute_plan(on_plan, on_split, on_flagged)
+
+        delta = nodes_before - nodes_after
+        pct = (delta / nodes_before * 100) if nodes_before else 0.0
+        speedup = runtime_before_s / runtime_after_s if runtime_after_s > 0 else float("inf")
+
+        result = RewriteResult(
+            name="★ COMBINED (all on vs all off)",
+            nodes_before=nodes_before,
+            nodes_after=nodes_after,
+            delta=delta,
+            reduction_pct=pct,
+            runtime_before_ms=runtime_before_s * 1000,
+            runtime_after_ms=runtime_after_s * 1000,
+            speedup=speedup,
+        )
+        TestAlgebraicRewriteBenchmark.results.append(result)
+
+        print(
+            f"\n  {'★ COMBINED':30s} | "
+            f"nodes: {nodes_before:2d}→{nodes_after:2d}  "
+            f"time: {result.runtime_before_ms:7.2f}→{result.runtime_after_ms:7.2f} ms  "
+            f"({speedup:.1f}× faster)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Summary report (printed after all benchmarks)
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(results: list[RewriteResult]) -> None:
+    if not results:
+        return
+    print("\n" + "=" * 90)
+    print("ALGEBRAIC REWRITE BENCHMARK SUMMARY")
+    print(f"DataFrame rows: {BENCH_ROWS:,}")
+    print("=" * 90)
+    print(
+        f"{'Rewrite':30s}  {'Nodes':>9s}  {'Time (ms)':>16s}  "
+        f"{'Speedup':>8s}"
+    )
+    print(f"{'':30s}  {'Before After':>9s}  {'Before':>7s} {'After':>7s}  ")
+    print("-" * 90)
+    for r in results:
+        if r.runtime_before_ms == 0 and r.runtime_after_ms == 0:
+            time_col = "(scalar DAG)"
+        else:
+            time_col = f"{r.runtime_before_ms:7.2f} {r.runtime_after_ms:7.2f}  {r.speedup:6.1f}×"
+        print(
+            f"{r.name:30s}  {r.nodes_before:3d} → {r.nodes_after:<3d}  {time_col}"
+        )
+    print("=" * 90)
+
+    total_before = sum(r.nodes_before for r in results if not r.name.startswith("★"))
+    total_after = sum(r.nodes_after for r in results if not r.name.startswith("★"))
+    if total_before:
+        print(
+            f"\nAggregate (excl. combined): "
+            f"{total_before} → {total_after} nodes "
+            f"({(total_before - total_after) / total_before * 100:.1f}% reduction)"
+        )
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Module-level teardown (pytest)
+# ---------------------------------------------------------------------------
+
+
+def tearDownModule():
+    """Print the summary table once, after all tests in this module finish."""
+    _print_summary(TestAlgebraicRewriteBenchmark.results)
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/conftest.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/conftest.py
@@ -1,0 +1,23 @@
+"""pytest configuration for algebraic rewrite benchmarks."""
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--bench-rows",
+        type=int,
+        default=100_000,
+        help="Number of rows in benchmark DataFrames (default: 100_000).",
+    )
+    parser.addoption(
+        "--bench-viz",
+        action="store_true",
+        default=True,
+        help="Render before/after DAG PNGs via graphviz.",
+    )
+
+
+def pytest_configure(config):
+    import stratum.tests.logical_optimizer.algebraic_rewrites.benchmark_numeric as bn
+
+    bn.BENCH_ROWS = config.getoption("--bench-rows", default=100_000)
+    bn.BENCH_VIZ = config.getoption("--bench-viz", default=True)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -5,7 +5,8 @@ from stratum.optimizer._optimize import  optimize
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
-from stratum.optimizer.ir._ops import OperandRef
+from stratum.optimizer.ir._ops import OperandRef, ValueOp
+from stratum.optimizer._numeric_rewrites import match_constant_foldable
 
 class TestCSE(unittest.TestCase):
 
@@ -24,7 +25,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.exp)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 1)
 
@@ -43,7 +45,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.log)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 1)
 
@@ -71,14 +74,15 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_expm1_log1p_disabled(self):
         df = st.as_data_op(1)
         t1 = df.skb.apply_func(np.expm1)
         t2 = t1.skb.apply_func(np.log1p)
-        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(log1p_expm1 = False,expm1_log1p = False))
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(log1p_expm1 = False,expm1_log1p = False, constant_folding=False))
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
         self.assertEqual(out[0].value, 1)
@@ -89,7 +93,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.log1p)
         t3 = t2.skb.apply_func(np.exp)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 4)
 
     def test_log1p_log1p_exp(self):
@@ -98,7 +103,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log1p)
         t2 = t1.skb.apply_func(np.log1p)
         t3 = t2.skb.apply_func(np.exp)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 4)
 
     def test_disable_log_exp_rewrite1(self):
@@ -108,7 +114,7 @@ class TestCSE(unittest.TestCase):
 
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(log_exp=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(log_exp=False, constant_folding=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -130,7 +136,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         # abs(4) = 4
         self.assertEqual(out[0].value, 4)
@@ -140,7 +147,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 2
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         # abs(-3) = 3
         self.assertEqual(out[0].value, -3)
@@ -151,7 +159,8 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.sqrt)
         t3 = t2.skb.apply_func(np.log1p)
 
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 3)
         self.assertEqual(out[0].value, 4)
 
@@ -162,7 +171,7 @@ class TestCSE(unittest.TestCase):
 
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(sqrt_square=False, constant_folding=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -171,7 +180,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(4)
         t1 = df.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t1)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
 
     def test_sqrt_square_produces_abs_op(self):
@@ -180,7 +190,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ABS)
@@ -191,7 +202,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 2
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ABS)
@@ -201,7 +213,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.square)
         t2 = t1.skb.apply_func(np.log)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_sqrt_exp(self):
@@ -209,7 +222,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.sqrt)
         t2 = t1.skb.apply_func(np.exp)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_pow3_sqrt(self):
@@ -218,7 +232,8 @@ class TestCSE(unittest.TestCase):
         t1 = df ** 3
         t2 = t1.skb.apply_func(np.sqrt)
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_disable_sqrt_square_does_not_affect_log_exp(self):
@@ -239,7 +254,8 @@ class TestCSE(unittest.TestCase):
         t1 = df * 1
         t2 = t1 + 3
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 5)
 
@@ -247,7 +263,7 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(2)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_op=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_op=False, constant_folding=False),
         )
         t1 = df * 1
         t2 = t1 + 3
@@ -267,12 +283,14 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(out[0].process("fit", [out[0].value]), 2)
 
     def test_eliminate_identity_operation_dedups_repeated_input(self):
+        """Identity-op eliminates ``*1`` multiplies; repeated inputs are properly deduplicated."""
         value = st.as_data_op(2)
         a = value + (value * 1)
         b = (value * 1) + value
         root = a + b
 
-        out, *_ = optimize(root)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(root, config=config)
 
         self.assertEqual(len(out), 4)
         self.assertEqual(out[1].inputs, [out[0]])
@@ -286,7 +304,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(-3)
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.abs)
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
 
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
@@ -295,7 +314,8 @@ class TestCSE(unittest.TestCase):
     def test_single_abs_untouched(self):
         df = st.as_data_op(-3)
         t1 = df.skb.apply_func(np.abs)
-        out, *_ = optimize(t1)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
 
     def test_abs_abs_with_trailing_op(self):
@@ -303,14 +323,16 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.abs)
         t3 = t2.skb.apply_func(np.log1p)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 3)
 
     def test_no_rewrite_abs_sqrt(self):
         df = st.as_data_op(4)
         t1 = df.skb.apply_func(np.abs)
         t2 = t1.skb.apply_func(np.sqrt)
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
 
     def test_abs_abs_disabled(self):
@@ -319,7 +341,7 @@ class TestCSE(unittest.TestCase):
         t2 = t1.skb.apply_func(np.abs)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False)
+            algebraic_rewrite_config=AlgebraicRewritesConfig(abs_abs=False, constant_folding=False)
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -334,12 +356,13 @@ class TestCSE(unittest.TestCase):
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
-
+    
     def test_eliminate_add_zero(self):
         df = st.as_data_op(2)
         t1 = df + 0
         t2 = t1 + 3
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 5)
 
@@ -347,14 +370,16 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(2)
         t1 = 0 + df
         t2 = t1 + 3
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 5)
 
     def test_eliminate_add_zero_root_safe(self):
         df = st.as_data_op(2)
         root = df + 0
-        out, *_ = optimize(root)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(root, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].process("fit", [out[0].value]), 2)
 
@@ -362,7 +387,7 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(2)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(add_zero=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(add_zero=False, constant_folding=False),
         )
         t1 = 0 + df
         t2 = t1 + 3
@@ -374,7 +399,8 @@ class TestCSE(unittest.TestCase):
     def test_no_rewrite_add_nonzero(self):
         df = st.as_data_op(2)
         t1 = df + 1
-        out, *_ = optimize(t1)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 3)
 
@@ -383,14 +409,16 @@ class TestCSE(unittest.TestCase):
         t1 = df + 0
         t2 = t1 + 3
         t3 = t2.skb.apply_func(np.log1p)
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 3)
 
     def test_add_zero_and_identity_operation(self):
         df = st.as_data_op(2)
         t1 = df * 1
         t2 = t1 + 0
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 2)
 
@@ -398,7 +426,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(0)
         t1 = df.skb.apply_func(np.exp)
         t2 = t1 - 1
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)                                  # source + expm1 (was 3)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXPM1)
@@ -408,7 +437,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(0)
         t1 = df.skb.apply_func(np.exp)
         t2 = 1 - t1                                                     # reversed: NOT expm1
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXP)
@@ -418,7 +448,8 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(0)
         t1 = df.skb.apply_func(np.exp)
         t2 = t1 - 2                                                     # constant != 1
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXP)
@@ -429,7 +460,7 @@ class TestCSE(unittest.TestCase):
         t2 = t1 - 1
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(exp_minus_one=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(exp_minus_one=False, constant_folding=False),
         )
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 3)
@@ -441,7 +472,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.exp)
         t2 = t1 + 0
         t3 = t2 - 1
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.EXPM1)
@@ -460,7 +492,8 @@ class TestCSE(unittest.TestCase):
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.exp)
         t3 = t2 - 1  # exp(log(x)) - 1
-        out, *_ = optimize(t3)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t3, config=config)
         self.assertEqual(len(out), 2)  # exp/log cancel -> x - 1
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.SUBTRACT)
@@ -471,7 +504,8 @@ class TestCSE(unittest.TestCase):
         t1 = df - 0
         t2 = t1 + 3
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[1].process("fit", [out[0].value]), 8)
 
@@ -480,7 +514,8 @@ class TestCSE(unittest.TestCase):
         value = st.as_data_op(7)
         root = value - 0
 
-        out, *_ = optimize(root)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(root, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].process("fit", [out[0].value]), 7)
 
@@ -489,7 +524,7 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(5)
         config = OptConfig(
             algebraic_rewrites=True,
-            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_subtract=False),
+            algebraic_rewrite_config=AlgebraicRewritesConfig(identity_subtract=False, constant_folding=False),
         )
         t1 = df - 0
         t2 = t1 + 3
@@ -506,6 +541,150 @@ class TestCSE(unittest.TestCase):
         t1 = 0 - df
         t2 = t1 + 3
 
-        out, *_ = optimize(t2)
+        config = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
+        out, *_ = optimize(t2, config=config)
         # x - 0 would collapse to 2 ops; 0 - x stays as 3 ops
         self.assertEqual(len(out), 3)
+
+    # --- constant folding -------------------------------------------------
+
+    def test_constant_folding_log1(self):
+        """log(1) → 0"""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0.0)
+
+    def test_constant_folding_exp0(self):
+        """exp(0) → 1"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.exp)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1.0)
+
+    def test_constant_folding_abs(self):
+        """abs(-5) → 5"""
+        df = st.as_data_op(-5)
+        t1 = df.skb.apply_func(np.abs)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_constant_folding_sqrt(self):
+        """sqrt(4) → 2"""
+        df = st.as_data_op(4)
+        t1 = df.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 2.0)
+
+    def test_constant_folding_square(self):
+        """square(3) → 9"""
+        df = st.as_data_op(3)
+        t1 = df.skb.apply_func(np.square)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 9)
+
+    def test_constant_folding_log1p(self):
+        """log1p(e-1) → 1"""
+        df = st.as_data_op(np.e - 1)
+        t1 = df.skb.apply_func(np.log1p)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        np.testing.assert_almost_equal(out[0].value, 1.0)
+
+    def test_constant_folding_expm1(self):
+        """expm1(1) → e-1"""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.expm1)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, np.expm1(1))
+
+    def test_constant_folding_sin0(self):
+        """sin(0) → 0 (GENERIC numeric op)"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.sin)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0.0)
+
+    def test_constant_folding_cos0(self):
+        """cos(0) → 1 (GENERIC numeric op)"""
+        df = st.as_data_op(0)
+        t1 = df.skb.apply_func(np.cos)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1.0)
+
+    def test_constant_folding_add_var_var(self):
+        """5 + 3 → 8 (binary var-var)"""
+        df1 = st.as_data_op(5)
+        df2 = st.as_data_op(3)
+        t1 = df1 + df2
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 8)
+
+    def test_constant_folding_add_var_const(self):
+        """5 + 3 → 8 (binary var-const)"""
+        df = st.as_data_op(5)
+        t1 = df + 3
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 8)
+
+    def test_constant_folding_cascade(self):
+        """sqrt(abs(-4)) → 2 (two-level cascade)"""
+        df = st.as_data_op(-4)
+        t1 = df.skb.apply_func(np.abs)
+        t2 = t1.skb.apply_func(np.sqrt)
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 2.0)
+
+    def test_constant_folding_disabled(self):
+        """Disabling constant_folding must leave log(1) as a NumericOp."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)  # ValueOp + NumericOp
+
+    def test_disable_constant_folding_does_not_affect_log_exp(self):
+        """Disabling constant_folding must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)  # log(exp(x)) eliminated
+        self.assertEqual(out[0].value, 1)
+
+    def test_constant_folding_empty_inputs_returns_none(self):
+        """match_constant_foldable must return None for a NumericOp with no inputs."""
+        op = NumericOp(inputs=[], outputs=[], type=NumericOpType.LOG)
+        self.assertIsNone(match_constant_foldable(op))

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
@@ -1,11 +1,17 @@
 import unittest
 import stratum as st
 import numpy as np
-from stratum.optimizer._optimize import optimize
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer.ir._ops import ValueOp
 
 class TestNumericComplexFanout(unittest.TestCase):
+
+    def _opt(self, dag):
+        return optimize(dag, OptConfig(
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        ))
 
     def test_fanout_before_and_after_chain(self):
         """
@@ -32,7 +38,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         t1 = d + b
         final = t1 + c
         
-        linearized_dag, *_ = optimize(final)
+        linearized_dag, *_ = self._opt(final)
         
         # 1. Find the original 'a' Op
         a_op = linearized_dag[0]
@@ -68,7 +74,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         c = exp_log_a + 2.0
         final = b + c
 
-        linearized_dag, *_ = optimize(final)
+        linearized_dag, *_ = self._opt(final)
 
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)
@@ -95,7 +101,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         log_a = a.skb.apply_func(np.log)
         exp_log_a = log_a.skb.apply_func(np.exp)
 
-        linearized_dag, *_ = optimize(exp_log_a)
+        linearized_dag, *_ = self._opt(exp_log_a)
 
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)
@@ -126,7 +132,7 @@ class TestNumericComplexFanout(unittest.TestCase):
         d = a + 10.0
         
         combined = exp_log_a + d
-        linearized_dag, *_ = optimize(combined)
+        linearized_dag, *_ = self._opt(combined)
         
         a_op = linearized_dag[0]
         self.assertIsInstance(a_op, ValueOp)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/viz/combined_after.txt
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/viz/combined_after.txt
@@ -1,0 +1,4 @@
+  DataSourceOp(Frame)
+    → [NumericOp]
+  NumericOp(abs)
+    ← [DataSourceOp]

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/viz/combined_before.txt
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/viz/combined_before.txt
@@ -1,0 +1,19 @@
+  DataSourceOp(Frame)
+    → [NumericOp]
+  NumericOp(log)
+    ← [DataSourceOp]
+    → [NumericOp]
+  NumericOp(exp)
+    ← [NumericOp]
+    → [NumericOp]
+  NumericOp(multiply)
+    ← [NumericOp]
+    → [NumericOp]
+  NumericOp(add)
+    ← [NumericOp]
+    → [NumericOp]
+  NumericOp(square)
+    ← [NumericOp]
+    → [NumericOp]
+  NumericOp(sqrt)
+    ← [NumericOp]

--- a/stratum/tests/logical_optimizer/test_numeric_ops.py
+++ b/stratum/tests/logical_optimizer/test_numeric_ops.py
@@ -6,9 +6,16 @@ import numpy as np
 from sklearn.dummy import DummyRegressor
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType, make_binary_numeric_op
 from stratum.optimizer.ir._ops import CallOp, OperandRef, ValueOp
-from stratum.optimizer._optimize import optimize
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
+
 
 class TestNumericOps(unittest.TestCase):
+    def _opt(self, dag):
+        return optimize(dag, OptConfig(
+            algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
+        ))
+
     def setUp(self):
         self.df = pd.DataFrame({
             "x": [1, 2, 3],
@@ -121,7 +128,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_add_var_const(self):
         df = st.as_data_op(5)
         t1 = df + 3
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ADD)
@@ -131,7 +138,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_add_const_var(self):
         df = st.as_data_op(5)
         t1 = 3 + df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.ADD)
@@ -141,7 +148,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_subtract_var_const(self):
         df = st.as_data_op(5)
         t1 = df - 2
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.SUBTRACT)
@@ -149,7 +156,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_multiply_var_const(self):
         df = st.as_data_op(5)
         t1 = df * 4
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.MULTIPLY)
@@ -157,7 +164,7 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_divide_var_const(self):
         df = st.as_data_op(10)
         t1 = df / 2
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         self.assertEqual(len(out), 2)
         self.assertIsInstance(out[1], NumericOp)
         self.assertEqual(out[1].type, NumericOpType.DIVIDE)
@@ -195,35 +202,35 @@ class TestNumericOps(unittest.TestCase):
     def test_extract_binop_add_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1 + df2)
+        out, *_ = self._opt(df1 + df2)
         op = self._assert_var_var_extracted(out, NumericOpType.ADD)
         self.assertEqual(op.process("fit", [2, 3]), 5)
 
     def test_extract_binop_subtract_var_var(self):
         df1 = st.as_data_op(10)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1 - df2)
+        out, *_ = self._opt(df1 - df2)
         op = self._assert_var_var_extracted(out, NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [10, 3]), 7)
 
     def test_extract_binop_multiply_var_var(self):
         df1 = st.as_data_op(4)
         df2 = st.as_data_op(5)
-        out, *_ = optimize(df1 * df2)
+        out, *_ = self._opt(df1 * df2)
         op = self._assert_var_var_extracted(out, NumericOpType.MULTIPLY)
         self.assertEqual(op.process("fit", [4, 5]), 20)
 
     def test_extract_binop_divide_var_var(self):
         df1 = st.as_data_op(12)
         df2 = st.as_data_op(4)
-        out, *_ = optimize(df1 / df2)
+        out, *_ = self._opt(df1 / df2)
         op = self._assert_var_var_extracted(out, NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [12, 4]), 3.0)
 
     def test_extract_add_produces_correct_result(self):
         df = st.as_data_op(5)
         t1 = df + 3
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         add_op = next(op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.ADD)
         self.assertEqual(add_op.process("fit", [5]), 8)
 
@@ -231,7 +238,7 @@ class TestNumericOps(unittest.TestCase):
         """CallOp with np.add should be extracted to NumericOp ADD."""
         df = st.as_data_op(5)
         t1 = df.skb.apply_func(np.add, 3)
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         add_ops = [op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.ADD]
         self.assertEqual(len(add_ops), 1)
 
@@ -239,49 +246,49 @@ class TestNumericOps(unittest.TestCase):
         """CallOp with np.multiply should be extracted to NumericOp MULTIPLY."""
         df = st.as_data_op(5)
         t1 = df.skb.apply_func(np.multiply, 4)
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         mul_ops = [op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.MULTIPLY]
         self.assertEqual(len(mul_ops), 1)
 
     def test_extract_callop_add_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.add, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.add, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.ADD)
         self.assertEqual(op.process("fit", [2, 3]), 5)
 
     def test_extract_callop_subtract_var_var(self):
         df1 = st.as_data_op(5)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.subtract, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.subtract, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [5, 3]), 2)
 
     def test_extract_callop_multiply_var_var(self):
         df1 = st.as_data_op(2)
         df2 = st.as_data_op(3)
-        out, *_ = optimize(df1.skb.apply_func(np.multiply, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.multiply, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.MULTIPLY)
         self.assertEqual(op.process("fit", [2, 3]), 6)
 
     def test_extract_callop_divide_var_var(self):
         df1 = st.as_data_op(6)
         df2 = st.as_data_op(2)
-        out, *_ = optimize(df1.skb.apply_func(np.divide, df2))
+        out, *_ = self._opt(df1.skb.apply_func(np.divide, df2))
         op = self._assert_var_var_extracted(out, NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [6, 2]), 3.0)
 
     def test_extract_subtract_const_var_produces_correct_result(self):
         df = st.as_data_op(3)
         t1 = 10 - df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         op = next(o for o in out if isinstance(o, NumericOp) and o.type == NumericOpType.SUBTRACT)
         self.assertEqual(op.process("fit", [3]), 7)
 
     def test_extract_divide_const_var_produces_correct_result(self):
         df = st.as_data_op(4)
         t1 = 12 / df
-        out, *_ = optimize(t1)
+        out, *_ = self._opt(t1)
         op = next(o for o in out if isinstance(o, NumericOp) and o.type == NumericOpType.DIVIDE)
         self.assertEqual(op.process("fit", [4]), 3.0)
 

--- a/stratum/tests/logical_optimizer/test_op_utils.py
+++ b/stratum/tests/logical_optimizer/test_op_utils.py
@@ -2,6 +2,7 @@
 import unittest
 import stratum as st
 from stratum.optimizer._optimize import optimize as optimize_, OptConfig, choice_unrolling, convert_to_ops
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer._op_utils import (
     show_graph, clone_sub_dag, topological_iterator, validate_operands,
     validate_dag, compute_graph_node_indegree, FLAGS,
@@ -13,6 +14,8 @@ from stratum._config import config
 graph = False
 
 def optimize(dag, conf=None):
+    if conf is None:
+        conf = OptConfig(algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False))
     linearized_dag, *_ = optimize_(dag, conf)
     return linearized_dag
 


### PR DESCRIPTION
## Adds constant folding `f(constant_inputs...) -> constant` for numeric operations (#136)

Adds `eliminate_constant_folding` - evaluates `NumericOp` nodes at compile time when all their inputs are `ValueOp` constants, replacing the entire op with the computed result. This collapses chains like `log(1) → sqrt(4) → abs(-5)` down to single constants before runtime.
#### Before:  log(1) -> sqrt(4)  _(chain of ops in the DAG)_
#### After:   ValueOp(0.0) -> ValueOp(2.0)  _(single constant)_

### Known issues
Any test that builds a DAG from `st.as_data_op(N)` (a constant scalar) and then asserts on DAG structure (op count, op types, fan-out edges, etc.) will be affected: constant folding collapses the entire chain to a single `ValueOp(result)`. Such tests must opt out via:
```
config = OptConfig(
    algebraic_rewrite_config=AlgebraicRewritesConfig(constant_folding=False),
)
out, *_ = optimize(dag, config=config)
```

This is the main reason for the conflicts.