### PR TITLE
[Rewrite] annihilator operation: 0 / x -> 0

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -10,6 +10,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_add_zero,
     fold_exp_minus_one,
     eliminate_pow_zero,
+    eliminate_zero_div,
     eliminate_identity_subtract,
     eliminate_any_mul_zero,
     eliminate_div_by_one,
@@ -34,6 +35,7 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     pow_zero: bool = True
+    zero_div: bool = True
     identity_subtract: bool = True
     any_mul_zero: bool = True
     div_by_one: bool = True
@@ -49,6 +51,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_add_zero(root)
     if config.div_by_one:
         root = eliminate_div_by_one(root)
+    if config.zero_div:
+        root = eliminate_zero_div(root)
     if config.log_exp:
         root = eliminate_log_exp(root)
     if config.exp_log:

--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -35,7 +35,7 @@ class AlgebraicRewritesConfig:
     add_zero: bool = True
     exp_minus_one: bool = True
     pow_zero: bool = True
-    zero_div: bool = True
+    zero_div: bool = False
     identity_subtract: bool = True
     any_mul_zero: bool = True
     div_by_one: bool = True

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -116,11 +116,10 @@ def make_replace_two_op_chain_root_safe(make_replacement):
     return action
 
 def fold_to_zero(op: Op, root: Op) -> Op:
-    """Fold an op whose result is the constant ``0`` to a ``ValueOp(0.0)``.
+    """Replace ``op`` with a ``ValueOp(0.0)`` and drop its operand edges.
 
-    Used for rewrites like ``x * 0`` and ``0 / x``. Drops the op and its input
-    edges and points downstream consumers at a ``ValueOp(0.0)`` instead, so the
-    operand subgraph is never computed.
+    Mechanism only: the caller must ensure folding to 0 is valid for its op
+    (``x * 0`` always is; ``0 / x`` only when x is non-zero and non-NaN).
     """
     zero_op = ValueOp(0.0)
     for operand in op.inputs:
@@ -215,6 +214,9 @@ eliminate_any_mul_zero = rewrite_pass(
     fold_to_zero,
 )
 
+# NOT semantics-preserving in general: 0/x == 0 only when x != 0 (0/0 = NaN),
+# and folding skips evaluating the divisor. Opt-in via the zero_div flag
+# (default off); enable only when the divisor is known non-zero.
 eliminate_zero_div = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.DIVIDE, 0, reversed=True),
     fold_to_zero,

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -116,13 +116,11 @@ def make_replace_two_op_chain_root_safe(make_replacement):
     return action
 
 def fold_to_zero(op: Op, root: Op) -> Op:
-    """Constant-fold ``x * 0`` (or ``0 * x``) to ``0``.
+    """Fold an op whose result is the constant ``0`` to a ``ValueOp(0.0)``.
 
-    Unlike the identity rewrites, the result is not the input but a constant, so
-    we drop the multiply and its now-dead operand edges and rewire downstream
-    consumers to a :class:`ValueOp` holding ``0.0``. A ValueOp is a source node
-    (no inputs) whose ``process`` returns the constant directly, so the whole
-    ``x`` subgraph is never computed.
+    Used for rewrites like ``x * 0`` and ``0 / x``. Drops the op and its input
+    edges and points downstream consumers at a ``ValueOp(0.0)`` instead, so the
+    operand subgraph is never computed.
     """
     zero_op = ValueOp(0.0)
     for operand in op.inputs:
@@ -214,6 +212,11 @@ eliminate_identity_subtract = rewrite_pass(
 
 eliminate_any_mul_zero = rewrite_pass(
     match_identity_operation(NumericOp, NumericOpType.MULTIPLY, 0),
+    fold_to_zero,
+)
+
+eliminate_zero_div = rewrite_pass(
+    match_identity_operation(NumericOp, NumericOpType.DIVIDE, 0, reversed=True),
     fold_to_zero,
 )
 

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -7,6 +7,10 @@ from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer.ir._ops import OperandRef, ValueOp
 
+
+ZERO_DIV_ON = OptConfig(algebraic_rewrites=True,
+                        algebraic_rewrite_config=AlgebraicRewritesConfig(zero_div=True))
+
 class TestCSE(unittest.TestCase):
 
     def test_log_exp1(self):
@@ -659,10 +663,16 @@ class TestCSE(unittest.TestCase):
         self.assertEqual(out[0].value, 1)
 
     # 0 / x -> 0
-    def test_zero_div(self):
-        """0 / x folds to a single ValueOp(0)."""
+    def test_zero_div_off_by_default(self):
+        """zero_div is opt-in: 0 / x is NOT folded unless the flag is enabled."""
         df = st.as_data_op(5)
         out, *_ = optimize(0 / df)
+        self.assertEqual(len(out), 2)
+
+    def test_zero_div(self):
+        """0 / x folds to a single ValueOp(0) when zero_div is enabled."""
+        df = st.as_data_op(5)
+        out, *_ = optimize(0 / df, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 1)
         self.assertIsInstance(out[0], ValueOp)
         self.assertEqual(out[0].value, 0)
@@ -670,35 +680,27 @@ class TestCSE(unittest.TestCase):
     def test_zero_div_float_numerator(self):
         """0.0 / x also matches (0.0 == 0)."""
         df = st.as_data_op(5)
-        out, *_ = optimize(0.0 / df)
+        out, *_ = optimize(0.0 / df, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 0)
 
     def test_no_rewrite_div_by_zero(self):
-        """x / 0 must not be rewritten to 0."""
+        """x / 0 must not be rewritten to 0 (only 0 / x is)."""
         df = st.as_data_op(np.float64(5.0))
-        out, *_ = optimize(df / 0)
+        out, *_ = optimize(df / 0, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 2)
 
     def test_no_rewrite_normal_div(self):
         """x / 2 must not be rewritten."""
         df = st.as_data_op(6)
-        out, *_ = optimize(df / 2)
-        self.assertEqual(len(out), 2)
-
-    def test_disable_zero_div(self):
-        """zero_div=False keeps the division op in place."""
-        df = st.as_data_op(5)
-        config = OptConfig(algebraic_rewrites=True,
-                           algebraic_rewrite_config=AlgebraicRewritesConfig(zero_div=False))
-        out, *_ = optimize(0 / df, config=config)
+        out, *_ = optimize(df / 2, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 2)
 
     def test_zero_div_with_trailing_op(self):
         """(0 / x) + 3 folds the division to 0, keeping the trailing + 3."""
         df = st.as_data_op(5)
         t2 = (0 / df) + 3
-        out, *_ = optimize(t2)
+        out, *_ = optimize(t2, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0].value, 0)
         self.assertEqual(out[1].process("fit", [out[0].value]), 3)
@@ -707,7 +709,7 @@ class TestCSE(unittest.TestCase):
         """0 / exp(x) folds to 0; the whole divisor subgraph is dropped."""
         df = st.as_data_op(5)
         t2 = 0 / df.skb.apply_func(np.exp)
-        out, *_ = optimize(t2)
+        out, *_ = optimize(t2, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 0)
 
@@ -715,7 +717,7 @@ class TestCSE(unittest.TestCase):
         """identity_op strips * 1 first, then 0 / (x * 1) folds to 0."""
         df = st.as_data_op(5)
         t2 = 0 / (df * 1)
-        out, *_ = optimize(t2)
+        out, *_ = optimize(t2, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 0)
 
@@ -724,6 +726,32 @@ class TestCSE(unittest.TestCase):
         df = st.as_data_op(5)
         t1 = df.skb.apply_func(np.log)
         t2 = t1.skb.apply_func(np.exp)
-        out, *_ = optimize(0 / t2)
+        out, *_ = optimize(0 / t2, config=ZERO_DIV_ON)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 0)
+
+    def test_zero_div_diverges_at_zero_divisor(self):
+        """Divisor = 0: unoptimized 0/0 is NaN, optimized gives 0."""
+        with np.errstate(divide="ignore", invalid="ignore"):
+            df = st.as_data_op(np.float64(0.0))
+            t = 0 / df
+            # flag off (default): DIVIDE op kept, evaluates 0 / 0 -> NaN
+            out_off, *_ = optimize(t)
+            self.assertEqual(len(out_off), 2)
+            self.assertTrue(np.isnan(out_off[1].process("fit", [out_off[0].value])))
+            # flag on: folded to constant 0
+            out_on, *_ = optimize(t, config=ZERO_DIV_ON)
+            self.assertEqual(len(out_on), 1)
+            self.assertEqual(out_on[0].value, 0)
+
+    def test_zero_div_diverges_at_nan_divisor(self):
+        """Divisor = NaN: unoptimized 0/NaN is NaN, optimized gives 0."""
+        with np.errstate(divide="ignore", invalid="ignore"):
+            df = st.as_data_op(np.float64(np.nan))
+            t = 0 / df
+            out_off, *_ = optimize(t)
+            self.assertEqual(len(out_off), 2)
+            self.assertTrue(np.isnan(out_off[1].process("fit", [out_off[0].value])))
+            out_on, *_ = optimize(t, config=ZERO_DIV_ON)
+            self.assertEqual(len(out_on), 1)
+            self.assertEqual(out_on[0].value, 0)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -5,7 +5,7 @@ from stratum.optimizer._optimize import  optimize
 from stratum.optimizer._optimize import OptConfig
 from stratum.optimizer._algebraic_rewrites import AlgebraicRewritesConfig
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
-from stratum.optimizer.ir._ops import OperandRef
+from stratum.optimizer.ir._ops import OperandRef, ValueOp
 
 class TestCSE(unittest.TestCase):
 
@@ -657,3 +657,73 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)
+
+    # 0 / x -> 0
+    def test_zero_div(self):
+        """0 / x folds to a single ValueOp(0)."""
+        df = st.as_data_op(5)
+        out, *_ = optimize(0 / df)
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], ValueOp)
+        self.assertEqual(out[0].value, 0)
+
+    def test_zero_div_float_numerator(self):
+        """0.0 / x also matches (0.0 == 0)."""
+        df = st.as_data_op(5)
+        out, *_ = optimize(0.0 / df)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)
+
+    def test_no_rewrite_div_by_zero(self):
+        """x / 0 must not be rewritten to 0."""
+        df = st.as_data_op(np.float64(5.0))
+        out, *_ = optimize(df / 0)
+        self.assertEqual(len(out), 2)
+
+    def test_no_rewrite_normal_div(self):
+        """x / 2 must not be rewritten."""
+        df = st.as_data_op(6)
+        out, *_ = optimize(df / 2)
+        self.assertEqual(len(out), 2)
+
+    def test_disable_zero_div(self):
+        """zero_div=False keeps the division op in place."""
+        df = st.as_data_op(5)
+        config = OptConfig(algebraic_rewrites=True,
+                           algebraic_rewrite_config=AlgebraicRewritesConfig(zero_div=False))
+        out, *_ = optimize(0 / df, config=config)
+        self.assertEqual(len(out), 2)
+
+    def test_zero_div_with_trailing_op(self):
+        """(0 / x) + 3 folds the division to 0, keeping the trailing + 3."""
+        df = st.as_data_op(5)
+        t2 = (0 / df) + 3
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0].value, 0)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 3)
+
+    def test_zero_div_complex_divisor(self):
+        """0 / exp(x) folds to 0; the whole divisor subgraph is dropped."""
+        df = st.as_data_op(5)
+        t2 = 0 / df.skb.apply_func(np.exp)
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)
+
+    def test_zero_div_after_identity(self):
+        """identity_op strips * 1 first, then 0 / (x * 1) folds to 0."""
+        df = st.as_data_op(5)
+        t2 = 0 / (df * 1)
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)
+
+    def test_zero_div_with_cancelable_divisor(self):
+        """0 / exp(log(x)) folds to 0 regardless of which rewrite runs first."""
+        df = st.as_data_op(5)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+        out, *_ = optimize(0 / t2)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)


### PR DESCRIPTION
1. Add a rewrite rule that folds 0 / x into the constant 0, reusing the existing match_identity_operation and fold_to_zero helpers.
2. Add this rewrite to AlgebraicRewritesConfig
3. Add tests to check that:
-   0 / x collapses to 0.
-   x / 0 and normal divisions like x / 2 are left unchanged.
-   The rule does nothing when zero_div is turned off.
-   It also works inside a larger expression, (0 / x) + 3.
-   It still folds to 0 when combined with other rewrites,  0 / (x * 1).