### PR TITLE
[Minor] add runtime distribution per operator for stats printing

### DIFF
--- a/stratum/_api.py
+++ b/stratum/_api.py
@@ -46,9 +46,17 @@ def stats_printer(sched: SequentialScheduler):
         table = table.groupby("Op").aggregate(["sum", "count"])
         table.columns = ["Time", "Count"]
         table = table.reset_index().sort_values(by="Time", ascending=False)
+        # Share of total DataOp evaluation time, so heavy hitters stand out
+        # relative to the whole run rather than only by absolute seconds.
+        total_time = table["Time"].sum()
+        table["%"] = 100 * table["Time"] / total_time if total_time else 0.0
+        table = table[["Op", "Count", "Time", "%"]]
         print("\n" + "=" * 80)
         print(f"Heavy hitters (sorted by time spent in DataOp evaluation):\n")
-        print(table.head(FLAGS.stats_top_k).to_string(index=False))
+        print(table.head(FLAGS.stats_top_k).to_string(
+            index=False,
+            formatters={"Time": "{:.4f}".format, "%": "{:.1f}%".format},
+        ))
         print("=" * 80)
         print("Total BufferPool overhead during execution:", sched.buffer_pool_overhead)
         print("=" * 80 + "\n")

--- a/stratum/tests/runtime/test_search.py
+++ b/stratum/tests/runtime/test_search.py
@@ -121,8 +121,13 @@ class SearchTest(RuntimeTest):
         out = stdout.getvalue()
         out = out.split("\n")
         self.assertIn("Heavy hitters", out[2])
+        # Header exposes the runtime-distribution column.
+        self.assertIn("%", out[4])
+        # Row: Op, Count, Time, %  (the lambda sleeps 10x so it dominates).
         self.assertIn("CallOp(<lambda>)", out[5])
-        assert(out[5].split(" ")[-1] == "10")
+        fields = out[5].split()
+        self.assertEqual(fields[1], "10")          # invocation count
+        self.assertTrue(fields[-1].endswith("%"))  # share of total runtime
 
 
     def test_fused_attr(self):


### PR DESCRIPTION
new stats output:

```
                              Op  Count   Time     %
                CallOp(<lambda>)      6 0.0376 87.5%
    PandasAssignMapOp(...) [df]       6 0.0020  4.7%
              PandasDropOp [df]       6 0.0012  2.8%
```              