### PR TITLE
[Rewrite] eliminate neg(neg(x)) double inverse

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -10,6 +10,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_add_zero,
     fold_exp_minus_one,
     eliminate_pow_zero,
+    eliminate_neg_neg,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
     eliminate_div_by_one,
@@ -34,6 +35,7 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     pow_zero: bool = True
+    neg_neg: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
     div_by_one: bool = True
@@ -69,6 +71,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_identity_subtract(root)
     if config.pow_zero:
         root = eliminate_pow_zero(root)
+    if config.neg_neg:
+        root = eliminate_neg_neg(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
     log_time("algebraic_rewrite", start)

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -23,8 +23,23 @@ def _matches_scalar_const(op, const, reversed=None):
     )
 
 
-def match_two_op_chain(op_cls, type1, type2, *, match1=None, match2=None):
-    """Match a typed two-op chain with optional per-operation predicates."""
+def match_two_op_chain(op_cls, type1, type2, *, match1=None, match2=None,
+                       innermost_first=False):
+    """Match a typed two-op chain with optional per-operation predicates.
+
+    ``innermost_first`` guards self-inverse chains that are collapsed by
+    *elimination* (``eliminate_two_op_chain``): if op1's own input is already a
+    matching op, the match is declined so the inner pair collapses first. Without
+    it, an odd-length chain (n >= 3) matches an overlapping pair and the action
+    rewires through a node the pass has already detached, so
+    ``topological_iterator`` raises "Encountered op ... which should not exist in
+    the DAG".
+
+    Left ``False`` by default: rewrites using a *replacement* action
+    (``make_replace_two_op_chain_root_safe``, e.g. ``abs(abs(x)) -> abs(x)``)
+    consume the chain outermost-first and would stop collapsing entirely under
+    this guard.
+    """
     def match(op1):
         if (
             isinstance(op1, op_cls)
@@ -32,6 +47,10 @@ def match_two_op_chain(op_cls, type1, type2, *, match1=None, match2=None):
             and len(op1.outputs) == 1
             and (match1 is None or match1(op1))
         ):
+            if innermost_first and op1.inputs:
+                inner = op1.inputs[0]
+                if isinstance(inner, op_cls) and inner.type is type1:
+                    return None  # not the innermost pair
             op2 = op1.outputs[0]
             if (
                 isinstance(op2, op_cls)
@@ -232,3 +251,15 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
+
+
+# `neg(neg(x)) -> x`. NEGATIVE is a NumericOpType (this PR), so the pair is matched
+# with the shared `match_two_op_chain` helper, exactly like `abs(abs(x))`. Before
+# NEGATIVE was in the enum, `np.negative` fell through to GENERIC and matching it
+# needed two conditions (`type is GENERIC and func is np.negative`) plus a bespoke
+# `match_two_op_chain_by_func` helper; promoting it to the enum removes both.
+eliminate_neg_neg = rewrite_pass(
+    match_two_op_chain(NumericOp, NumericOpType.NEGATIVE, NumericOpType.NEGATIVE,
+                       innermost_first=True),
+    eliminate_two_op_chain_root_safe,
+)

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -12,6 +12,7 @@ class NumericOpType(Enum):
     SQUARE = "square"
     LOG1P = "log1p"
     EXPM1 = "expm1"
+    NEGATIVE = "negative"
     ADD = "add"
     SUBTRACT = "subtract"
     MULTIPLY = "multiply"
@@ -42,6 +43,7 @@ _NUMPY_UNARY_MAP = {
     np.square: NumericOpType.SQUARE,
     np.log1p: NumericOpType.LOG1P,
     np.expm1: NumericOpType.EXPM1,
+    np.negative: NumericOpType.NEGATIVE,
 }
 
 _UNARY_NUMPY_FUNCS = frozenset(_NUMPY_UNARY_MAP.keys())
@@ -94,6 +96,8 @@ class NumericOp(Op):
             return np.log1p(inputs[0])
         elif self.type == NumericOpType.EXPM1:
             return np.expm1(inputs[0])
+        elif self.type == NumericOpType.NEGATIVE:
+            return np.negative(inputs[0])
         elif self.type in _BINARY_TYPES:
             # The primary operand is always input 0 (bound first); the optional
             # second operand is referenced explicitly so x op x (single edge) works.

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -657,3 +657,125 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)
+
+
+class TestNegNeg(unittest.TestCase):
+    """`neg(neg(x)) -> x`, matched on NumericOpType.NEGATIVE.
+
+    NEGATIVE is promoted to a NumericOpType by this PR, so the matcher is the
+    shared `match_two_op_chain` keyed on one type, rather than the two-condition
+    GENERIC + `func is np.negative` form it needed while `np.negative` fell
+    through to GENERIC.
+    """
+
+    def test_neg_neg_eliminated(self):
+        """neg(neg(x)) -> x"""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative).skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_negative_lowers_to_typed_op(self):
+        """Pin the representation: np.negative must extract to NumericOp(NEGATIVE),
+        not to a GENERIC op wrapping the func."""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        neg_op = out[-1]
+        self.assertIsInstance(neg_op, NumericOp)
+        self.assertIs(neg_op.type, NumericOpType.NEGATIVE)
+
+    def test_single_neg_untouched(self):
+        """A lone negation must survive."""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [5]), -5)
+
+    def test_odd_length_chain_collapses_to_single_neg(self):
+        """neg^3 -> neg. Regression for the overlapping-pair bug: without the
+        innermost-first guard the pass rewires through an already-detached node
+        and topological_iterator raises "Encountered op ... should not exist"."""
+        df = st.as_data_op(5)
+        t1 = df
+        for _ in range(3):
+            t1 = t1.skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [5]), -5)
+
+    def test_even_length_chain_collapses_fully(self):
+        """neg^4 -> x"""
+        df = st.as_data_op(5)
+        t1 = df
+        for _ in range(4):
+            t1 = t1.skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 5)
+
+    def test_long_odd_chain(self):
+        """neg^5 -> neg (the guard must hold for longer chains too)."""
+        df = st.as_data_op(5)
+        t1 = df
+        for _ in range(5):
+            t1 = t1.skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [5]), -5)
+
+    def test_neg_neg_with_trailing_op(self):
+        """neg(neg(x)) + 3 -> x + 3"""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative).skb.apply_func(np.negative) + 3
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 8)
+
+    def test_neg_neg_root_safe(self):
+        """When neg(neg(x)) is the root, the DAG must not break."""
+        value = st.as_data_op(7)
+        root = value.skb.apply_func(np.negative).skb.apply_func(np.negative)
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 7)
+
+    def test_neg_neg_disabled(self):
+        """Disabling neg_neg must leave the pair untouched."""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative).skb.apply_func(np.negative)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(neg_neg=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 3)
+
+    def test_neg_then_abs_untouched(self):
+        """Mixed chains must not collapse: abs(neg(x)) != x."""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.negative).skb.apply_func(np.abs)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 3)
+
+    def test_neg_neg_numeric_result(self):
+        """End-to-end value check on an array."""
+        arr = np.array([1.0, -2.0, 3.0])
+        df = st.as_data_op(arr)
+        t1 = df.skb.apply_func(np.negative).skb.apply_func(np.negative)
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        np.testing.assert_allclose(out[0].value, arr)


### PR DESCRIPTION
Adds `neg(neg(x)) -> x` for `apply_func(np.negative)` chains (part of #51).
Chains collapse innermost-pair-first so odd-length chains reduce correctly.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #147
- <kbd>&nbsp;3&nbsp;</kbd> #146 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #145
- <kbd>&nbsp;1&nbsp;</kbd> #144
<!-- GitButler Footer Boundary Bottom -->
