### PR TITLE
[Rewrite] eliminate power-by-one identity

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -10,6 +10,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_add_zero,
     fold_exp_minus_one,
     eliminate_pow_zero,
+    eliminate_pow_by_one,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
     eliminate_div_by_one,
@@ -34,6 +35,7 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     pow_zero: bool = True
+    pow_by_one: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
     div_by_one: bool = True
@@ -69,6 +71,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_identity_subtract(root)
     if config.pow_zero:
         root = eliminate_pow_zero(root)
+    if config.pow_by_one:
+        root = eliminate_pow_by_one(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
     log_time("algebraic_rewrite", start)

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,3 +1,5 @@
+import numbers
+
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
 from stratum.optimizer.ir._ops import Op, ValueOp
@@ -9,8 +11,14 @@ def _is_scalar_const(value) -> bool:
     Guards against ndarray constants (e.g. ``df * np.array([...])``), whose
     ``== const`` yields an array and raises "truth value of an array is
     ambiguous" when used in a boolean context.
+
+    ``numbers.Real`` rather than ``(int, float)`` so numpy scalars match too:
+    ``df ** np.int64(1)`` keeps its exponent as ``np.int64``, which is not an
+    ``int`` subclass and would otherwise skip every identity rewrite. (``np.float64``
+    *is* a ``float`` subclass, so only the integer types were affected.) ``Real``
+    still excludes ndarray and ``complex``, which is what the guard is for.
     """
-    return isinstance(value, (int, float))
+    return isinstance(value, numbers.Real)
 
 
 def _matches_scalar_const(op, const, reversed=None):
@@ -220,6 +228,16 @@ eliminate_any_mul_zero = rewrite_pass(
 eliminate_pow_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.POW, 0, reversed=False),
     fold_to_one,
+)
+
+# `x ** 1 -> x`. Matched as a first-class identity on `NumericOpType.POW`, reusing the
+# same helper as `x * 1` / `x / 1`. An earlier version of this rewrite matched a raw
+# `BinOp` with `operator.pow` because POW was not yet a NumericOpType; once #135 added
+# it, `x ** 1` lowers to `NumericOp(POW, constant=1)` and the BinOp matcher stopped
+# firing. `reversed=False` keeps `1 ** x` (which is 1, not x) untouched.
+eliminate_pow_by_one = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.POW, 1, reversed=False),
+    eliminate_single_op_chain_root_safe,
 )
 
 # TODO(dtype): unlike the other identity rewrites (`x*1`, `x+0`, `x-0`), dropping

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -1,4 +1,5 @@
 from stratum.optimizer.ir._ops import BinOp, CallOp, Op, OperandRef
+import numbers
 import operator
 import numpy as np
 from enum import Enum
@@ -143,7 +144,12 @@ def make_binary_numeric_op(op: CallOp, type: NumericOpType) -> NumericOp:
 
 def extract_numeric_op(op: Op, root: Op) -> tuple[Op, bool]:
     new_op = None
-    if isinstance(op, BinOp) and op.op is operator.pow and op.right == 2:
+    # `isinstance` before `== 2`: an ndarray exponent (`df ** np.array([...])`) makes
+    # `op.right == 2` an elementwise array, which raises "truth value of an array is
+    # ambiguous" in this boolean context. Same trap the `_is_scalar_const` guard in
+    # _numeric_rewrites.py closes for the identity matchers.
+    if (isinstance(op, BinOp) and op.op is operator.pow
+            and isinstance(op.right, numbers.Real) and op.right == 2):
         new_op = NumericOp(func=np.square, args=(), kwargs={}, inputs=op.inputs, outputs=op.outputs)
     elif isinstance(op, BinOp) and op.op in _ARITH_OP_MAP:
         l_ph = isinstance(op.left, OperandRef)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -636,12 +636,20 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t1)
         self.assertEqual(len(out), 2)
 
-    def test_pow_one_untouched(self):
-        """x ** 1 must not be affected (identity, not annihilator)."""
+    def test_pow_one_untouched_by_pow_zero(self):
+        """x ** 1 is an identity, not an annihilator: `pow_zero` must not touch it.
+
+        `pow_by_one` *does* eliminate it (see TestPowByOne), so this test disables
+        that rewrite to isolate `pow_zero`'s behaviour.
+        """
         df = st.as_data_op(5)
         t1 = df ** 1
 
-        out, *_ = optimize(t1)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_by_one=False),
+        )
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 2)
 
     def test_disable_pow_zero_does_not_affect_log_exp(self):
@@ -655,5 +663,152 @@ class TestCSE(unittest.TestCase):
             algebraic_rewrite_config=AlgebraicRewritesConfig(pow_zero=False),
         )
         out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)
+
+
+class TestPowByOne(unittest.TestCase):
+    """`x ** 1 -> x`, matched on NumericOpType.POW.
+
+    An earlier version matched a raw `BinOp` with `operator.pow`, because POW was
+    not a NumericOpType yet. Once #135 added POW, `x ** 1` lowered to
+    `NumericOp(POW, constant=1)` and that matcher stopped firing; these tests pin
+    the current representation so a future IR change fails loudly instead of
+    silently disabling the rewrite.
+    """
+
+    def test_pow_by_one_eliminated(self):
+        """x ** 1  ->  x"""
+        df = st.as_data_op(5)
+        t1 = df ** 1
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_pow_by_one_lowers_to_numeric_pow(self):
+        """Pin the representation the matcher depends on: `x ** 1` must become a
+        NumericOp(POW) with a scalar constant, not a raw BinOp."""
+        df = st.as_data_op(5)
+        t1 = df ** 1
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_by_one=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        pow_op = out[-1]
+        self.assertIsInstance(pow_op, NumericOp)
+        self.assertIs(pow_op.type, NumericOpType.POW)
+        self.assertEqual(pow_op.constant, 1)
+        self.assertFalse(pow_op.reversed)
+
+    def test_pow_by_numpy_int_exponent(self):
+        """`df ** np.int64(1)` must be eliminated too.
+
+        np.int64 is not an `int` subclass, so the old `isinstance(value, (int, float))`
+        guard skipped it and the rewrite silently did not fire.
+        """
+        df = st.as_data_op(5)
+        t1 = df ** np.int64(1)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_pow_by_numpy_float_exponent(self):
+        """`df ** np.float64(1.0)` must be eliminated (np.float64 *is* a float
+        subclass, so this worked before too -- pinned to prevent regressions)."""
+        df = st.as_data_op(5)
+        t1 = df ** np.float64(1.0)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_div_by_numpy_int_one(self):
+        """`_is_scalar_const` is shared, so widening it to numbers.Real also fixes
+        `x / np.int64(1)`, which previously did not fire."""
+        df = st.as_data_op(6)
+        t1 = df / np.int64(1)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 6)
+
+    def test_mul_by_numpy_int_one(self):
+        """Same shared-helper fix for `x * np.int64(1)`."""
+        df = st.as_data_op(6)
+        t1 = df * np.int64(1)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 6)
+
+    def test_pow_by_one_with_trailing_op(self):
+        """(x ** 1) + 3  ->  x + 3"""
+        df = st.as_data_op(5)
+        t1 = (df ** 1) + 3
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 8)
+
+    def test_pow_by_one_root_safe(self):
+        """When x ** 1 is the root, the DAG must not break."""
+        value = st.as_data_op(7)
+        root = value ** 1
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 7)
+
+    def test_pow_by_one_disabled(self):
+        """Disabling pow_by_one must leave x ** 1 untouched."""
+        df = st.as_data_op(5)
+        t1 = df ** 1
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_by_one=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)
+
+    def test_pow_by_two_untouched(self):
+        """x ** 2 is not an identity and must survive."""
+        df = st.as_data_op(5)
+        t1 = df ** 2
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_one_pow_x_untouched(self):
+        """`1 ** x` is 1, not x: the reversed=False guard must reject it."""
+        df = st.as_data_op(5)
+        t1 = 1 ** df
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+
+    def test_no_crash_pow_by_ndarray_constant(self):
+        """`df ** ndarray` must neither crash nor rewrite: numbers.Real still
+        excludes ndarray, so the ambiguous-truth-value guard is preserved."""
+        df = st.as_data_op(np.array([6.0, 8.0]))
+        t1 = df ** np.array([1.0, 1.0])
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)                        # ValueOp + POW survive
+
+    def test_disable_pow_by_one_does_not_affect_pow_zero(self):
+        """The two pow rewrites are independent."""
+        df = st.as_data_op(5)
+        t1 = df ** 0
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(pow_by_one=False),
+        )
+        out, *_ = optimize(t1, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)


### PR DESCRIPTION
Adds `x ** 1 -> x`. Matches the raw BinOp because POWER is not yet a NumericOpType (see #62), same shape as the existing `x**2 -> SQUARE` extraction.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #147
- <kbd>&nbsp;3&nbsp;</kbd> #146
- <kbd>&nbsp;2&nbsp;</kbd> #145 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #144
<!-- GitButler Footer Boundary Bottom -->
