### PR TITLE
[Rewrite] Eliminate divide-by-one identity

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -11,6 +11,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_exp_minus_one,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
+    eliminate_div_by_one,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -32,6 +33,7 @@ class AlgebraicRewritesConfig:
     exp_minus_one: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
+    div_by_one: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -41,6 +43,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_identity_operation(root)
     if config.add_zero:
         root = eliminate_add_zero(root)
+    if config.div_by_one:
+        root = eliminate_div_by_one(root)
     if config.log_exp:
         root = eliminate_log_exp(root)
     if config.exp_log:

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -26,7 +26,10 @@ def match_identity_operation(op_cls, type1, const, reversed=None):
     """
     def match(op1):
         if isinstance(op1, op_cls) and op1.type == type1:
-            if op1.opt_operand is None and op1.constant == const:
+            # isinstance guard: an ndarray constant would raise
+            # "truth value of an array is ambiguous" on `== const`.
+            if op1.opt_operand is None and isinstance(op1.constant, (int, float)) \
+                    and op1.constant == const:
                 if reversed is None or op1.reversed == reversed:
                     return (op1,)
         return None
@@ -172,4 +175,9 @@ eliminate_identity_subtract = rewrite_pass(
 eliminate_any_mul_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 0),
     fold_to_zero,
+)
+
+eliminate_div_by_one = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.DIVIDE, 1, reversed=False),
+    eliminate_single_op_chain_root_safe,
 )

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -509,3 +509,69 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2)
         # x - 0 would collapse to 2 ops; 0 - x stays as 3 ops
         self.assertEqual(len(out), 3)
+
+    def test_eliminate_div_by_one_fires(self):
+        df = st.as_data_op(6)
+        t1 = df / 1
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)                        # only the ValueOp remains
+        self.assertEqual(out[0].value, 6)
+
+    def test_eliminate_div_by_one_in_chain(self):
+        df = st.as_data_op(6)
+        t1 = df / 1
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)                        # ValueOp + ADD
+        self.assertEqual(out[1].process("fit", [out[0].value]), 9)
+
+    def test_eliminate_div_by_one_disabled(self):
+        df = st.as_data_op(6)
+        t1 = df / 1
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(div_by_one=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)                        # DIV remains
+
+    def test_no_rewrite_one_over_x(self):
+        """1 / x must NOT be rewritten — DIVIDE is non-commutative."""
+        df = st.as_data_op(6)
+        t1 = 1 / df
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)                        # ValueOp + DIV(reversed=True)
+        # sanity: check the DIV is still there and reversed
+        div_op = out[1]
+        self.assertIsInstance(div_op, NumericOp)
+        self.assertEqual(div_op.type, NumericOpType.DIVIDE)
+        self.assertTrue(div_op.reversed)
+
+    def test_no_rewrite_div_by_other_constant(self):
+        """x / 2 must NOT be rewritten — only constant 1 counts."""
+        df = st.as_data_op(6)
+        t1 = df / 2
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_no_crash_div_by_ndarray_constant(self):
+        """df / ndarray must neither crash nor rewrite (ambiguous-truth-value trap)."""
+        df = st.as_data_op(np.array([6.0, 8.0]))
+        t1 = df / np.array([1.0, 1.0])
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)                        # ValueOp + DIV survive
+
+    def test_no_crash_mul_by_ndarray_constant(self):
+        """Regression for the pre-existing crash in mul-by-one (#93): before the
+        isinstance guard, `df * np.array([...])` raised 'truth value of an array
+        is ambiguous' inside match_identity_operation."""
+        df = st.as_data_op(np.array([6.0, 8.0]))
+        t1 = df * np.array([2.0, 3.0])
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)                        # ValueOp + MUL survive


### PR DESCRIPTION
Adds `x / 1 -> x` (guarded against `1 / x`, which is not an identity).
Also hardens `match_identity_operation` against ndarray constants: `df * np.array([...])` currently crashes with "truth value of an array is ambiguous" on main; regression tests included.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #147
- <kbd>&nbsp;3&nbsp;</kbd> #146
- <kbd>&nbsp;2&nbsp;</kbd> #145
- <kbd>&nbsp;1&nbsp;</kbd> #144 👈 
<!-- GitButler Footer Boundary Bottom -->
