### PR TITLE
[ElasticNet] Rust kernel and its benchmark against Sklearn

### DIFF
--- a/_rust/src/elastic_net.rs
+++ b/_rust/src/elastic_net.rs
@@ -1,0 +1,342 @@
+//! ElasticNet regression via cyclic-Jacobi coordinate descent.
+//!
+//! Minimises: (1/2n)||y − Xw − b||² + α·ρ·||w||₁ + (α/2)·(1−ρ)·||w||²
+//!   where α = alpha, ρ = l1_ratio.
+//!
+//! Algorithm: fused single-pass coordinate descent
+//! -------------------------------------------------
+//! The original two-pass Jacobi loop read X twice per iteration:
+//!   pass 1 — accumulate X^T·r  (fold/reduce over rows)
+//!   pass 2 — update residuals  (par_for_each over rows)
+//! For matrices larger than L3 cache (≥ 20 MB) both passes hit DRAM,
+//! making the algorithm memory-bandwidth bound.
+//!
+//! The fused pass reads X once per iteration. Each Rayon task owns a block
+//! of B rows (target ~256 KB → fits in L2 cache) and performs both operations
+//! before moving on:
+//!
+//!   for each row-block B:
+//!     phase 1 — r[B] -= X[B] · Δw_prev        (X[B] cold → loads into L2)
+//!     phase 2 — dots += X[B]^T · r[B]          (X[B] L2-hot; r[B] L1-hot)
+//!   coordinate update  (O(n_cols), sequential)
+//!
+//! Δw_prev is the coefficient delta from the PREVIOUS iteration; applying it
+//! in phase 1 brings r in sync with the current coef before accumulating dots.
+//! The first iteration is correct because Δw_prev starts at zero.
+//!
+//! Intercept lag correction
+//! -------------------------
+//! After the fused pass r reflects coef_prev. The exact intercept update is:
+//!   b_delta = mean(r) − dot(col_sum, Δw_cur) / n
+//! where col_sum[j] = Σ_i X[i,j] is precomputed once before the main loop.
+
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
+use rayon::prelude::*;
+use crate::threads::get_thread_pool;
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+pub struct ElasticNetModel {
+    pub n_cols:    usize,
+    pub coef:      Vec<f32>,
+    pub intercept: f32,
+    pub n_iter:    usize,
+}
+
+// ─── Core algorithm ───────────────────────────────────────────────────────────
+
+#[inline]
+fn soft_threshold(x: f32, t: f32) -> f32 {
+    if x > t { x - t } else if x < -t { x + t } else { 0.0 }
+}
+
+#[inline]
+fn dot_scalar(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+}
+
+#[inline]
+fn axpy_scalar(acc: &mut [f32], scale: f32, x: &[f32]) {
+    for (a, &xi) in acc.iter_mut().zip(x.iter()) { *a += scale * xi; }
+}
+
+/// Fit an ElasticNet model using Jacobi parallel coordinate descent.
+///
+/// # Parameters
+/// - `x`             — (n_rows × n_cols) design matrix, C-contiguous f32
+/// - `y`             — (n_rows,) target vector, f32
+/// - `alpha`         — total regularisation strength (≥ 0)
+/// - `l1_ratio`      — mixing: 0 = Ridge, 1 = Lasso
+/// - `max_iter`      — maximum full passes over all coordinates
+/// - `tol`           — stop when max relative |Δw_j| < tol
+/// - `fit_intercept` — whether to fit an unpenalised bias term
+pub fn elastic_net_fit(
+    x:             ArrayView2<f32>,
+    y:             ArrayView1<f32>,
+    alpha:         f32,
+    l1_ratio:      f32,
+    max_iter:      usize,
+    tol:           f32,
+    fit_intercept: bool,
+) -> Result<ElasticNetModel, String> {
+    let (n_rows, n_cols) = x.dim();
+    // Reachable from Python, so return an error instead of panicking across FFI.
+    if y.len() != n_rows {
+        return Err(format!(
+            "y length must match number of rows in X: got {} but X has {n_rows} rows",
+            y.len(),
+        ));
+    }
+    let n      = n_rows as f32;
+    let l1_pen = alpha * l1_ratio;
+    let l2_pen = alpha * (1.0 - l1_ratio);
+
+    let x_raw = x.as_slice().ok_or("X must be C-contiguous")?;
+    let pool  = get_thread_pool();
+
+    // ── Precompute (1/n)·||X[:,j]||² ──────────────────────────────────────────
+    let col_norm_sq: Vec<f32> = {
+        let compute = || x_raw
+            .par_chunks(n_cols)
+            .fold(
+                || vec![0.0f32; n_cols],
+                |mut acc, row| {
+                    for (a, &v) in acc.iter_mut().zip(row.iter()) { *a += v * v; }
+                    acc
+                },
+            )
+            .reduce(
+                || vec![0.0f32; n_cols],
+                |mut a, b| { for j in 0..n_cols { a[j] += b[j]; } a },
+            )
+            .into_iter()
+            .map(|s| s / n)
+            .collect();
+        match pool { Some(p) => p.install(compute), None => compute() }
+    };
+
+    // ── Precompute Σ_i X[i,j] — exact intercept lag correction ───────────────
+    let col_sum: Vec<f32> = if fit_intercept {
+        let compute = || x_raw
+            .par_chunks(n_cols)
+            .fold(
+                || vec![0.0f32; n_cols],
+                |mut acc, row| { axpy_scalar(&mut acc, 1.0, row); acc },
+            )
+            .reduce(
+                || vec![0.0f32; n_cols],
+                |mut a, b| { for j in 0..n_cols { a[j] += b[j]; } a },
+            );
+        match pool { Some(p) => p.install(compute), None => compute() }
+    } else {
+        Vec::new()
+    };
+
+    // ── Initialise ────────────────────────────────────────────────────────────
+    let mut coef = vec![0.0f32; n_cols];
+    let mut intercept = if fit_intercept { y.iter().sum::<f32>() / n } else { 0.0 };
+    let mut r: Vec<f32> = y.iter().map(|&yi| yi - intercept).collect();
+
+    // block_rows: target ~256 KB of X per block to fit in L2 cache.
+    let block_rows = (256_usize * 1024 / (n_cols * 4)).clamp(64, 4096);
+
+    let mut prev_deltas = vec![0.0f32; n_cols];
+    let mut n_iter = max_iter;
+
+    for iter in 0..max_iter {
+        // ── Fused pass: ONE read of X per iteration ───────────────────────────
+        // Each Rayon task handles block_rows rows:
+        //   phase 1 — r[block] -= X[block] · prev_deltas  (X cold → L2)
+        //   phase 2 — dots     += X[block]^T · r[block]   (X L2-hot)
+        let dots: Vec<f32> = {
+            let mut fused = || x_raw
+                .par_chunks(block_rows * n_cols)
+                .zip(r.par_chunks_mut(block_rows))
+                .fold(
+                    || vec![0.0f32; n_cols],
+                    |mut local_dots, (x_block, r_block)| {
+                        for (row, ri) in x_block.chunks(n_cols).zip(r_block.iter_mut()) {
+                            *ri -= dot_scalar(row, &prev_deltas);
+                        }
+                        for (row, &ri) in x_block.chunks(n_cols).zip(r_block.iter()) {
+                            axpy_scalar(&mut local_dots, ri, row);
+                        }
+                        local_dots
+                    },
+                )
+                .reduce(
+                    || vec![0.0f32; n_cols],
+                    |mut a, b| { for j in 0..n_cols { a[j] += b[j]; } a },
+                );
+            match pool { Some(p) => p.install(fused), None => fused() }
+        };
+
+        // ── Coordinate update (sequential, O(n_cols)) ─────────────────────────
+        let mut max_delta = 0.0f32;
+        prev_deltas.fill(0.0);
+        for j in 0..n_cols {
+            if col_norm_sq[j] == 0.0 { continue; }
+            let rho_j = dots[j] / n + coef[j] * col_norm_sq[j];
+            let new_w = soft_threshold(rho_j, l1_pen) / (col_norm_sq[j] + l2_pen);
+            let delta = new_w - coef[j];
+            prev_deltas[j] = delta;
+            coef[j]        = new_w;
+            let rel = delta.abs() / new_w.abs().max(1.0);
+            if rel > max_delta { max_delta = rel; }
+        }
+
+        // ── Intercept update (sequential, O(n_rows + n_cols)) ─────────────────
+        // Exact correction for the one-iteration lag in r:
+        //   mean(r_true) = mean(r) − dot(col_sum, Δw_cur) / n
+        if fit_intercept {
+            let lag: f32 = col_sum.iter().zip(prev_deltas.iter())
+                .map(|(&s, &d)| s * d).sum::<f32>();
+            let b_delta = r.iter().sum::<f32>() / n - lag / n;
+            if b_delta.abs() > f32::EPSILON {
+                for ri in r.iter_mut() { *ri -= b_delta; }
+                intercept += b_delta;
+            }
+        }
+
+        if max_delta < tol { n_iter = iter + 1; break; }
+    }
+
+    Ok(ElasticNetModel { n_cols, coef, intercept, n_iter })
+}
+
+/// Predict with a fitted model: ŷ = X·w + b.
+///
+/// Takes a borrowed view (fix #1): predict is read-only, so there is no need to
+/// copy the whole design matrix across the FFI boundary. Rows are processed in
+/// L2-sized blocks (fix #3) so each Rayon task does substantial work — one dot
+/// product per row was far too fine-grained and let scheduling overhead dominate.
+pub fn elastic_net_predict(
+    x:     ArrayView2<f32>,
+    model: &ElasticNetModel,
+) -> Result<Vec<f32>, String> {
+    let n_cols = model.n_cols;
+    if x.ncols() != n_cols {
+        return Err(format!(
+            "n_cols mismatch: got {} but model expects {}",
+            x.ncols(), n_cols
+        ));
+    }
+    let n_rows    = x.nrows();
+    let coef      = &model.coef;
+    let intercept = model.intercept;
+    let raw  = x.as_slice().ok_or("elastic_net_predict: C-contiguous input required")?;
+    let pool = get_thread_pool();
+
+    // Coarse task granularity: ~256 KB of X per block, matching the fit loop.
+    let block_rows = (256_usize * 1024 / (n_cols * 4)).clamp(64, 4096);
+
+    let mut preds = vec![0.0f32; n_rows];
+    let mut compute = || {
+        raw.par_chunks(block_rows * n_cols)
+            .zip(preds.par_chunks_mut(block_rows))
+            .for_each(|(x_block, p_block)| {
+                for (row, p) in x_block.chunks(n_cols).zip(p_block.iter_mut()) {
+                    *p = dot_scalar(row, coef) + intercept;
+                }
+            });
+    };
+    match pool { Some(p) => p.install(compute), None => compute() };
+    Ok(preds)
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    const EPS: f32 = 1e-2;
+
+    fn arr2(rows: Vec<Vec<f32>>) -> Array2<f32> {
+        let n_rows = rows.len();
+        let n_cols = rows[0].len();
+        Array2::from_shape_vec(
+            (n_rows, n_cols),
+            rows.into_iter().flatten().collect(),
+        ).unwrap()
+    }
+
+    #[test]
+    fn fits_linear_signal() {
+        let x = arr2(vec![
+            vec![1.0, 2.0], vec![2.0, 1.0], vec![3.0, 4.0],
+            vec![4.0, 3.0], vec![5.0, 5.0],
+        ]);
+        let y: Array1<f32> = array![8.0, 7.0, 18.0, 17.0, 25.0];
+        let model = elastic_net_fit(x.view(), y.view(), 1e-4, 0.5, 5000, 1e-6, false).unwrap();
+        let preds = elastic_net_predict(x.view(), &model).unwrap();
+        for (p, &t) in preds.iter().zip(y.iter()) {
+            assert!((p - t).abs() < 0.1, "pred={p:.3} target={t:.3}");
+        }
+    }
+
+    #[test]
+    fn lasso_produces_sparsity() {
+        let x = arr2(vec![
+            vec![1.0, 0.0, 5.0], vec![2.0, 0.0, 6.0],
+            vec![3.0, 0.0, 7.0], vec![4.0, 0.0, 8.0],
+        ]);
+        let y: Array1<f32> = array![5.0, 10.0, 15.0, 20.0];
+        let model = elastic_net_fit(x.view(), y.view(), 1.0, 1.0, 5000, 1e-6, false).unwrap();
+        assert!(model.coef[1].abs() < EPS, "zero column should stay zero");
+    }
+
+    #[test]
+    fn ridge_does_not_zero_coefficients() {
+        let x = arr2(vec![
+            vec![1.0, 2.0], vec![2.0, 3.0], vec![3.0, 4.0], vec![4.0, 5.0],
+        ]);
+        let y: Array1<f32> = array![3.0, 5.0, 7.0, 9.0];
+        let model = elastic_net_fit(x.view(), y.view(), 0.1, 0.0, 5000, 1e-6, false).unwrap();
+        assert!(model.coef[0].abs() > 1e-4 || model.coef[1].abs() > 1e-4);
+        let preds = elastic_net_predict(x.view(), &model).unwrap();
+        let mse: f32 = preds.iter().zip(y.iter()).map(|(p, &t)| (p - t).powi(2)).sum::<f32>() / 4.0;
+        assert!(mse < 1.0, "MSE={mse:.4}");
+    }
+
+    #[test]
+    fn fit_intercept_shifts_prediction() {
+        let x = arr2(vec![vec![1.0], vec![2.0], vec![3.0]]);
+        let y: Array1<f32> = array![11.0, 12.0, 13.0]; // y = x + 10
+        let model = elastic_net_fit(x.view(), y.view(), 1e-4, 0.5, 5000, 1e-6, true).unwrap();
+        assert!((model.intercept - 10.0).abs() < 0.5, "intercept={:.3}", model.intercept);
+    }
+
+    #[test]
+    fn predict_ncols_mismatch_errors() {
+        let x = arr2(vec![vec![1.0, 2.0]]);
+        let y: Array1<f32> = array![3.0];
+        let model = elastic_net_fit(x.view(), y.view(), 0.1, 0.5, 100, 1e-4, false).unwrap();
+        let bad = arr2(vec![vec![1.0]]);
+        assert!(elastic_net_predict(bad.view(), &model).is_err());
+    }
+
+    #[test]
+    fn fit_rejects_mismatched_y_length() {
+        let x = arr2(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+        let y: Array1<f32> = array![1.0];
+        assert!(elastic_net_fit(x.view(), y.view(), 0.1, 0.5, 10, 1e-4, false).is_err());
+    }
+
+    #[test]
+    fn fit_rejects_non_contiguous_x() {
+        let x = arr2(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+        let y: Array1<f32> = array![1.0, 2.0];
+        // Transposed: right shape, not C-contiguous.
+        assert!(elastic_net_fit(x.t(), y.view(), 0.1, 0.5, 10, 1e-4, false).is_err());
+    }
+
+    #[test]
+    fn zero_input_zero_predictions() {
+        let x = Array2::<f32>::zeros((4, 3));
+        let y: Array1<f32> = array![1.0, 2.0, 3.0, 4.0];
+        let model = elastic_net_fit(x.view(), y.view(), 0.1, 0.5, 100, 1e-4, true).unwrap();
+        assert!(model.coef.iter().all(|&c| c.abs() < EPS));
+    }
+}

--- a/_rust/src/lib.rs
+++ b/_rust/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use ndarray::{Array2, Axis};
-use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
+use ndarray::{Array1, Array2, Axis};
+use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyIterator, PyList, PyModule};
 use pyo3::{PyErr, exceptions::PyValueError};
@@ -19,6 +19,7 @@ mod truncated_svd;  //TruncatedSVD using randomized SVD
 mod util;
 mod threads;
 mod one_hot_encoder;
+mod elastic_net;
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
 
@@ -51,6 +52,9 @@ struct FdEmbedModel {
 }
 static FD_EMBED_NEXT_ID: AtomicU64 = AtomicU64::new(1);
 static FD_EMBED_MODELS: Lazy<Mutex<HashMap<u64, FdEmbedModel>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+static EN_NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static EN_MODELS: Lazy<Mutex<HashMap<u64, elastic_net::ElasticNetModel>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 // Simple mapping from domain error to PyErr
 fn to_pyerr(err: tfidf::Error) -> PyErr {
@@ -654,6 +658,79 @@ fn tfidf_transform_csr(
     Ok((Py::from(py_data), Py::from(py_indices), Py::from(py_indptr), n_rows, n_cols))
 }
 
+// ---- ElasticNet ----
+
+#[pyfunction]
+fn elastic_net_fit_dense(
+    py:            Python<'_>,
+    x:             PyReadonlyArray2<f32>,
+    y:             PyReadonlyArray1<f32>,
+    alpha:         f32,
+    l1_ratio:      f32,
+    max_iter:      usize,
+    tol:           f32,
+    fit_intercept: bool,
+) -> PyResult<(u64, Py<PyArray1<f32>>, f32, usize)> {
+    // fix #2: fit only reads X and y, so borrow the numpy buffers instead of
+    // copying them across the FFI boundary.
+    let x_arr = x.as_array();
+    let y_arr = y.as_array();
+    let model = py.detach(|| {
+        elastic_net::elastic_net_fit(x_arr, y_arr, alpha, l1_ratio, max_iter, tol, fit_intercept)
+    }).map_err(pyo3::exceptions::PyValueError::new_err)?;
+    let coef_arr  = Array1::from_vec(model.coef.clone());
+    let intercept = model.intercept;
+    let n_iter    = model.n_iter;
+    let model_id  = EN_NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    EN_MODELS
+        .lock()
+        .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("EN_MODELS mutex poisoned"))?
+        .insert(model_id, model);
+    Ok((model_id, Py::from(coef_arr.into_pyarray(py).to_owned()), intercept, n_iter))
+}
+
+#[pyfunction]
+fn elastic_net_predict_dense(
+    py:       Python<'_>,
+    model_id: u64,
+    x:        PyReadonlyArray2<f32>,
+) -> PyResult<Py<PyArray1<f32>>> {
+    // fix #1: predict is read-only, so borrow the numpy buffer as a view instead
+    // of copying the whole design matrix across the FFI boundary.
+    let x_arr = x.as_array();
+    let (coef, intercept, n_cols) = {
+        let guard = EN_MODELS
+            .lock()
+            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("EN_MODELS mutex poisoned"))?;
+        let m = guard
+            .get(&model_id)
+            .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(format!("Unknown model_id {model_id}")))?;
+        (m.coef.clone(), m.intercept, m.n_cols)
+    };
+    let preds = py.detach(|| {
+        elastic_net::elastic_net_predict(x_arr, &elastic_net::ElasticNetModel {
+            n_cols,
+            coef,
+            intercept,
+            n_iter: 0,
+        })
+    }).map_err(|e| PyErr::new::<PyValueError, _>(e))?;
+    let preds_arr = Array1::from_vec(preds);
+    Ok(Py::from(preds_arr.into_pyarray(py).to_owned()))
+}
+
+/// Drop a fitted model from the registry, which fit() otherwise only grows.
+///
+/// Returns True if a model was removed, so freeing the same id twice is safe.
+#[pyfunction]
+fn elastic_net_free(model_id: u64) -> PyResult<bool> {
+    Ok(EN_MODELS
+        .lock()
+        .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("EN_MODELS mutex poisoned"))?
+        .remove(&model_id)
+        .is_some())
+}
+
 // ---- Expose module ----
 #[pymodule]
 fn _rust_backend_native(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
@@ -667,5 +744,8 @@ fn _rust_backend_native(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(one_hot_encoder::csr_to_dense, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_fit_csr, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_transform_csr, m)?)?;
+    m.add_function(wrap_pyfunction!(elastic_net_fit_dense, m)?)?;
+    m.add_function(wrap_pyfunction!(elastic_net_predict_dense, m)?)?;
+    m.add_function(wrap_pyfunction!(elastic_net_free, m)?)?;
     Ok(())
 }

--- a/benchmarks/adapters/bench_elastic_net.py
+++ b/benchmarks/adapters/bench_elastic_net.py
@@ -1,0 +1,226 @@
+"""
+Benchmark: Rust ElasticNet vs sklearn ElasticNet.
+
+Both sides run the same stratum.ElasticNet estimator, with
+skrub.set_config(rust_backend=...) choosing the backend, so the sklearn column
+measures the fallback path the adapter itself would take and both sides receive
+the identical float32 input. Timing covers the whole fit / predict call,
+including the input validation both backends perform.
+
+Metrics: fit time, predict time, and coefficient agreement between the two
+backends.
+
+Usage
+-----
+    cd <repo_root>
+    uv run python benchmarks/adapters/bench_elastic_net.py            # default small sizes
+    uv run python benchmarks/adapters/bench_elastic_net.py --reps 10
+    uv run python benchmarks/adapters/bench_elastic_net.py --large    # only large   (~100 MB)
+    uv run python benchmarks/adapters/bench_elastic_net.py --xlarge   # only v. large (~1 GB)
+    uv run python benchmarks/adapters/bench_elastic_net.py --xxlarge  # only vv large (~2 GB)
+    uv run python benchmarks/adapters/bench_elastic_net.py --debug-timing
+
+Size flags are mutually exclusive and each runs ONLY its own tier.
+"""
+import os
+os.environ["SKRUB_RUST"] = "1"
+
+import argparse
+import gc
+import sys
+import time
+
+import numpy as np
+
+import stratum as skrub
+from stratum import ElasticNet
+from stratum import _rust_backend as rb
+
+if not rb.HAVE_RUST:
+    sys.exit("Rust backend not built. Run: cd _rust && maturin develop --release")
+
+MAX_ITER = 1000
+TOL = 1e-4
+
+# ── backend selection ─────────────────────────────────────────────────────────
+
+DEBUG_TIMING = False
+NUM_THREADS = 0        # 0 = let the backend decide (Rayon global pool = one per core)
+
+def use_backend(rust: bool):
+    """Point stratum at the Rust solver or back at sklearn.
+
+    stratum.ElasticNet reads the config on every call, so one estimator class
+    serves both columns of the table.
+
+    The thread count must be set before the first kernel call: the Rust side
+    caches it in a Lazy (util.rs NUM_THREADS) and builds its pool in a OnceLock
+    (threads.rs POOL), so later changes are silently ignored. One process
+    therefore measures exactly one thread count, which is why --threads takes a
+    single value rather than a sweep.
+    """
+    if rust:
+        skrub.set_config(rust_backend=True, debug_timing=DEBUG_TIMING,
+                         num_threads=NUM_THREADS)
+    else:
+        skrub.set_config(rust_backend=False, debug_timing=DEBUG_TIMING)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def make_data(n_rows, n_cols, seed=42):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n_rows, n_cols)).astype(np.float32)
+    true_coef = rng.standard_normal(n_cols).astype(np.float32)
+    y = (X @ true_coef + 0.1 * rng.standard_normal(n_rows)).astype(np.float32)
+    return X, y
+
+
+def timeit(fn, n_reps=5):
+    times = []
+    for _ in range(n_reps):
+        gc.collect()
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return float(np.median(times))
+
+
+def warmup(fn, n=2):
+    for _ in range(n):
+        fn()
+    gc.collect()
+
+
+# ── benchmark ─────────────────────────────────────────────────────────────────
+
+COL_W = 22
+
+def _ms(t): return f"{t * 1000:.1f} ms"
+
+def print_header():
+    h = (f"{'kernel':<{COL_W}}"
+         f"{'sklearn':>{COL_W}}"
+         f"{'rust':>{COL_W}}"
+         f"{'speedup':>{COL_W}}")
+    print(h)
+    print("-" * len(h))
+
+def print_row(name, sk_t, ru_t, extra=""):
+    if sk_t is None:
+        print(f"{name:<{COL_W}}{'— skipped':>{COL_W}}{_ms(ru_t):>{COL_W}}"
+              f"{'—':>{COL_W}}{extra}")
+        return
+    sp = sk_t / ru_t if ru_t > 0 else float("inf")
+    mark = " ✓" if sp >= 1.0 else " ✗"
+    print(f"{name:<{COL_W}}{_ms(sk_t):>{COL_W}}{_ms(ru_t):>{COL_W}}"
+          f"{sp:>{COL_W - 2}.2f}x{mark}{extra}")
+
+
+def _fresh(alpha, l1_ratio):
+    return ElasticNet(alpha=alpha, l1_ratio=l1_ratio, max_iter=MAX_ITER,
+                      tol=TOL, fit_intercept=True)
+
+
+def bench_one(X, y, alpha, l1_ratio, n_reps, compare_sklearn=True):
+    """Time fit and predict on each backend and compare the fitted coefficients."""
+    results = {}
+    for rust in ((False, True) if compare_sklearn else (True,)):
+        use_backend(rust)
+        # A fresh estimator per repetition: fit must not reuse prior state.
+        warmup(lambda: _fresh(alpha, l1_ratio).fit(X, y))
+        fit_t = timeit(lambda: _fresh(alpha, l1_ratio).fit(X, y), n_reps)
+
+        model = _fresh(alpha, l1_ratio).fit(X, y)
+        warmup(lambda: model.predict(X))
+        pred_t = timeit(lambda: model.predict(X), n_reps)
+        results[rust] = (fit_t, pred_t, np.asarray(model.coef_, dtype=np.float32),
+                         int(getattr(model, "n_iter_", -1)))
+        del model
+        gc.collect()
+
+    ru_fit, ru_pred, ru_coef, ru_iter = results[True]
+    if not compare_sklearn:
+        return None, ru_fit, None, ru_pred, None, ru_iter, None
+    sk_fit, sk_pred, sk_coef, sk_iter = results[False]
+    coef_mse = float(np.mean((ru_coef - sk_coef) ** 2))
+    return sk_fit, ru_fit, sk_pred, ru_pred, coef_mse, ru_iter, sk_iter
+
+
+def run_suite(sizes, alpha, l1_ratio, n_reps, compare_sklearn=True):
+    for n_rows, n_cols in sizes:
+        gb = n_rows * n_cols * 4 / 1e9
+        size_str = f"~{gb*1000:.0f} MB" if gb < 1 else f"~{gb:.1f} GB"
+        print(f"\n{'='*88}")
+        print(f"  ({n_rows:,} × {n_cols})  {size_str} f32  alpha={alpha}  l1_ratio={l1_ratio}  "
+              f"max_iter={MAX_ITER}  reps={n_reps}")
+        print(f"{'='*88}")
+
+        X, y = make_data(n_rows, n_cols)
+        sk_fit_t, ru_fit_t, sk_pred_t, ru_pred_t, coef_mse, n_iter, sk_iter = \
+            bench_one(X, y, alpha, l1_ratio, n_reps, compare_sklearn)
+
+        print_header()
+        # Both iteration counts, because the solvers stop on different criteria
+        # (max relative |dw_j| here, duality gap in sklearn). Without sklearn's
+        # count there is no way to tell a faster iteration from a shorter run.
+        iters = f"  (n_iter rust={n_iter}"
+        iters += f", sklearn={sk_iter})" if sk_iter is not None else ")"
+        print_row("elastic_net fit", sk_fit_t, ru_fit_t, iters)
+        mse_extra = f"  coef_mse={coef_mse:.2e}" if coef_mse is not None else ""
+        print_row("elastic_net predict", sk_pred_t, ru_pred_t, mse_extra)
+        del X, y
+        gc.collect()
+
+
+# Size tiers — mutually exclusive; each flag runs ONLY its own set.
+DEFAULT_SIZES = [(10_000, 50), (50_000, 50), (100_000, 50), (100_000, 100)]
+LARGE_SIZES   = [(500_000, 50), (1_000_000, 20)]                       # ~100 MB
+XLARGE_SIZES  = [(2_000_000, 100), (5_000_000, 50), (10_000_000, 20)]  # ~1 GB
+XXLARGE_SIZES = [(10_000_000, 50)]                                    # ~2 GB
+
+
+def main():
+    global DEBUG_TIMING, NUM_THREADS
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--reps",     type=int,   default=None,
+                   help="timed repetitions (default: 5, or 3 for --xlarge/--xxlarge)")
+    p.add_argument("--alpha",    type=float, default=0.1)
+    p.add_argument("--l1-ratio", type=float, default=0.5)
+    p.add_argument("--threads", type=int, default=0, metavar="N",
+                   help=f"Rust thread count (default 0 = one per core, {os.cpu_count()} here)")
+    p.add_argument("--debug-timing", action="store_true",
+                   help="print the backend's per-call kernel timings")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--large",   action="store_true",
+                   help="run ONLY large matrices (~100 MB f32)")
+    g.add_argument("--xlarge",  action="store_true",
+                   help="run ONLY very large matrices (~1 GB f32)")
+    g.add_argument("--xxlarge", action="store_true",
+                   help="run ONLY very very large matrices (~2 GB f32)")
+    args = p.parse_args()
+
+    DEBUG_TIMING = args.debug_timing
+    NUM_THREADS = args.threads
+
+    if args.xxlarge:
+        sizes = XXLARGE_SIZES
+    elif args.xlarge:
+        sizes = XLARGE_SIZES
+    elif args.large:
+        sizes = LARGE_SIZES
+    else:
+        sizes = DEFAULT_SIZES
+
+    # Very/very-very large fits are seconds each; fewer reps keeps runtime sane.
+    big = args.xlarge or args.xxlarge
+    n_reps = args.reps if args.reps is not None else (3 if big else 5)
+
+    print(f"sklearn {__import__('sklearn').__version__}  |  numpy {np.__version__}  "
+          f"|  reps={n_reps}  |  threads={args.threads or 'default (%d)' % (os.cpu_count() or 1)}")
+    run_suite(sizes, args.alpha, args.l1_ratio, n_reps, compare_sklearn=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/stratum/__init__.py
+++ b/stratum/__init__.py
@@ -26,11 +26,13 @@ __skrub_version__ = _dist_version("skrub")
 # Expose our subclasses under the same names
 from .adapters.string_encoder import RustyStringEncoder as StringEncoder
 from .adapters.one_hot_encoder import RustyOneHotEncoder as OneHotEncoder
+from .adapters.elastic_net import RustyElasticNet as ElasticNet
 
 # __all__ passthrough. Keep __all__ minimal
 __all__ = [
     "StringEncoder",
     "OneHotEncoder",
+    "ElasticNet",
     "config",
     "__version__",
     "__skrub_version__",

--- a/stratum/_rust_backend.py
+++ b/stratum/_rust_backend.py
@@ -75,3 +75,6 @@ truncated_svd_fit = getattr(native, "truncated_svd_fit_from_csr", None) if nativ
 truncated_svd_transform = getattr(native, "truncated_svd_transform_from_csr", None) if native else None
 ohe_transform = getattr(native, "ohe_transform_csr", None) if native else None
 csr_to_dense = getattr(native, "csr_to_dense", None) if native else None
+elastic_net_fit = getattr(native, "elastic_net_fit_dense", None) if native else None
+elastic_net_predict = getattr(native, "elastic_net_predict_dense", None) if native else None
+elastic_net_free = getattr(native, "elastic_net_free", None) if native else None

--- a/stratum/adapters/elastic_net.py
+++ b/stratum/adapters/elastic_net.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+import warnings
+
+import numpy as np
+from sklearn.linear_model import ElasticNet as _SKElasticNet
+from sklearn.utils.validation import check_array, check_is_fitted, validate_data
+
+from .._config import get_config
+from .. import _rust_backend as rb
+
+# File-internal config flags
+_DEBUG_INFO = False
+
+
+class UnsupportedParameterWarning(UserWarning):
+    """A parameter the Rust solver cannot honour was set and has been ignored."""
+
+
+# Options the Jacobi solver does not implement. The Rust path runs anyway and
+# ignores them, warning the caller. Split by whether ignoring them can change
+# the answer:
+#   * "tuning" options only affect how the solution is reached, so ignoring them
+#     yields the same coefficients sklearn would produce.
+#   * "semantic" options change what the solution IS. Ignoring them returns a
+#     different model from the one that was asked for.
+_IGNORED_TUNING = {
+    "precompute": (False, "the solver has no Gram-matrix path"),
+    "warm_start": (False, "the Jacobi solver keeps no state between fits"),
+    "selection":  ("cyclic", "Jacobi updates every coordinate from one snapshot, "
+                             "so coordinate ordering has no meaning"),
+}
+_IGNORED_SEMANTIC = {
+    "positive": (False, "the solver has no non-negativity constraint, so "
+                        "coefficients MAY BE NEGATIVE despite positive=True"),
+}
+
+
+def _warn_ignored(est):
+    """Warn about set-but-unhonoured parameters. Returns nothing; never raises."""
+    for name, (default, why) in _IGNORED_TUNING.items():
+        if getattr(est, name) != default:
+            warnings.warn(
+                f"{type(est).__name__}: {name}={getattr(est, name)!r} is not supported "
+                f"by the Rust backend and was ignored ({why}). It affects how "
+                f"the solution is reached, not what is optimised, but it can "
+                f"still move the coefficients if max_iter or tol stops the "
+                f"solver before convergence.",
+                UnsupportedParameterWarning, stacklevel=3,
+            )
+    for name, (default, why) in _IGNORED_SEMANTIC.items():
+        if getattr(est, name) != default:
+            warnings.warn(
+                f"{type(est).__name__}: {name}={getattr(est, name)!r} is not supported "
+                f"by the Rust backend and was ignored ({why}). THE RESULT DIFFERS "
+                f"from sklearn. Use set_config(rust_backend=False) to honour it.",
+                UnsupportedParameterWarning, stacklevel=3,
+            )
+    # random_state only has an effect together with selection='random'
+    if est.random_state is not None and est.selection == "random":
+        warnings.warn(
+            f"{type(est).__name__}: random_state is not used by the Rust backend, "
+            f"because coordinate selection is not randomised.",
+            UnsupportedParameterWarning, stacklevel=3,
+        )
+
+
+def _rust_available():
+    """True when the config allows the Rust backend and both kernels are present."""
+    rc = get_config()
+    if not (rc["allow_patch"] and rc["rust_backend"] and rb.HAVE_RUST):
+        return False
+    return getattr(rb, "elastic_net_fit", None) is not None \
+        and getattr(rb, "elastic_net_predict", None) is not None
+
+
+def _is_supported_array(X):
+    """The kernel takes a 2-D, C-contiguous, float32 dense design matrix.
+
+    Anything else (sparse, float64, F-order, a DataFrame) goes back to sklearn
+    rather than being silently converted, so the result matches what sklearn
+    would have produced for that input.
+    """
+    return (isinstance(X, np.ndarray) and X.ndim == 2
+            and X.dtype == np.float32 and X.flags.c_contiguous)
+
+
+class RustyElasticNet(_SKElasticNet):
+    """Drop-in :class:`sklearn.linear_model.ElasticNet` backed by the Rust solver.
+
+    The Rust path covers the common case: a dense ``float32`` design matrix, a
+    single ``float32`` target, and the default solver options. Everything else
+    (sparse input, ``float64``, multi-output ``y``, ``precompute``,
+    ``warm_start``, ``positive``, random ``selection``, or sample weights) falls
+    back to sklearn, so behaviour and dtypes stay what sklearn would produce.
+
+    The config is read on every call, so ``set_config(rust_backend=False)``
+    routes back to sklearn without rebuilding the estimator.
+    """
+
+    def fit(self, X, y, sample_weight=None, check_input=True):
+        # The registry never collects on its own, so release the previous model
+        # before its id is overwritten.
+        self._free_rust_model()
+        self._rust_model_id = None
+        # sample_weight is not a constructor option and reweighting the loss
+        # changes the objective outright, so that one still defers to sklearn.
+        if not _rust_available() or sample_weight is not None \
+                or not _is_supported_array(X):
+            return super().fit(X, y, sample_weight=sample_weight, check_input=check_input)
+
+        # Validate the way sklearn does, so NaN/inf raise here rather than
+        # propagating into the solver and so n_features_in_ is recorded.
+        X, y = validate_data(self, X, y, accept_sparse="csc", order="C",
+                             dtype=np.float32, y_numeric=True, multi_output=True)
+        # sklearn's ElasticNet.fit scans three times: validate_data covers X and
+        # y, then it re-checks y alone to coerce it to whichever dtype X ended up
+        # with (it accepts float32 or float64, so it cannot know in advance).
+        # Mirror that third scan exactly, over y and not X, so both backends do
+        # identical validation work.
+        y = check_array(y, order="C", copy=False, dtype=X.dtype.type,
+                        ensure_2d=False, estimator=type(self).__name__)
+        y = np.asarray(y, dtype=np.float32)
+        if y.ndim != 1:
+            # Multi-output is a different solver; hand it back to sklearn.
+            return super().fit(X, y, sample_weight=sample_weight, check_input=check_input)
+
+        # Warn only once the Rust path is committed to; the fallbacks above do
+        # honour these options.
+        _warn_ignored(self)
+
+        if _DEBUG_INFO:
+            print("INFO: Dispatching ElasticNet fit to Rust backend")
+
+        t0 = rb.start_timing()
+        model_id, coef, intercept, n_iter = rb.elastic_net_fit(
+            X, y, float(self.alpha), float(self.l1_ratio),
+            int(self.max_iter), float(self.tol), bool(self.fit_intercept),
+        )
+        rb.print_timing("elastic_net_fit", t0)
+
+        self._rust_model_id = model_id
+        self.coef_      = np.asarray(coef, dtype=np.float32)
+        self.intercept_ = np.float32(intercept)
+        self.n_iter_    = int(n_iter)
+        # sklearn exposes the coordinate-descent duality gap; the Jacobi solver
+        # does not compute one, so report it as unavailable rather than faking it.
+        self.dual_gap_  = np.nan
+        return self
+
+    def predict(self, X):
+        check_is_fitted(self)
+        if (getattr(self, "_rust_model_id", None) is None
+                or not _rust_available() or not _is_supported_array(X)):
+            return super().predict(X)
+
+        X = validate_data(self, X, accept_sparse="csr", order="C",
+                          dtype=np.float32, reset=False)
+        if _DEBUG_INFO:
+            print("INFO: Dispatching ElasticNet predict to Rust backend")
+
+        t0 = rb.start_timing()
+        out = rb.elastic_net_predict(self._rust_model_id, X)
+        rb.print_timing("elastic_net_predict", t0)
+        return np.asarray(out, dtype=np.float32)
+
+    def _free_rust_model(self):
+        """Release this estimator's model from the Rust-side registry.
+
+        The registry is process-global and only ever inserted into, so an
+        unreleased model lives until the process exits. Safe to call repeatedly
+        and on an unfitted estimator.
+        """
+        try:
+            model_id = getattr(self, "_rust_model_id", None)
+            if model_id is None or rb.elastic_net_free is None:
+                return
+            rb.elastic_net_free(model_id)
+        except Exception:
+            # Cleanup must not raise: __del__ can run during interpreter
+            # shutdown, with module globals already torn down.
+            return
+        self._rust_model_id = None
+
+    def __del__(self):
+        # Covers fit-and-discard, where no refit comes along to release it.
+        self._free_rust_model()

--- a/stratum/tests/adapters/test_elastic_net.py
+++ b/stratum/tests/adapters/test_elastic_net.py
@@ -1,0 +1,158 @@
+import os
+os.environ.setdefault("SKRUB_RUST", "1")
+import numpy as np
+import pytest
+from sklearn.linear_model import ElasticNet, Lasso, Ridge
+
+from stratum import _rust_backend as rb
+
+pytestmark = pytest.mark.skipif(not rb.HAVE_RUST, reason="Rust backend not built")
+
+EPS = 1e-2   # f32 precision + CD approximation tolerance
+
+
+def _f32(arr):
+    return np.asarray(arr, dtype=np.float32)
+
+
+def make_regression(n=200, p=10, seed=42):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p)).astype(np.float32)
+    true_coef = rng.standard_normal(p).astype(np.float32)
+    y = (X @ true_coef + 0.1 * rng.standard_normal(n)).astype(np.float32)
+    return X, y, true_coef
+
+
+# ---- fit return shape / dtype ----
+
+class TestFitReturnValues:
+    def test_returns_four_tuple(self):
+        X, y, _ = make_regression(50, 5)
+        result = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert len(result) == 4
+
+    def test_model_id_is_positive_int(self):
+        X, y, _ = make_regression(50, 5)
+        model_id, *_ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert isinstance(model_id, int) and model_id > 0
+
+    def test_coef_shape(self):
+        X, y, _ = make_regression(50, 5)
+        _, coef, intercept, _ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert coef.shape == (5,)
+
+    def test_coef_dtype_float32(self):
+        X, y, _ = make_regression(50, 5)
+        _, coef, _, _ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert coef.dtype == np.float32
+
+    def test_intercept_is_scalar(self):
+        X, y, _ = make_regression(50, 5)
+        _, _, intercept, _ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert np.isscalar(intercept) or intercept.ndim == 0
+
+    def test_n_iter_positive(self):
+        X, y, _ = make_regression(50, 5)
+        _, _, _, n_iter = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        assert n_iter >= 1
+
+
+# ---- predict ----
+
+class TestPredict:
+    def test_predict_shape(self):
+        X, y, _ = make_regression(100, 8)
+        model_id, *_ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        preds = rb.elastic_net_predict(model_id, X)
+        assert preds.shape == (100,)
+
+    def test_predict_dtype_float32(self):
+        X, y, _ = make_regression(50, 5)
+        model_id, *_ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        preds = rb.elastic_net_predict(model_id, X)
+        assert preds.dtype == np.float32
+
+    def test_predict_ncols_mismatch_raises(self):
+        X, y, _ = make_regression(50, 5)
+        model_id, *_ = rb.elastic_net_fit(X, y, 0.1, 0.5, 1000, 1e-4, True)
+        bad = _f32(np.random.randn(10, 3))
+        with pytest.raises(Exception):
+            rb.elastic_net_predict(model_id, bad)
+
+    def test_invalid_model_id_raises(self):
+        X = _f32(np.random.randn(10, 3))
+        with pytest.raises(Exception):
+            rb.elastic_net_predict(999_999_999, X)
+
+    def test_manual_prediction_matches(self):
+        X, y, _ = make_regression(50, 5)
+        model_id, coef, intercept, _ = rb.elastic_net_fit(X, y, 0.01, 0.5, 5000, 1e-6, True)
+        preds_rust = rb.elastic_net_predict(model_id, X)
+        preds_manual = X.astype(np.float32) @ coef.astype(np.float32) + float(intercept)
+        np.testing.assert_allclose(preds_rust, preds_manual, atol=1e-4)
+
+
+# ---- agreement with sklearn ----
+
+class TestSklearnAgreement:
+    """
+    ElasticNet implementations can differ in convergence criterion and
+    normalisation, so we compare predictions rather than coefficients.
+    """
+
+    def _compare_predictions(self, X, y, alpha=0.01, l1_ratio=0.5,
+                              fit_intercept=True, rtol=0.05):
+        sk = ElasticNet(alpha=alpha, l1_ratio=l1_ratio,
+                        fit_intercept=fit_intercept,
+                        max_iter=10_000, tol=1e-6)
+        sk.fit(X.astype(np.float64), y.astype(np.float64))
+        sk_preds = sk.predict(X.astype(np.float64)).astype(np.float32)
+
+        model_id, *_ = rb.elastic_net_fit(X, y, alpha, l1_ratio, 10_000, 1e-6, fit_intercept)
+        ru_preds = rb.elastic_net_predict(model_id, X)
+
+        np.testing.assert_allclose(ru_preds, sk_preds, rtol=rtol, atol=0.1)
+
+    def test_elasticnet_medium_alpha(self):
+        X, y, _ = make_regression(300, 20)
+        self._compare_predictions(X, y, alpha=0.1, l1_ratio=0.5)
+
+    def test_lasso_limit(self):
+        X, y, _ = make_regression(300, 10)
+        self._compare_predictions(X, y, alpha=0.05, l1_ratio=1.0)
+
+    def test_ridge_limit(self):
+        X, y, _ = make_regression(300, 10)
+        self._compare_predictions(X, y, alpha=0.05, l1_ratio=0.0)
+
+    def test_no_intercept(self):
+        X, y, _ = make_regression(300, 10)
+        self._compare_predictions(X, y, alpha=0.05, l1_ratio=0.5, fit_intercept=False)
+
+
+# ---- regularisation behaviour ----
+
+class TestRegularisation:
+    def test_large_l1_ratio_sparsity(self):
+        """Pure Lasso with large alpha should zero out many coefficients."""
+        X, y, _ = make_regression(200, 20, seed=7)
+        _, coef, _, _ = rb.elastic_net_fit(X, y, 2.0, 1.0, 5000, 1e-6, True)
+        n_zero = np.sum(np.abs(coef) < 1e-5)
+        assert n_zero > 5, f"Expected sparse solution; only {n_zero} zeros out of 20"
+
+    def test_zero_alpha_smaller_residual_than_large_alpha(self):
+        """Less regularisation should give smaller training residual."""
+        X, y, _ = make_regression(100, 5)
+        mid_id, _, _, _ = rb.elastic_net_fit(X, y, 1.0, 0.5, 5000, 1e-6, True)
+        low_id, _, _, _ = rb.elastic_net_fit(X, y, 0.001, 0.5, 5000, 1e-6, True)
+        mse_mid = np.mean((rb.elastic_net_predict(mid_id, X) - y) ** 2)
+        mse_low = np.mean((rb.elastic_net_predict(low_id, X) - y) ** 2)
+        assert mse_low < mse_mid
+
+    def test_fit_intercept_moves_intercept(self):
+        """Shifting y by a constant should be absorbed in the intercept."""
+        X, y, _ = make_regression(100, 5)
+        y_shifted = y + 50.0
+        _, _, intercept_base, _ = rb.elastic_net_fit(X, y, 0.01, 0.5, 5000, 1e-6, True)
+        _, _, intercept_shift, _ = rb.elastic_net_fit(X, y_shifted, 0.01, 0.5, 5000, 1e-6, True)
+        assert abs((intercept_shift - intercept_base) - 50.0) < 1.0

--- a/stratum/tests/adapters/test_rusty_elastic_net.py
+++ b/stratum/tests/adapters/test_rusty_elastic_net.py
@@ -1,0 +1,529 @@
+"""Tests for the RustyElasticNet *adapter*.
+
+test_elastic_net.py covers the Rust kernel through ``rb.elastic_net_fit`` /
+``rb.elastic_net_predict`` directly. This file covers the estimator wrapped
+around it: which inputs reach the Rust path, which fall back to sklearn, what
+the caller is warned about, and whether the fitted attributes look like
+sklearn's.
+
+The distinction that most of these tests turn on: a fallback must be
+*invisible* apart from being slower. Same attributes, same dtypes sklearn would
+produce, same predictions.
+"""
+import os
+os.environ.setdefault("SKRUB_RUST", "1")
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+from sklearn.linear_model import ElasticNet as SKElasticNet
+
+from stratum import ElasticNet, set_config
+from stratum import _rust_backend as rb
+from stratum.adapters.elastic_net import (
+    RustyElasticNet,
+    UnsupportedParameterWarning,
+    _is_supported_array,
+    _rust_available,
+)
+
+pytestmark = pytest.mark.skipif(not rb.HAVE_RUST, reason="Rust backend not built")
+
+
+@pytest.fixture(autouse=True)
+def _rust_on():
+    """Every test starts with the Rust path enabled and leaves it that way.
+
+    The adapter reads the config on each call, so a test that flips it has to
+    restore it or it leaks into whatever runs next.
+    """
+    set_config(rust_backend=True, allow_patch=True)
+    yield
+    set_config(rust_backend=True, allow_patch=True)
+
+
+def make_regression(n=200, p=10, seed=42):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p)).astype(np.float32)
+    true_coef = rng.standard_normal(p).astype(np.float32)
+    y = (X @ true_coef + 0.1 * rng.standard_normal(n)).astype(np.float32)
+    return X, y, true_coef
+
+
+def took_rust_path(est):
+    """A model id is registered only by the Rust branch of fit."""
+    return getattr(est, "_rust_model_id", None) is not None
+
+
+# ---- the exported name ----
+
+class TestExport:
+    def test_stratum_elasticnet_is_the_subclass(self):
+        assert ElasticNet is RustyElasticNet
+
+    def test_subclasses_sklearn(self):
+        assert issubclass(RustyElasticNet, SKElasticNet)
+
+    def test_is_clonable(self):
+        """get_params/set_params must round-trip or sklearn tooling breaks."""
+        est = ElasticNet(alpha=0.3, l1_ratio=0.7, max_iter=123, tol=1e-5)
+        cloned = clone(est)
+        assert type(cloned) is RustyElasticNet
+        assert cloned.get_params() == est.get_params()
+
+    def test_no_extra_constructor_params(self):
+        """The adapter must not add parameters sklearn does not have."""
+        assert set(ElasticNet().get_params()) == set(SKElasticNet().get_params())
+
+
+# ---- the Rust path ----
+
+class TestRustPath:
+    def test_supported_input_uses_rust(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, l1_ratio=0.5).fit(X, y)
+        assert took_rust_path(est)
+
+    def test_matches_the_kernel_called_directly(self):
+        """The adapter must not perturb what it forwards to the kernel."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, l1_ratio=0.5, max_iter=1000, tol=1e-4).fit(X, y)
+        _, coef, intercept, n_iter = rb.elastic_net_fit(
+            X, y, 0.1, 0.5, 1000, 1e-4, True)
+        np.testing.assert_allclose(est.coef_, coef, rtol=1e-5, atol=1e-6)
+        assert est.intercept_ == pytest.approx(float(intercept), abs=1e-5)
+        assert est.n_iter_ == n_iter
+
+    def test_fitted_attribute_dtypes(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        assert est.coef_.dtype == np.float32
+        assert est.coef_.shape == (X.shape[1],)
+        assert np.ndim(est.intercept_) == 0
+        assert isinstance(est.n_iter_, int) and est.n_iter_ >= 1
+
+    def test_dual_gap_is_nan_not_faked(self):
+        """The Jacobi solver computes no duality gap, so it reports none."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        assert np.isnan(est.dual_gap_)
+
+    def test_n_features_in_recorded(self):
+        X, y, _ = make_regression(100, 7)
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        assert est.n_features_in_ == 7
+
+    def test_no_intercept_gives_zero_intercept(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, fit_intercept=False).fit(X, y)
+        assert took_rust_path(est)
+        assert est.intercept_ == pytest.approx(0.0, abs=1e-6)
+
+    def test_predict_agrees_with_sklearn(self):
+        """End to end: same estimator API, same answers within f32 tolerance."""
+        X, y, _ = make_regression(300, 20)
+        ours = ElasticNet(alpha=0.1, l1_ratio=0.5, max_iter=10_000, tol=1e-6)
+        theirs = SKElasticNet(alpha=0.1, l1_ratio=0.5, max_iter=10_000, tol=1e-6)
+        ours.fit(X, y)
+        theirs.fit(X.astype(np.float64), y.astype(np.float64))
+        assert took_rust_path(ours)
+        np.testing.assert_allclose(
+            ours.predict(X), theirs.predict(X.astype(np.float64)),
+            rtol=0.05, atol=0.1)
+
+    def test_refit_replaces_previous_model(self):
+        """A second fit must not keep serving the first model's coefficients."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.001, max_iter=5000, tol=1e-6).fit(X, y)
+        first_id, first_coef = est._rust_model_id, est.coef_.copy()
+        est.fit(X, 10.0 * y)
+        assert est._rust_model_id != first_id
+        assert not np.allclose(est.coef_, first_coef)
+        np.testing.assert_allclose(est.coef_, 10.0 * first_coef, rtol=0.05, atol=1e-3)
+
+
+# ---- fallbacks ----
+
+class TestFallback:
+    """Each of these inputs must reach sklearn instead of the kernel.
+
+    Nothing is silently converted: converting would return an answer for a
+    different input than the caller passed.
+    """
+
+    def _fit_and_assert_fallback(self, X, y, **kw):
+        est = ElasticNet(alpha=0.1, **kw).fit(X, y)
+        assert not took_rust_path(est)
+        return est
+
+    def test_rust_backend_disabled(self):
+        X, y, _ = make_regression()
+        set_config(rust_backend=False)
+        self._fit_and_assert_fallback(X, y)
+
+    def test_allow_patch_disabled(self):
+        X, y, _ = make_regression()
+        set_config(allow_patch=False)
+        self._fit_and_assert_fallback(X, y)
+
+    def test_float64_input(self):
+        X, y, _ = make_regression()
+        self._fit_and_assert_fallback(X.astype(np.float64), y.astype(np.float64))
+
+    def test_fortran_order_input(self):
+        X, y, _ = make_regression()
+        assert not np.asfortranarray(X).flags.c_contiguous
+        self._fit_and_assert_fallback(np.asfortranarray(X), y)
+
+    def test_sparse_input(self):
+        X, y, _ = make_regression()
+        self._fit_and_assert_fallback(sp.csc_matrix(X), y)
+
+    def test_dataframe_input(self):
+        pd = pytest.importorskip("pandas")
+        X, y, _ = make_regression()
+        self._fit_and_assert_fallback(pd.DataFrame(X), y)
+
+    def test_sample_weight_reweights_the_objective(self):
+        """sample_weight changes the loss, so it cannot be quietly dropped."""
+        X, y, _ = make_regression()
+        w = np.abs(np.random.default_rng(0).standard_normal(X.shape[0]))
+        est = ElasticNet(alpha=0.1).fit(X, y, sample_weight=w)
+        assert not took_rust_path(est)
+
+    def test_multi_output_y(self):
+        """A 2-D target is a different solver entirely."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, np.column_stack([y, 2.0 * y]))
+        assert not took_rust_path(est)
+        assert est.coef_.shape == (2, X.shape[1])
+
+    def test_fallback_result_matches_sklearn_exactly(self):
+        """A fallback is sklearn, so it should be bit-for-bit sklearn."""
+        X, y, _ = make_regression()
+        X64, y64 = X.astype(np.float64), y.astype(np.float64)
+        ours = ElasticNet(alpha=0.1, l1_ratio=0.5).fit(X64, y64)
+        theirs = SKElasticNet(alpha=0.1, l1_ratio=0.5).fit(X64, y64)
+        assert not took_rust_path(ours)
+        np.testing.assert_array_equal(ours.coef_, theirs.coef_)
+        np.testing.assert_array_equal(ours.predict(X64), theirs.predict(X64))
+
+    def test_fallback_preserves_sklearn_dtype(self):
+        """float64 in, float64 out. The adapter must not downcast on this path."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X.astype(np.float64), y.astype(np.float64))
+        assert est.coef_.dtype == np.float64
+
+    def test_fallback_reports_a_real_dual_gap(self):
+        """Only the Rust path has no duality gap to report."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X.astype(np.float64), y.astype(np.float64))
+        assert not np.isnan(est.dual_gap_)
+
+
+# ---- input validation happens on both paths ----
+
+class TestValidation:
+    @pytest.mark.parametrize("bad", [np.nan, np.inf])
+    def test_non_finite_X_raises(self, bad):
+        X, y, _ = make_regression()
+        X = X.copy()
+        X[0, 0] = bad
+        with pytest.raises(ValueError):
+            ElasticNet(alpha=0.1).fit(X, y)
+
+    @pytest.mark.parametrize("bad", [np.nan, np.inf])
+    def test_non_finite_y_raises(self, bad):
+        X, y, _ = make_regression()
+        y = y.copy()
+        y[0] = bad
+        with pytest.raises(ValueError):
+            ElasticNet(alpha=0.1).fit(X, y)
+
+    def test_length_mismatch_raises(self):
+        X, y, _ = make_regression()
+        with pytest.raises(ValueError):
+            ElasticNet(alpha=0.1).fit(X, y[:-1])
+
+
+# ---- warnings for options the solver cannot honour ----
+
+class TestUnsupportedParameterWarnings:
+    @pytest.mark.parametrize("kw", [
+        {"precompute": True},
+        {"warm_start": True},
+        {"selection": "random"},
+    ])
+    def test_tuning_options_warn_but_still_use_rust(self, kw):
+        """These change only how the answer is reached, so Rust still runs."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, **kw)
+        with pytest.warns(UnsupportedParameterWarning, match="ignored"):
+            est.fit(X, y)
+        assert took_rust_path(est)
+
+    def test_tuning_warning_does_not_promise_an_identical_result(self):
+        """The warning must not claim equivalence it cannot guarantee."""
+        X, y, _ = make_regression()
+        with pytest.warns(UnsupportedParameterWarning,
+                          match="can still move the coefficients"):
+            ElasticNet(alpha=0.1, warm_start=True).fit(X, y)
+
+    def test_positive_warns_that_the_result_differs(self):
+        """positive=True changes what the solution IS, so the warning must be loud."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, positive=True)
+        with pytest.warns(UnsupportedParameterWarning, match="DIFFERS"):
+            est.fit(X, y)
+        assert took_rust_path(est)
+
+    def test_positive_is_actually_honoured_on_the_fallback(self):
+        """The warning tells the caller to disable Rust. That advice must work."""
+        X, y, _ = make_regression()
+        set_config(rust_backend=False)
+        est = ElasticNet(alpha=0.1, positive=True).fit(X, y)
+        assert not took_rust_path(est)
+        assert (est.coef_ >= 0).all()
+
+    def test_random_state_warns_only_with_random_selection(self):
+        X, y, _ = make_regression()
+        with pytest.warns(UnsupportedParameterWarning, match="random_state"):
+            ElasticNet(alpha=0.1, selection="random", random_state=0).fit(X, y)
+
+        with warnings_as_errors():
+            ElasticNet(alpha=0.1, random_state=0).fit(X, y)
+
+    def test_default_parameters_warn_about_nothing(self):
+        X, y, _ = make_regression()
+        with warnings_as_errors():
+            ElasticNet(alpha=0.1).fit(X, y)
+
+    def test_no_warning_on_the_fallback_path(self):
+        """The fallback honours everything, so there is nothing to warn about."""
+        X, y, _ = make_regression()
+        set_config(rust_backend=False)
+        with warnings_as_errors():
+            ElasticNet(alpha=0.1, warm_start=True, positive=True).fit(X, y)
+
+
+class warnings_as_errors:
+    """Fail if any UnsupportedParameterWarning is raised in the block."""
+
+    def __enter__(self):
+        import warnings
+        self._cm = warnings.catch_warnings()
+        self._cm.__enter__()
+        warnings.simplefilter("error", UnsupportedParameterWarning)
+        return self
+
+    def __exit__(self, *exc):
+        return self._cm.__exit__(*exc)
+
+
+# ---- predict ----
+
+class TestPredict:
+    def test_predict_before_fit_raises(self):
+        with pytest.raises(NotFittedError):
+            ElasticNet(alpha=0.1).predict(make_regression()[0])
+
+    def test_predict_dtype_and_shape(self):
+        X, y, _ = make_regression(150, 6)
+        preds = ElasticNet(alpha=0.1).fit(X, y).predict(X)
+        assert preds.shape == (150,)
+        assert preds.dtype == np.float32
+
+    def test_predict_matches_manual_computation(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.01, max_iter=5000, tol=1e-6).fit(X, y)
+        manual = X @ est.coef_ + float(est.intercept_)
+        np.testing.assert_allclose(est.predict(X), manual, rtol=1e-4, atol=1e-4)
+
+    def test_predict_on_unseen_rows(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        X_new = np.ascontiguousarray(
+            np.random.default_rng(1).standard_normal((17, X.shape[1])),
+            dtype=np.float32)
+        assert est.predict(X_new).shape == (17,)
+
+    def test_predict_wrong_n_features_raises(self):
+        X, y, _ = make_regression(100, 5)
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        with pytest.raises(ValueError):
+            est.predict(np.zeros((10, 3), dtype=np.float32))
+
+    def test_predict_falls_back_for_unsupported_dtype(self):
+        """A Rust-fitted model still has to serve a float64 matrix."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        np.testing.assert_allclose(
+            est.predict(X.astype(np.float64)), est.predict(X),
+            rtol=1e-4, atol=1e-4)
+
+    def test_config_is_read_per_call_not_cached_at_fit(self):
+        """Disabling Rust after fitting must route predict back to sklearn."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        rust_preds = est.predict(X)
+        set_config(rust_backend=False)
+        np.testing.assert_allclose(est.predict(X), rust_preds, rtol=1e-4, atol=1e-4)
+
+    def test_sklearn_fitted_model_predicts_without_rust(self):
+        """No model id was registered, so predict cannot use the Rust path."""
+        X, y, _ = make_regression()
+        set_config(rust_backend=False)
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        set_config(rust_backend=True)
+        assert not took_rust_path(est)
+        assert est.predict(X).shape == (X.shape[0],)
+
+
+# ---- helpers ----
+
+class TestIsSupportedArray:
+    def test_accepts_c_contiguous_float32_2d(self):
+        assert _is_supported_array(np.zeros((4, 3), dtype=np.float32))
+
+    @pytest.mark.parametrize("X", [
+        np.zeros((4, 3), dtype=np.float64),
+        np.zeros((4, 3), dtype=np.int32),
+        np.zeros(4, dtype=np.float32),
+        np.asfortranarray(np.zeros((4, 3), dtype=np.float32)),
+        sp.csr_matrix((4, 3), dtype=np.float32),
+        [[1.0, 2.0], [3.0, 4.0]],
+    ])
+    def test_rejects_everything_else(self, X):
+        assert not _is_supported_array(X)
+
+    def test_rejects_a_non_contiguous_view(self):
+        assert not _is_supported_array(np.zeros((4, 6), dtype=np.float32)[:, ::2])
+
+
+class TestRustAvailable:
+    def test_true_by_default(self):
+        assert _rust_available()
+
+    @pytest.mark.parametrize("flag", ["rust_backend", "allow_patch"])
+    def test_false_when_a_config_flag_is_off(self, flag):
+        set_config(**{flag: False})
+        assert not _rust_available()
+
+
+class TestWarningsMatchTheChosenPath:
+    """A warning must describe the path taken, not the one nearly taken."""
+
+    def test_no_warning_when_multi_output_falls_back(self):
+        X, y, _ = make_regression()
+        y2d = np.column_stack([y, y * 2]).astype(np.float32)
+        est = ElasticNet(alpha=0.1, positive=True)
+        with warnings_as_errors():
+            est.fit(X, y2d)
+        assert not took_rust_path(est)
+
+    def test_multi_output_fallback_still_honours_positive(self):
+        """The claim the warning would have made is false here."""
+        X, y, _ = make_regression()
+        y2d = np.column_stack([y, y * 2]).astype(np.float32)
+        est = ElasticNet(alpha=0.1, positive=True).fit(X, y2d)
+        assert (est.coef_ >= 0).all()
+
+    def test_no_warning_when_unsupported_dtype_falls_back(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1, positive=True)
+        with warnings_as_errors():
+            est.fit(X.astype(np.float64), y.astype(np.float64))
+        assert not took_rust_path(est)
+
+
+class TestKernelErrorsAreNotPanics:
+    """Bad kernel input must raise a Python error, not panic across FFI.
+
+    Only reachable through rb.* directly; the adapter filters both cases first.
+    """
+
+    def test_mismatched_y_length_raises_value_error(self):
+        X = np.ones((10, 3), dtype=np.float32)
+        y = np.ones(7, dtype=np.float32)
+        with pytest.raises(ValueError, match="y length must match"):
+            rb.elastic_net_fit(X, y, 0.1, 0.5, 100, 1e-4, True)
+
+    def test_non_contiguous_x_raises_value_error(self):
+        X = np.asfortranarray(np.ones((10, 3), dtype=np.float32))
+        y = np.ones(10, dtype=np.float32)
+        with pytest.raises(ValueError, match="C-contiguous"):
+            rb.elastic_net_fit(X, y, 0.1, 0.5, 100, 1e-4, True)
+
+
+class TestModelRegistryIsReleased:
+    """Fitted models must leave the process-global Rust registry.
+
+    Otherwise a refit loop grows by n_features * 4 bytes per iteration.
+    """
+
+    def test_refit_releases_the_previous_model(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1)
+        est.fit(X, y)
+        first = est._rust_model_id
+        est.fit(X, y)
+        assert est._rust_model_id != first
+        # Released by the refit, so freeing it again is a no-op.
+        assert rb.elastic_net_free(first) is False
+        assert rb.elastic_net_free(est._rust_model_id) is True
+
+    def test_freeing_makes_the_id_unusable(self):
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        model_id = est._rust_model_id
+        assert rb.elastic_net_free(model_id) is True
+        with pytest.raises(KeyError):
+            rb.elastic_net_predict(model_id, X)
+
+    def test_discarding_an_estimator_releases_its_model(self):
+        import gc
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        model_id = est._rust_model_id
+        del est
+        gc.collect()
+        assert rb.elastic_net_free(model_id) is False
+
+
+class TestDiagnosticsAndCleanupPaths:
+    """The branches that only run under a debug flag or a failed cleanup."""
+
+    def test_debug_info_announces_both_dispatches(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "stratum.adapters.elastic_net._DEBUG_INFO", True, raising=True)
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        est.predict(X)
+        out = capsys.readouterr().out
+        assert "Dispatching ElasticNet fit to Rust backend" in out
+        assert "Dispatching ElasticNet predict to Rust backend" in out
+
+    def test_cleanup_survives_a_failing_free(self, monkeypatch):
+        """__del__ runs this, so it must never raise."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+
+        def boom(_model_id):
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr(rb, "elastic_net_free", boom, raising=True)
+        est._free_rust_model()          # must not propagate
+        assert est._rust_model_id is not None  # not cleared on failure
+
+    def test_cleanup_is_a_noop_without_the_binding(self, monkeypatch):
+        """An extension built without elastic_net_free must still work."""
+        X, y, _ = make_regression()
+        est = ElasticNet(alpha=0.1).fit(X, y)
+        monkeypatch.setattr(rb, "elastic_net_free", None, raising=True)
+        est._free_rust_model()
+        assert est._rust_model_id is not None
+
+    def test_cleanup_on_an_unfitted_estimator(self):
+        ElasticNet(alpha=0.1)._free_rust_model()


### PR DESCRIPTION
- _rust/src/elastic_net.rs — Jacobi-style coordinate descent, one fused pass per iteration over the design matrix, parallelised with Rayon over the project thread pool.
- stratum/adapters/elastic_net.py — RustyElasticNet, subclassing sklearn's. The Rust path handles dense C-contiguous float32 with default solver options; sparse input, float64, Fortran order, multi-output y, and sample_weight fall back to sklearn unchanged. Options the Jacobi solver cannot honour (precompute, warm_start, selection, positive) warn rather than silently differ.
- Tests: 6 Rust unit tests, 18 kernel tests, 56 adapter tests.
- benchmarks/adapters/bench_elastic_net.py — reports n_iter_ for both backends so fit speedups read as per-iteration gains.