### PR TITLE
[POC] Propagate dataframe schemas through logical ops

### DIFF
--- a/stratum/optimizer/ir/_projection_ops.py
+++ b/stratum/optimizer/ir/_projection_ops.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from pandas.api.types import is_dict_like, is_list_like
 from skrub.selectors._base import make_selector
 from stratum.optimizer.ir._ops import (OutputType, CallOp, GetAttrOp,
                                        MethodCallOp, Op, TransformerOp, _resolve_args, _resolve_kwargs)
@@ -68,6 +69,54 @@ class MetadataOp(Op):
         self.args = args
         self.kwargs = kwargs
         self.output_type = OutputType.FRAME
+        self.has_schema = False
+        self.schema = None
+        self.infer_schema()
+
+    def infer_schema(self):
+        """Infer the schema produced by a dataframe metadata operation.
+
+        For ``rename``, pandas changes column labels in either of these forms::
+
+            frame.rename(mapper, axis=1)
+            frame.rename(columns=mapper)
+
+        ``mapper`` may be dict-like or callable. Renaming the index does not
+        affect the column schema. A schema is represented as ``(name, dtype)``
+        pairs, so only the names change and their order and dtypes are retained.
+        """
+        if not self.inputs or not getattr(self.inputs[0], "has_schema", False):
+            return None
+
+        input_schema = getattr(self.inputs[0], "schema", None)
+        if input_schema is None:
+            return None
+        if self.func != "rename":
+            return input_schema
+
+        args = self.args or ()
+        kwargs = self.kwargs or {}
+
+        if "columns" in kwargs:
+            mapper = kwargs["columns"]
+        else:
+            mapper = kwargs.get("mapper", args[0] if args else None)
+            axis = kwargs.get("axis", args[1] if len(args) > 1 else 0)
+            if axis not in (1, "columns"):
+                self.schema = input_schema
+                self.has_schema = True
+                return
+
+        if is_dict_like(mapper):
+            rename = lambda column: mapper[column] if column in mapper else column
+        elif callable(mapper):
+            rename = mapper
+        else:
+            # Dynamic/unsupported mappers cannot be evaluated at plan time.
+            return None
+
+        self.schema = tuple((rename(column), dtype) for column, dtype in input_schema)
+        self.has_schema = True
 
 
 class ProjectionOp(Op):
@@ -112,10 +161,45 @@ class ProjectionOp(Op):
 
 class DropOp(ProjectionOp):
     fields = ["args", "kwargs", "columns"]
-    def __init__(self, args: tuple | list = (), kwargs: dict = {},
+
+    def __init__(self, args: tuple | list = (), kwargs: dict = None,
         inputs: list[Op] = None, outputs: list[Op] = None, columns: list[str] = None):
         super().__init__(args=args, kwargs=kwargs, inputs=inputs, outputs=outputs, columns=columns)
+        self.schema = None
+        self.has_schema = False
+        self.infer_schema()
 
+    def infer_schema(self):
+        if not self.inputs or not getattr(self.inputs[0], "has_schema", False):
+            return None
+        input_schema = self.inputs[0].schema
+        columns_to_remove = None
+
+        args = self.args or ()
+        kwargs = self.kwargs or {}
+
+        if "columns" in kwargs:
+            columns_to_remove = kwargs["columns"]
+        else:
+            labels = kwargs.get("labels", args[0] if args else None)
+            axis = kwargs.get("axis", args[1] if len(args) > 1 else 0)
+            if labels is not None and axis in (1, "columns"):
+                columns_to_remove = labels
+
+        if columns_to_remove is None:
+            self.schema = input_schema
+            self.has_schema = True
+            return
+
+        if not is_list_like(columns_to_remove):
+            columns_to_remove = [columns_to_remove]
+
+        self.schema = tuple(
+            (column, dtype)
+            for column, dtype in input_schema
+            if column not in columns_to_remove
+        )
+        self.has_schema = True
 
 class ColumnSelectorOp(Op):
     """A column selection by (deferred) skrub selector: keeps rows, restricts columns.

--- a/stratum/optimizer/ir/_source_ops.py
+++ b/stratum/optimizer/ir/_source_ops.py
@@ -1,5 +1,6 @@
 from stratum.optimizer.ir._ops import OperandRef, Op, OutputType, ValueOp, VariableOp, CallOp
 from pandas import DataFrame
+from polars import DataFrame as PolarsDataFrame
 
 
 class DataSourceOp(Op):
@@ -12,7 +13,8 @@ class DataSourceOp(Op):
     """
     logical_family = "Source"
 
-    def __init__(self, data: DataFrame = None, file_path: str = None, _format: str = None,
+    def __init__(self, data: DataFrame | PolarsDataFrame = None,
+                 file_path: str = None, _format: str = None,
                  read_args: tuple | list = None, read_kwargs: dict = None, is_X=False, is_y=False, outputs: list[Op] = None, inputs: list[Op] = None):
         if outputs is None:
             outputs = []
@@ -24,6 +26,14 @@ class DataSourceOp(Op):
         self.file_path = file_path
         self.read_args = read_args
         self.read_kwargs = read_kwargs
+
+        if isinstance(data, DataFrame):
+            self.schema = tuple(zip(data.columns, data.dtypes))
+        elif isinstance(data, PolarsDataFrame):
+            self.schema = tuple(data.schema.items())
+        else:
+            self.schema = None
+        self.has_schema = self.schema is not None
         # A directly-passed DataFrame or a csv read is a FRAME; np.load yields an
         # ndarray, so an npy source is a MATRIX.
         self.output_type = OutputType.MATRIX if _format == "npy" else OutputType.FRAME

--- a/stratum/tests/logical_optimizer/test_projection_ops.py
+++ b/stratum/tests/logical_optimizer/test_projection_ops.py
@@ -13,6 +13,7 @@ from stratum.optimizer.ir._projection_ops import (
     make_string_method_op, polars_datetime_kwargs)
 from stratum.optimizer.ir._map_ops import AssignMapOp
 from stratum.optimizer.ir._column_expr import Col, DtExpr
+from stratum.optimizer.ir._source_ops import DataSourceOp
 from stratum.optimizer.ir._ops import (
     CallOp, GetAttrOp, GetItemOp, MethodCallOp, Op, OperandRef, OutputType,
     TransformerOp)
@@ -139,6 +140,88 @@ class TestMetadataOp(unittest.TestCase):
     def test_kwargs_none_skips_check(self):
         self.assertIsNone(MetadataOp(func="rename").kwargs)
 
+    def test_schema_from_columns_dict(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2.0]}))
+        op = MetadataOp(
+            func="rename", args=(), kwargs={"columns": {"a": "x"}},
+            inputs=[source],
+        )
+        self.assertEqual((("x", source.schema[0][1]), ("b", source.schema[1][1])),
+                         op.schema)
+
+    def test_schema_from_custom_dict_like_mapper(self):
+        class Mapper:
+            def __init__(self):
+                self._mapping = {"a": "x"}
+
+            def __getitem__(self, key):
+                return self._mapping[key]
+
+            def keys(self):
+                return self._mapping.keys()
+
+            def __contains__(self, key):
+                return key in self._mapping
+
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        op = MetadataOp(
+            func="rename", args=(), kwargs={"columns": Mapper()},
+            inputs=[source],
+        )
+        self.assertEqual(["x", "b"], [name for name, _ in op.schema])
+
+    def test_schema_from_callable_columns_mapper(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        op = MetadataOp(
+            func="rename", args=(), kwargs={"columns": str.upper},
+            inputs=[source],
+        )
+        self.assertEqual(["A", "B"], [name for name, _ in op.schema])
+
+    def test_schema_from_mapper_on_column_axis(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        op = MetadataOp(
+            func="rename", args=({"a": "x"},), kwargs={"axis": 1},
+            inputs=[source],
+        )
+        self.assertEqual(["x", "b"], [name for name, _ in op.schema])
+
+    def test_schema_propagates_through_chained_renames(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        first = MetadataOp(
+            func="rename", args=(), kwargs={"columns": {"a": "x"}},
+            inputs=[source],
+        )
+        second = MetadataOp(
+            func="rename", args=(), kwargs={"columns": str.upper},
+            inputs=[first],
+        )
+        self.assertEqual(["X", "B"], [name for name, _ in second.schema])
+
+    def test_index_rename_keeps_column_schema(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        op = MetadataOp(
+            func="rename", args=(), kwargs={"index": {0: 1}},
+            inputs=[source],
+        )
+        self.assertEqual(source.schema, op.schema)
+
+    def test_mapper_defaults_to_index_axis(self):
+        source = DataSourceOp(data=pd.DataFrame({"a": [1], "b": [2]}))
+        op = MetadataOp(
+            func="rename", args=({"a": "x"},), kwargs={},
+            inputs=[source],
+        )
+        self.assertEqual(source.schema, op.schema)
+
+    def test_unknown_input_schema_stays_unknown(self):
+        source = DataSourceOp(file_path="data.csv", _format="csv")
+        op = MetadataOp(
+            func="rename", args=(), kwargs={"columns": {"a": "x"}},
+            inputs=[source],
+        )
+        self.assertIsNone(op.schema)
+
     def test_rename_polars_with_columns_kwarg(self):
         with force_polars():
             op = MetadataOp(func="rename", args=(), kwargs={"columns": {"a": "x"}})
@@ -181,6 +264,47 @@ class TestProjectionOp(unittest.TestCase):
             op = ProjectionOp(method="drop", args=(), kwargs={})
             with self.assertRaises(ValueError):
                 run_op(op, pl.DataFrame({"a": [1]}))
+
+
+class TestDropOpSchema(unittest.TestCase):
+    def setUp(self):
+        self.source = DataSourceOp(
+            data=pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        )
+
+    def test_drop_columns_list_updates_schema(self):
+        op = DropOp(
+            kwargs={"columns": ["b"]},
+            inputs=[self.source],
+        )
+        self.assertEqual(["a", "c"], [name for name, _ in op.schema])
+        self.assertTrue(op.has_schema)
+
+    def test_drop_single_column_updates_schema(self):
+        op = DropOp(
+            kwargs={"columns": "b"},
+            inputs=[self.source],
+        )
+        self.assertEqual(["a", "c"], [name for name, _ in op.schema])
+
+    def test_row_drop_preserves_schema(self):
+        op = DropOp(
+            args=(0,),
+            kwargs={"axis": 0},
+            inputs=[self.source],
+        )
+        self.assertEqual(self.source.schema, op.schema)
+
+    def test_unknown_input_schema_stays_unknown(self):
+        source = DataSourceOp(file_path="data.csv", _format="csv")
+        op = DropOp(kwargs={"columns": "b"}, inputs=[source])
+        self.assertIsNone(op.schema)
+        self.assertFalse(op.has_schema)
+
+    def test_missing_input_stays_unknown(self):
+        op = DropOp(kwargs={"columns": "b"})
+        self.assertIsNone(op.schema)
+        self.assertFalse(op.has_schema)
 
 
 class TestDropOpPolars(PolarsTestCase):

--- a/stratum/tests/logical_optimizer/test_source_ops.py
+++ b/stratum/tests/logical_optimizer/test_source_ops.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import stratum as st
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer.ir._source_ops import DataSourceOp, make_read_op
@@ -47,6 +48,25 @@ class TestDataSourceRewrites(unittest.TestCase):
             data = st.as_data_op(path).skb.apply_func(pd.read_parquet)
             ops = optimize(data, OptConfig(dataframe_ops=True))
         self.assertTrue(any(isinstance(op, ReadParquet) for op in ops))
+
+
+class TestDataSourceMetadata(unittest.TestCase):
+    def test_pandas_schema_preserves_duplicate_columns(self):
+        data = pd.DataFrame([[1, 2]], columns=["a", "a"])
+        op = DataSourceOp(data=data)
+        self.assertEqual(tuple(zip(data.columns, data.dtypes)), op.schema)
+        self.assertTrue(op.has_schema)
+
+    def test_polars_schema(self):
+        data = pl.DataFrame({"a": [1], "b": [2.0]})
+        op = DataSourceOp(data=data)
+        self.assertEqual(tuple(data.schema.items()), op.schema)
+        self.assertTrue(op.has_schema)
+
+    def test_file_schema_is_unknown(self):
+        op = DataSourceOp(file_path="data.csv", _format="csv")
+        self.assertIsNone(op.schema)
+        self.assertFalse(op.has_schema)
 
 
 class TestMakeReadOp(unittest.TestCase):


### PR DESCRIPTION
## Summary

- attach known `(column, dtype)` schemas to in-memory pandas and Polars data sources
- propagate schemas through dataframe `rename` metadata operations
- infer the remaining schema for column drops while preserving schemas for row drops
- cover pandas duplicate columns, Polars schemas, unknown file schemas, rename variants, and drop variants

## Motivation

This is a proof of concept for making dataframe shape and column information available during logical optimization. The draft is intended for architectural feedback before schema information is consumed by `GetItem` classification or column-expression folding.

## Current scope

- in-memory dataframe sources only; file-backed schemas remain unknown
- schema propagation through `rename` and `drop`
- no changes yet to folding or semantic operator grouping


