### PR TITLE
[Rewrite] Adds eliminate self subtraction #160

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -14,6 +14,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_any_mul_zero,
     eliminate_div_by_one,
     fold_log_plus_one,
+    eliminate_self_subtract,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -38,6 +39,7 @@ class AlgebraicRewritesConfig:
     any_mul_zero: bool = True
     div_by_one: bool = True
     log_plus_one: bool = True
+    self_subtract: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -71,5 +73,7 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_pow_zero(root)
     if config.any_mul_zero:
         root = eliminate_any_mul_zero(root)
+    if config.self_subtract:
+        root = eliminate_self_subtract(root)
     log_time("algebraic_rewrite", start)
     return root

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -164,6 +164,23 @@ _replace_with_log1p = make_replace_two_op_chain_root_safe(
     lambda: NumericOp(inputs=[], outputs=[], type=NumericOpType.LOG1P)
 )
 
+def match_self_subtract(op):
+    """Match ``x - x`` where both operands reference the same input.
+
+    The SUBTRACT must be var-var (``opt_operand is not None``) and both the
+    primary operand and the referenced operand must resolve to the same op.
+    """
+    if not isinstance(op, NumericOp):
+        return None
+    if op.type is not NumericOpType.SUBTRACT:
+        return None
+    if op.opt_operand is None:
+        return None
+    if op.inputs[0] is op.inputs[op.opt_operand.k]:
+        return (op,)
+    return None
+
+
 eliminate_log_exp = rewrite_pass(
     match_two_op_chain(NumericOp, NumericOpType.LOG, NumericOpType.EXP),
     eliminate_two_op_chain_root_safe,
@@ -232,3 +249,8 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
+
+eliminate_self_subtract = rewrite_pass(
+    match_self_subtract,
+    fold_to_zero,
+)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -655,5 +655,75 @@ class TestCSE(unittest.TestCase):
             algebraic_rewrite_config=AlgebraicRewritesConfig(pow_zero=False),
         )
         out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)  # log(exp(x)) still eliminated
+        self.assertEqual(out[0].value, 1)
+
+    # --- self-subtract annihilator ---------------------------------------
+
+    def test_self_subtract_annihilates_to_zero(self):
+        """x - x  →  0"""
+        df = st.as_data_op(5)
+        t1 = df - df
+
+        out, *_ = optimize(t1)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)
+
+    def test_self_subtract_with_trailing_op(self):
+        """(x - x) + 3  →  0 + 3"""
+        df = st.as_data_op(5)
+        t1 = df - df
+        t2 = t1 + 3
+
+        out, *_ = optimize(t2)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0].value, 0.0)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.ADD)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 3)
+
+    def test_self_subtract_root_safe(self):
+        """When x - x is the root, DAG must not break."""
+        value = st.as_data_op(7)
+        root = value - value
+
+        out, *_ = optimize(root)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 0)
+
+    def test_self_subtract_disabled(self):
+        """Disabling self_subtract must leave x - x untouched."""
+        df = st.as_data_op(5)
+        t1 = df - df
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(self_subtract=False),
+        )
+        out, *_ = optimize(t1, config=config)
+        self.assertEqual(len(out), 2)
+
+    def test_no_rewrite_x_minus_y_different_values(self):
+        """x - y with different values must NOT be rewritten."""
+        x = st.as_data_op(5)
+        y = st.as_data_op(3)
+        t1 = x - y
+        t2 = t1 + 1
+
+        out, *_ = optimize(t2)
+        subtract_ops = [op for op in out if isinstance(op, NumericOp) and op.type == NumericOpType.SUBTRACT]
+        self.assertEqual(len(subtract_ops), 1)
+
+    def test_disable_self_subtract_does_not_affect_log_exp(self):
+        """Disabling self_subtract must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(self_subtract=False),
+        )
+        out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)


### PR DESCRIPTION
## Adds Eliminate self subtraction `x - x -> 0` (https://github.com/deem-data/stratum/issues/160)

- match_self_subtract detects var-var SUBTRACT where both operands reference the same input (including CSE-deduplicated duplicates)
- Reuses fold_to_zero to replace the SUBTRACT with ValueOp(0), properly unlinking dead operand edges
- 5 tests: basic annihilator, trailing op, root safety, disabled, x-y with different values (no-rewrite), isolation