### PR TITLE
[Rewrite] fuse exp/sum(exp) into softmax

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -10,6 +10,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_add_zero,
     fold_exp_minus_one,
     eliminate_pow_zero,
+    fuse_softmax,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
     eliminate_div_by_one,
@@ -34,6 +35,7 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     pow_zero: bool = True
+    softmax: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
     div_by_one: bool = True
@@ -71,5 +73,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_pow_zero(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
+    if config.softmax:
+        root = fuse_softmax(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,3 +1,5 @@
+import scipy.special as sp
+
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
 from stratum.optimizer.ir._ops import Op, ValueOp
@@ -232,3 +234,61 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
+
+
+def match_softmax(op):
+    """Match ``DIVIDE(EXP(x), SUM(EXP(x)))`` where both operands are the same EXP
+    node and nothing outside the pattern consumes the EXP or SUM value.
+
+    The reduction is matched as ``NumericOpType.SUM``. It was previously keyed on
+    ``type is GENERIC and func is np.sum``; promoting SUM into the enum makes this
+    a single type check, but the args/kwargs guard below is still required --
+    the type says "this is a sum", not "this is a whole-array sum".
+    """
+    if not (isinstance(op, NumericOp) and op.type is NumericOpType.DIVIDE):
+        return None
+    if op.opt_operand is None or op.reversed:
+        return None
+
+    numer = op.inputs[0]
+    denom = op.inputs[op.opt_operand.k]
+
+    if not (isinstance(numer, NumericOp) and numer.type is NumericOpType.EXP):
+        return None
+    if not (isinstance(denom, NumericOp) and denom.type is NumericOpType.SUM):
+        return None
+    # Reject axis/keepdims/dtype sums: `exp(x)/sum(exp(x), axis=0)` is a
+    # column-wise softmax, not the whole-array `scipy.special.softmax(x)`.
+    if denom.args or denom.kwargs:
+        return None
+    # SUM must be fed by exactly the same EXP node as the numerator.
+    if len(denom.inputs) != 1 or denom.inputs[0] is not numer:
+        return None
+    # Fan-out: no other consumer may rely on the EXP or SUM value.
+    if set(numer.outputs) != {op, denom}:
+        return None
+    if set(denom.outputs) != {op}:
+        return None
+    return (op, numer, denom)
+
+
+def replace_with_softmax(div_op, exp_op, sum_op, root):
+    """Replace the DIV(EXP(x), SUM(EXP(x))) sub-DAG with a single GENERIC
+    NumericOp wrapping ``scipy.special.softmax``, which is numerically stable
+    (it subtracts the max before exponentiating)."""
+    x = exp_op.inputs[0]
+
+    softmax_op = NumericOp(
+        inputs=[x],
+        outputs=list(div_op.outputs),
+        func=sp.softmax,
+    )
+
+    x.replace_output(exp_op, softmax_op)
+    div_op.replace_input_of_outputs(softmax_op)
+    if div_op is root:
+        root = softmax_op
+    return root
+
+
+fuse_softmax = rewrite_pass(match_softmax, replace_with_softmax)

--- a/stratum/optimizer/ir/_numeric_ops.py
+++ b/stratum/optimizer/ir/_numeric_ops.py
@@ -12,6 +12,10 @@ class NumericOpType(Enum):
     SQUARE = "square"
     LOG1P = "log1p"
     EXPM1 = "expm1"
+    # A reduction, not an elementwise op: unlike every other member here, SUM's
+    # args/kwargs (axis, keepdims, dtype) change its result, so its `process`
+    # branch must forward them. See the note in `NumericOp.process`.
+    SUM = "sum"
     ADD = "add"
     SUBTRACT = "subtract"
     MULTIPLY = "multiply"
@@ -42,6 +46,7 @@ _NUMPY_UNARY_MAP = {
     np.square: NumericOpType.SQUARE,
     np.log1p: NumericOpType.LOG1P,
     np.expm1: NumericOpType.EXPM1,
+    np.sum: NumericOpType.SUM,
 }
 
 _UNARY_NUMPY_FUNCS = frozenset(_NUMPY_UNARY_MAP.keys())
@@ -94,6 +99,11 @@ class NumericOp(Op):
             return np.log1p(inputs[0])
         elif self.type == NumericOpType.EXPM1:
             return np.expm1(inputs[0])
+        elif self.type == NumericOpType.SUM:
+            # Forwards args/kwargs, unlike the elementwise branches above. `axis`,
+            # `keepdims` and `dtype` change the result, so dropping them would
+            # silently turn `np.sum(x, axis=0)` into a whole-array sum.
+            return np.sum(inputs[0], *self.args, **self.kwargs)
         elif self.type in _BINARY_TYPES:
             # The primary operand is always input 0 (bound first); the optional
             # second operand is referenced explicitly so x op x (single edge) works.

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric_complex_fanout.py
@@ -1,9 +1,19 @@
 import unittest
 import stratum as st
 import numpy as np
-from stratum.optimizer._optimize import optimize
+import scipy.special as sp
+from stratum.optimizer._optimize import optimize, OptConfig
+from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer.ir._ops import ValueOp
+
+
+def _has_softmax(dag):
+    """True if any op in the plan is the fused GENERIC softmax op."""
+    return any(isinstance(op, NumericOp)
+               and op.type is NumericOpType.GENERIC
+               and op.func is sp.softmax
+               for op in dag)
 
 class TestNumericComplexFanout(unittest.TestCase):
 
@@ -143,3 +153,123 @@ class TestNumericComplexFanout(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSoftmaxFusion(unittest.TestCase):
+    """`exp(x) / sum(exp(x)) -> scipy.special.softmax(x)`.
+
+    The reduction is matched as `NumericOpType.SUM` (promoted to the enum by this
+    PR) rather than by `type is GENERIC and func is np.sum`.
+    """
+
+    def test_softmax_fires(self):
+        arr = np.array([1., 2., 3.])
+        x = st.as_data_op(arr)
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize(e / s)
+        self.assertEqual(len(out), 2)
+        self.assertTrue(_has_softmax(out))
+        np.testing.assert_allclose(out[1].process("fit", [arr]), sp.softmax(arr))
+
+    def test_sum_lowers_to_typed_op(self):
+        """Pin the representation the matcher depends on: np.sum must extract to
+        NumericOp(SUM), not to a GENERIC op wrapping the func."""
+        x = st.as_data_op(np.array([1., 2., 3.]))
+        s = x.skb.apply_func(np.sum)
+
+        out, *_ = optimize(s)
+        self.assertIs(out[-1].type, NumericOpType.SUM)
+
+    def test_sum_forwards_axis_kwarg(self):
+        """SUM's process branch must forward args/kwargs, unlike the elementwise
+        branches. Dropping them would turn sum(axis=0) into a whole-array sum."""
+        m = np.array([[1., 2.], [3., 4.]])
+        x = st.as_data_op(m)
+        s = x.skb.apply_func(np.sum, axis=0)
+
+        out, *_ = optimize(s)
+        np.testing.assert_allclose(out[-1].process("fit", [m]), np.sum(m, axis=0))
+
+    def test_sum_forwards_keepdims_kwarg(self):
+        m = np.array([[1., 2.], [3., 4.]])
+        x = st.as_data_op(m)
+        s = x.skb.apply_func(np.sum, keepdims=True)
+
+        out, *_ = optimize(s)
+        np.testing.assert_allclose(out[-1].process("fit", [m]), np.sum(m, keepdims=True))
+
+    def test_no_fuse_axis_aware_sum(self):
+        """exp(x)/sum(exp(x), axis=0) is a column-wise softmax, not the whole-array
+        one: fusing it would silently change the result."""
+        m = np.array([[1., 2.], [3., 4.]])
+        x = st.as_data_op(m)
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum, axis=0)
+
+        out, *_ = optimize(e / s)
+        self.assertFalse(_has_softmax(out))
+
+    def test_no_fuse_reversed_divide(self):
+        """sum(exp(x)) / exp(x) is 1/softmax(x)."""
+        x = st.as_data_op(np.array([1., 2., 3.]))
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize(s / e)
+        self.assertFalse(_has_softmax(out))
+
+    def test_no_fuse_when_exp_has_third_consumer(self):
+        """A third consumer of EXP still needs that value materialized."""
+        x = st.as_data_op(np.array([1., 2., 3.]))
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize((e / s) + (e + 1.0))
+        self.assertFalse(_has_softmax(out))
+
+    def test_softmax_when_root(self):
+        x = st.as_data_op(np.array([1., 2., 3.]))
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize(e / s)
+        self.assertIs(out[-1].func, sp.softmax)
+
+    def test_softmax_fires_mid_dag(self):
+        """A consumer after the divide exercises the output-rewiring path."""
+        arr = np.array([1., 2., 3.])
+        x = st.as_data_op(arr)
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize((e / s) * 2.0)
+        self.assertEqual(len(out), 3)
+        self.assertTrue(_has_softmax(out))
+        self.assertIs(out[2].type, NumericOpType.MULTIPLY)
+
+    def test_softmax_disabled(self):
+        x = st.as_data_op(np.array([1., 2., 3.]))
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(softmax=False),
+        )
+        out, *_ = optimize(e / s, config=config)
+        self.assertFalse(_has_softmax(out))
+        self.assertEqual(len(out), 4)
+
+    def test_softmax_is_numerically_stable(self):
+        """The point of the fusion: the naive form overflows, softmax does not."""
+        arr = np.array([1000., 1001., 1002.])
+        x = st.as_data_op(arr)
+        e = x.skb.apply_func(np.exp)
+        s = e.skb.apply_func(np.sum)
+
+        out, *_ = optimize(e / s)
+        result = out[1].process("fit", [arr])
+        self.assertFalse(np.isnan(result).any())
+        np.testing.assert_allclose(result, sp.softmax(arr))


### PR DESCRIPTION
Fuses `exp(x) / sum(exp(x))` into a single generic op wrapping `scipy.special.softmax` (fan-out match with identity check on the shared exp node).
Adds scipy as a direct dependency; it was previously only transitive.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #147 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #146
- <kbd>&nbsp;2&nbsp;</kbd> #145
- <kbd>&nbsp;1&nbsp;</kbd> #144
<!-- GitButler Footer Boundary Bottom -->
