### PR TITLE
[TfidfVectorizer] Add Rust-backed TF-IDF vectorizer

### DIFF
--- a/_rust/src/lib.rs
+++ b/_rust/src/lib.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use ndarray::{Array2, Axis};
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
+use pyo3::create_exception;
+use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyAny, PyIterator, PyList, PyModule};
-use pyo3::{PyErr, exceptions::PyValueError};
+use pyo3::PyErr;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
 use crate::threads::{get_thread_pool};
@@ -13,6 +16,7 @@ use crate::util::{start_timing, print_timing};
 mod tokenize;   //n-gram extraction for char/char_wb
 mod hashing;    //stable fast hashing to [0, n_features)
 mod tfidf;      //DF counting, IDF vector, TF*IDF, per-row L2 norm
+mod tfidf_vectorizer; //sklearn TfidfVectorizer (word analyzer, learned vocabulary)
 mod csr;
 mod fd;         //Frequent Directions
 mod truncated_svd;  //TruncatedSVD using randomized SVD
@@ -22,11 +26,18 @@ mod one_hot_encoder;
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
 
+create_exception!(_rust_backend_native, TfidfVectorizerFallback, PyException);
+
 // TODO (refactor): Move functions to corresponding modules
 // TODO (perf): Test with blas/mkl. Accordingly move from faer
 
 // ---- Global registry for models (TODO: Return pointer to Python) ----
 static TFIDF_MODELS: Lazy<Mutex<Vec<tfidf::TfidfModel>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[pyclass(frozen, module = "stratum._rust_backend_native")]
+struct RustTfidfVectorizerModel {
+    inner: Arc<tfidf_vectorizer::Model>,
+}
 
 struct TruncatedSvdModel {
     n_cols: usize,
@@ -61,6 +72,30 @@ fn to_pyerr(err: tfidf::Error) -> PyErr {
         Internal => "Internal error".to_string()
     };
     PyErr::new::<PyValueError, _>(msg)
+}
+
+fn tfidf_vectorizer_to_pyerr(err: tfidf_vectorizer::Error) -> PyErr {
+    use tfidf_vectorizer::Error::*;
+    let message = match err {
+        EmptyDocuments => "empty document collection",
+        EmptyVocabulary => "empty vocabulary; perhaps the documents only contain stop words",
+        NoTermsAfterPruning => {
+            "After pruning, no terms remain. Try a lower min_df or a higher max_df."
+        }
+        TooManyFeatures => {
+            return PyValueError::new_err(
+                "vocabulary size exceeds the i32 feature-index limit",
+            );
+        }
+        AmbiguousMaxFeatures => "ambiguous max_features tie requires sklearn fallback",
+        InvalidMaxFeatures => {
+            return PyValueError::new_err("max_features must be greater than zero");
+        }
+        DuplicateVocabularyTerm(term) => {
+            return PyValueError::new_err(format!("Duplicate term in vocabulary: {term:?}"));
+        }
+    };
+    TfidfVectorizerFallback::new_err(message)
 }
 
 // Helper: CSR × Omega matmul: X @ Ω -> Y
@@ -558,6 +593,200 @@ fn hashing_tfidf_csr_with_idf(
 
 }
 
+// ---- sklearn TfidfVectorizer (word analyzer) ----
+
+/// Borrow document strings from Python without copying into Rust `String`.
+fn extract_tfidf_documents(seq: &Bound<'_, PyAny>) -> PyResult<Vec<PyBackedStr>> {
+    if let Ok(list) = seq.cast::<PyList>() {
+        let mut documents = Vec::with_capacity(list.len());
+        for index in 0..list.len() {
+            documents.push(list.get_item(index)?.extract::<PyBackedStr>()?);
+        }
+        return Ok(documents);
+    }
+
+    let mut documents = Vec::new();
+    let iterator = PyIterator::from_object(seq)?;
+    for item in iterator {
+        documents.push(item?.extract::<PyBackedStr>()?);
+    }
+    Ok(documents)
+}
+
+fn ensure_ascii_tfidf_documents(documents: &[PyBackedStr]) -> PyResult<()> {
+    if documents.iter().all(|document| document.is_ascii()) {
+        return Ok(());
+    }
+    Err(TfidfVectorizerFallback::new_err(
+        "non-ASCII documents require sklearn fallback",
+    ))
+}
+
+#[pyfunction]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+#[pyo3(signature = (
+    seq,
+    ngram_min,
+    ngram_max,
+    lowercase,
+    binary,
+    norm,
+    use_idf,
+    smooth_idf,
+    sublinear_tf,
+    min_document_count,
+    max_document_count,
+    max_features=None,
+    fixed_terms=None,
+    output_dtype="float64"
+))]
+fn tfidf_vectorizer_fit(
+    py: Python<'_>,
+    seq: Bound<PyAny>,
+    ngram_min: usize,
+    ngram_max: usize,
+    lowercase: bool,
+    binary: bool,
+    norm: &str,
+    use_idf: bool,
+    smooth_idf: bool,
+    sublinear_tf: bool,
+    min_document_count: f64,
+    max_document_count: f64,
+    max_features: Option<usize>,
+    fixed_terms: Option<Vec<String>>,
+    output_dtype: &str,
+) -> PyResult<(
+    Py<RustTfidfVectorizerModel>,
+    Py<PyArray1<f64>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
+    Vec<String>,
+    Vec<i32>,
+    Py<PyArray1<f64>>,
+)> {
+    if ngram_min == 0 || ngram_min > ngram_max {
+        return Err(PyValueError::new_err("invalid ngram_range"));
+    }
+    if fixed_terms.is_none() && min_document_count > max_document_count {
+        return Err(PyValueError::new_err(
+            "max_df corresponds to < documents than min_df",
+        ));
+    }
+    if max_features == Some(0) {
+        return Err(PyValueError::new_err("max_features must be greater than zero"));
+    }
+
+    let norm = match norm {
+        "none" => tfidf_vectorizer::Norm::None,
+        "l1" => tfidf_vectorizer::Norm::L1,
+        "l2" => tfidf_vectorizer::Norm::L2,
+        _ => return Err(PyValueError::new_err("norm must be None, 'l1', or 'l2'")),
+    };
+    let output_dtype = match output_dtype {
+        "float32" => tfidf_vectorizer::OutputDtype::Float32,
+        "float64" => tfidf_vectorizer::OutputDtype::Float64,
+        _ => return Err(PyValueError::new_err("dtype must be float32 or float64")),
+    };
+
+    let t_extract = start_timing();
+    let documents = extract_tfidf_documents(&seq)?;
+    ensure_ascii_tfidf_documents(&documents)?;
+    print_timing("tv ffi_extract", t_extract);
+    let n_rows = documents.len();
+
+    let options = tfidf_vectorizer::Options {
+        nmin: ngram_min,
+        nmax: ngram_max,
+        lowercase,
+        binary,
+        norm,
+        use_idf,
+        smooth_idf,
+        sublinear_tf,
+        output_dtype,
+    };
+
+    // Heavy work without the GIL.
+    let output = py
+        .detach(|| {
+            tfidf_vectorizer::fit(
+                &documents,
+                options,
+                fixed_terms,
+                min_document_count,
+                max_document_count,
+                max_features,
+            )
+        })
+        .map_err(tfidf_vectorizer_to_pyerr)?;
+
+    let n_cols = output.model.n_features();
+    let terms = output.model.terms().to_vec();
+    let idf = output.model.idf().to_vec();
+    let vocabulary_order = output.vocabulary_order;
+    let model = Py::new(py, RustTfidfVectorizerModel { inner: output.model })?;
+    let t_numpy = start_timing();
+    let py_data = PyArray1::<f64>::from_vec(py, output.data).to_owned();
+    let py_indices = PyArray1::<i32>::from_vec(py, output.indices).to_owned();
+    let py_indptr = PyArray1::<i64>::from_vec(py, output.indptr).to_owned();
+    let py_idf = PyArray1::<f64>::from_vec(py, idf).to_owned();
+    print_timing("tv numpy_handoff", t_numpy);
+
+    Ok((
+        model,
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_cols,
+        terms,
+        vocabulary_order,
+        Py::from(py_idf),
+    ))
+}
+
+#[pyfunction]
+#[allow(clippy::type_complexity)]
+#[pyo3(signature = (model, seq))]
+fn tfidf_vectorizer_transform(
+    py: Python<'_>,
+    model: PyRef<'_, RustTfidfVectorizerModel>,
+    seq: Bound<PyAny>,
+) -> PyResult<(
+    Py<PyArray1<f64>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
+)> {
+    let t_extract = start_timing();
+    let documents = extract_tfidf_documents(&seq)?;
+    ensure_ascii_tfidf_documents(&documents)?;
+    print_timing("tv ffi_extract", t_extract);
+    let n_rows = documents.len();
+    let model = Arc::clone(&model.inner);
+    let n_cols = model.n_features();
+
+    // Heavy work without the GIL.
+    let (data, indices, indptr) = py.detach(|| model.transform(&documents));
+    let t_numpy = start_timing();
+    let py_data = PyArray1::<f64>::from_vec(py, data).to_owned();
+    let py_indices = PyArray1::<i32>::from_vec(py, indices).to_owned();
+    let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
+    print_timing("tv numpy_handoff", t_numpy);
+
+    Ok((
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_cols,
+    ))
+}
+
 // ---- Fit TF-IDF vocabulary + return CSR ----
 #[pyfunction]
 #[pyo3(signature = (seq, analyzer, ngram_min, ngram_max))]
@@ -656,7 +885,7 @@ fn tfidf_transform_csr(
 
 // ---- Expose module ----
 #[pymodule]
-fn _rust_backend_native(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
+fn _rust_backend_native(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(hashing_tfidf_csr, m)?)?;
     m.add_function(wrap_pyfunction!(hashing_tfidf_csr_with_idf, m)?)?;
     m.add_function(wrap_pyfunction!(fd_fit_from_csr, m)?)?;
@@ -667,5 +896,12 @@ fn _rust_backend_native(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(one_hot_encoder::csr_to_dense, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_fit_csr, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_transform_csr, m)?)?;
+    m.add_function(wrap_pyfunction!(tfidf_vectorizer_fit, m)?)?;
+    m.add_function(wrap_pyfunction!(tfidf_vectorizer_transform, m)?)?;
+    m.add_class::<RustTfidfVectorizerModel>()?;
+    m.add(
+        "TfidfVectorizerFallback",
+        py.get_type::<TfidfVectorizerFallback>(),
+    )?;
     Ok(())
 }

--- a/_rust/src/tfidf_vectorizer.rs
+++ b/_rust/src/tfidf_vectorizer.rs
@@ -1,0 +1,1434 @@
+//! sklearn word-analyzer `TfidfVectorizer`.
+//!
+//! Learned fits are two passes over document chunks: collect DF/TF and
+//! discovery order, then retokenize into CSR. Fixed-vocabulary fits tokenize
+//! once and derive DF from the emitted indices when IDF is on.
+//!
+//! Chunk count is `min(n_docs, threads * CHUNKS_PER_THREAD,
+//! floor(n_docs / CHUNK_DOCS_MIN))`, with at least one chunk. Chunk size is
+//! `ceil(n_docs / n_chunks)`.
+
+use std::sync::Arc;
+
+use ahash::AHashMap as HashMap;
+use rayon::prelude::*;
+
+use crate::threads::get_thread_pool;
+use crate::tokenize::{for_each_word_ngram, for_each_word_token_ascii, word_tokens_ascii};
+
+const CHUNKS_PER_THREAD: usize = 4;
+/// Avoid tiny chunks on small corpora where Rayon/merge overhead dominates.
+const CHUNK_DOCS_MIN: usize = 1000;
+const MAX_MERGE_SHARDS: usize = 64;
+const DENSE_COUNT_FEATURE_LIMIT: usize = 1 << 18;
+
+#[derive(Debug)]
+pub enum Error {
+    EmptyDocuments,
+    EmptyVocabulary,
+    NoTermsAfterPruning,
+    TooManyFeatures,
+    AmbiguousMaxFeatures,
+    InvalidMaxFeatures,
+    DuplicateVocabularyTerm(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Norm {
+    None,
+    L1,
+    L2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputDtype {
+    Float32,
+    Float64,
+}
+
+impl OutputDtype {
+    /// Largest consecutive integer exactly representable by the output dtype.
+    fn exact_integer_limit(self) -> u64 {
+        match self {
+            Self::Float32 => 1 << 24,
+            Self::Float64 => 1 << 53,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Options {
+    pub nmin: usize,
+    pub nmax: usize,
+    pub lowercase: bool,
+    pub binary: bool,
+    pub norm: Norm,
+    pub use_idf: bool,
+    pub smooth_idf: bool,
+    pub sublinear_tf: bool,
+    pub output_dtype: OutputDtype,
+}
+
+#[derive(Debug)]
+pub struct Model {
+    vocabulary: HashMap<String, i32>,
+    terms: Vec<String>,
+    idf: Vec<f64>,
+    options: Options,
+}
+
+pub struct FitOutput {
+    pub model: Arc<Model>,
+    pub data: Vec<f64>,
+    pub indices: Vec<i32>,
+    pub indptr: Vec<i64>,
+    /// Feature indices in vocabulary insertion order (sklearn's observable order).
+    pub vocabulary_order: Vec<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct DiscoveryOrder {
+    chunk: usize,
+    position: usize,
+}
+
+impl Default for DiscoveryOrder {
+    fn default() -> Self {
+        Self {
+            chunk: usize::MAX,
+            position: usize::MAX,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TermStats {
+    document_frequency: u64,
+    term_frequency: u64,
+    first_occurrence: DiscoveryOrder,
+    /// Chunk-local document index used to update DF without a per-row term map.
+    last_document: usize,
+}
+
+impl Default for TermStats {
+    fn default() -> Self {
+        Self {
+            document_frequency: 0,
+            term_frequency: 0,
+            first_occurrence: DiscoveryOrder::default(),
+            last_document: usize::MAX,
+        }
+    }
+}
+
+/// Flat CSR block for one document chunk. `indptr` is local (starts at 0).
+struct CsrChunk {
+    data: Vec<f64>,
+    indices: Vec<i32>,
+    indptr: Vec<i64>,
+}
+
+/// Reusable per-chunk scratch for counting and row assembly.
+struct ChunkScratch {
+    feature_counts: FeatureCounts,
+    features: Vec<(i32, u64)>,
+}
+
+impl ChunkScratch {
+    fn new(n_features: usize) -> Self {
+        Self {
+            feature_counts: if n_features <= DENSE_COUNT_FEATURE_LIMIT {
+                FeatureCounts::Dense(vec![0; n_features])
+            } else {
+                FeatureCounts::Sparse(HashMap::new())
+            },
+            features: Vec::new(),
+        }
+    }
+}
+
+enum FeatureCounts {
+    Dense(Vec<u64>),
+    Sparse(HashMap<i32, u64>),
+}
+
+impl Model {
+    pub fn terms(&self) -> &[String] {
+        &self.terms
+    }
+
+    pub fn idf(&self) -> &[f64] {
+        &self.idf
+    }
+
+    pub fn n_features(&self) -> usize {
+        self.terms.len()
+    }
+
+    pub fn transform<S: AsRef<str> + Sync>(
+        &self,
+        documents: &[S],
+    ) -> (Vec<f64>, Vec<i32>, Vec<i64>) {
+        debug_assert!(
+            documents
+                .iter()
+                .all(|document| document.as_ref().is_ascii()),
+            "the TF-IDF word kernel requires ASCII documents",
+        );
+        let t0 = crate::util::start_timing();
+        let chunks = map_document_chunks(documents, |chunk| emit_weighted_chunk(chunk, self, None));
+        crate::util::print_timing("tv map_chunks", t0);
+
+        let t1 = crate::util::start_timing();
+        let out = assemble_chunks(chunks, documents.len());
+        crate::util::print_timing("tv assemble_csr", t1);
+        out
+    }
+}
+
+/// Fit and return the model plus the training CSR matrix.
+///
+/// `fixed_terms`, if set, must be ordered by feature index.
+/// `min_document_count` / `max_document_count` are absolute sklearn thresholds
+/// (already expanded from fractions). Documents are `AsRef<str>` so callers
+/// can pass `String` or `PyBackedStr` without copying.
+pub fn fit<S: AsRef<str> + Sync>(
+    documents: &[S],
+    options: Options,
+    fixed_terms: Option<Vec<String>>,
+    min_document_count: f64,
+    max_document_count: f64,
+    max_features: Option<usize>,
+) -> Result<FitOutput, Error> {
+    if max_features == Some(0) {
+        return Err(Error::InvalidMaxFeatures);
+    }
+    if documents.is_empty() {
+        return Err(Error::EmptyDocuments);
+    }
+    debug_assert!(
+        documents
+            .iter()
+            .all(|document| document.as_ref().is_ascii()),
+        "the TF-IDF word kernel requires ASCII documents",
+    );
+
+    match fixed_terms {
+        Some(terms) => fit_fixed_vocabulary(documents, options, terms),
+        None => fit_learned_vocabulary(
+            documents,
+            options,
+            min_document_count,
+            max_document_count,
+            max_features,
+        ),
+    }
+}
+
+fn fit_learned_vocabulary<S: AsRef<str> + Sync>(
+    documents: &[S],
+    options: Options,
+    min_document_count: f64,
+    max_document_count: f64,
+    max_features: Option<usize>,
+) -> Result<FitOutput, Error> {
+    // Pass A: DF/TF + discovery order per chunk.
+    let t0 = crate::util::start_timing();
+    let mut chunk_stats =
+        map_document_chunks(documents, |chunk| accumulate_chunk_stats(chunk, &options));
+    for (chunk, stats) in chunk_stats.iter_mut().enumerate() {
+        for term_stats in stats.values_mut() {
+            term_stats.first_occurrence.chunk = chunk;
+        }
+    }
+    let stats = merge_term_stats(chunk_stats);
+    crate::util::print_timing("tv pass_a_stats", t0);
+
+    let t1 = crate::util::start_timing();
+    let terms = select_terms(
+        stats.iter(),
+        min_document_count,
+        max_document_count,
+        max_features,
+        options.output_dtype.exact_integer_limit(),
+    )?;
+    ensure_feature_count_fits_i32(terms.len())?;
+
+    let vocabulary = vocabulary_from_terms(&terms);
+    let idf = terms
+        .iter()
+        .map(|term| {
+            let df = stats
+                .get(term.as_str())
+                .map_or(0, |term_stats| term_stats.document_frequency);
+            compute_idf(documents.len() as u64, df, &options)
+        })
+        .collect();
+
+    let model = Arc::new(Model {
+        vocabulary,
+        terms,
+        idf,
+        options,
+    });
+
+    // sklearn fit_transform emits rows in discovery order, then remaps
+    // feature ids lexicographically without re-sorting. Match that layout;
+    // transform uses final feature-index order.
+    let fit_feature_order: Vec<DiscoveryOrder> = model
+        .terms
+        .iter()
+        .map(|term| stats[term.as_str()].first_occurrence)
+        .collect();
+    let mut vocabulary_order: Vec<i32> = (0..model.n_features() as i32).collect();
+    vocabulary_order.sort_unstable_by_key(|&feature| fit_feature_order[feature as usize]);
+    crate::util::print_timing("tv select_vocab", t1);
+
+    // Pass B: retokenize into weighted CSR chunks.
+    let t2 = crate::util::start_timing();
+    let chunks = map_document_chunks(documents, |chunk| {
+        emit_weighted_chunk(chunk, &model, Some(&fit_feature_order))
+    });
+    crate::util::print_timing("tv pass_b_emit", t2);
+
+    let t3 = crate::util::start_timing();
+    let (data, indices, indptr) = assemble_chunks(chunks, documents.len());
+    crate::util::print_timing("tv assemble_csr", t3);
+
+    Ok(FitOutput {
+        model,
+        data,
+        indices,
+        indptr,
+        vocabulary_order,
+    })
+}
+
+fn fit_fixed_vocabulary<S: AsRef<str> + Sync>(
+    documents: &[S],
+    options: Options,
+    terms: Vec<String>,
+) -> Result<FitOutput, Error> {
+    if terms.is_empty() {
+        return Err(Error::EmptyVocabulary);
+    }
+    ensure_feature_count_fits_i32(terms.len())?;
+
+    let n_features = terms.len();
+    let vocabulary = fixed_vocabulary_from_terms(&terms)?;
+    let vocabulary_order = (0..n_features as i32).collect();
+
+    // One tokenize pass for TF. Each feature appears at most once per row,
+    // so the indices double as DF observations.
+    let t0 = crate::util::start_timing();
+    let chunks = map_document_chunks(documents, |chunk| {
+        emit_tf_chunk(chunk, &vocabulary, n_features, &options)
+    });
+    crate::util::print_timing("tv map_chunks", t0);
+
+    let t1 = crate::util::start_timing();
+    let idf = fixed_vocabulary_idf(&chunks, n_features, documents.len(), &options);
+
+    let (mut data, indices, indptr) = assemble_chunks(chunks, documents.len());
+    apply_idf_and_normalize(&mut data, &indices, &indptr, &idf, &options);
+    crate::util::print_timing("tv assemble_csr", t1);
+
+    let model = Arc::new(Model {
+        vocabulary,
+        terms,
+        idf,
+        options,
+    });
+
+    Ok(FitOutput {
+        model,
+        data,
+        indices,
+        indptr,
+        vocabulary_order,
+    })
+}
+
+fn vocabulary_from_terms(terms: &[String]) -> HashMap<String, i32> {
+    let mut vocabulary = HashMap::with_capacity(terms.len());
+    for (feature, term) in terms.iter().enumerate() {
+        vocabulary.insert(term.clone(), feature as i32);
+    }
+    vocabulary
+}
+
+fn fixed_vocabulary_from_terms(terms: &[String]) -> Result<HashMap<String, i32>, Error> {
+    let mut vocabulary = HashMap::with_capacity(terms.len());
+    for (feature, term) in terms.iter().enumerate() {
+        if vocabulary.insert(term.clone(), feature as i32).is_some() {
+            return Err(Error::DuplicateVocabularyTerm(term.clone()));
+        }
+    }
+    Ok(vocabulary)
+}
+
+/// Target chunk count: a few tasks per Rayon thread for load balance, but
+/// never so many that chunks fall below [`CHUNK_DOCS_MIN`] (over-parallelizes
+/// small corpora). Also capped at `n_docs`.
+fn target_chunk_count(n_docs: usize) -> usize {
+    if n_docs == 0 {
+        return 0;
+    }
+    let by_threads = worker_threads().max(1).saturating_mul(CHUNKS_PER_THREAD);
+    let by_min_docs = (n_docs / CHUNK_DOCS_MIN).max(1);
+    by_threads.min(by_min_docs).min(n_docs).max(1)
+}
+
+/// Documents per chunk from [`target_chunk_count`], never larger than `n_docs`.
+fn chunk_size(n_docs: usize) -> usize {
+    if n_docs == 0 {
+        return 1;
+    }
+    n_docs.div_ceil(target_chunk_count(n_docs)).max(1)
+}
+
+fn worker_threads() -> usize {
+    match get_thread_pool() {
+        Some(pool) => pool.current_num_threads(),
+        None => rayon::current_num_threads(),
+    }
+}
+
+fn map_document_chunks<S, T, F>(documents: &[S], map: F) -> Vec<T>
+where
+    S: Sync,
+    T: Send,
+    F: Fn(&[S]) -> T + Sync + Send,
+{
+    if documents.is_empty() {
+        return Vec::new();
+    }
+    let size = chunk_size(documents.len());
+    let run = || documents.par_chunks(size).map(&map).collect();
+    match get_thread_pool() {
+        Some(pool) => pool.install(run),
+        None => run(),
+    }
+}
+
+fn accumulate_chunk_stats<S: AsRef<str>>(
+    documents: &[S],
+    options: &Options,
+) -> HashMap<String, TermStats> {
+    let mut stats: HashMap<String, TermStats> = HashMap::new();
+    let mut next_discovery_position = 0;
+
+    for (document_index, document) in documents.iter().enumerate() {
+        for_each_document_term(document.as_ref(), options, |term| {
+            if let Some(term_stats) = stats.get_mut(term) {
+                let first_in_document = term_stats.last_document != document_index;
+                if first_in_document {
+                    term_stats.document_frequency += 1;
+                    term_stats.last_document = document_index;
+                }
+                if !options.binary || first_in_document {
+                    term_stats.term_frequency += 1;
+                }
+                return;
+            }
+
+            stats.insert(
+                term.to_owned(),
+                TermStats {
+                    document_frequency: 1,
+                    term_frequency: 1,
+                    first_occurrence: DiscoveryOrder {
+                        chunk: 0,
+                        position: next_discovery_position,
+                    },
+                    last_document: document_index,
+                },
+            );
+            next_discovery_position += 1;
+        });
+    }
+
+    // The marker has no meaning outside this chunk and must not affect tests
+    // or merged statistics.
+    for term_stats in stats.values_mut() {
+        term_stats.last_document = usize::MAX;
+    }
+    stats
+}
+
+/// Merge per-chunk term stats.
+///
+/// Hash-shard terms so each key is owned by one worker. A tree `reduce` would
+/// rehash the growing vocabulary at every level; this stays linear in the sum
+/// of chunk-map sizes. Semantics (DF/TF, earliest discovery) are unchanged.
+fn merge_term_stats(chunk_stats: Vec<HashMap<String, TermStats>>) -> HashMap<String, TermStats> {
+    match chunk_stats.len() {
+        0 => return HashMap::new(),
+        1 => return chunk_stats.into_iter().next().unwrap(),
+        _ => {}
+    }
+
+    // Power of two so we can mask; capped so tiny pools don't over-shard.
+    let shards = worker_threads()
+        .max(1)
+        .next_power_of_two()
+        .min(MAX_MERGE_SHARDS);
+    if shards == 1 {
+        return merge_shard(chunk_stats.into_iter().flatten());
+    }
+
+    // Fixed seeds: same term always lands in the same shard for this merge.
+    let hasher = ahash::RandomState::with_seeds(0, 0, 0, 0);
+    let shard_mask = shards - 1;
+    let shard_of = |term: &str| (hasher.hash_one(term) as usize) & shard_mask;
+
+    let merge = || {
+        let per_chunk: Vec<Vec<Vec<(String, TermStats)>>> = chunk_stats
+            .into_par_iter()
+            .map(|map| {
+                let mut buckets: Vec<Vec<(String, TermStats)>> =
+                    (0..shards).map(|_| Vec::new()).collect();
+                for (term, stats) in map {
+                    let shard = shard_of(&term);
+                    buckets[shard].push((term, stats));
+                }
+                buckets
+            })
+            .collect();
+
+        let mut shard_inputs: Vec<Vec<Vec<(String, TermStats)>>> = (0..shards)
+            .map(|_| Vec::with_capacity(per_chunk.len()))
+            .collect();
+        for chunk_buckets in per_chunk {
+            for (shard, bucket) in chunk_buckets.into_iter().enumerate() {
+                shard_inputs[shard].push(bucket);
+            }
+        }
+
+        // Disjoint keys per shard, so the final extend just concatenates.
+        let shard_maps: Vec<HashMap<String, TermStats>> = shard_inputs
+            .into_par_iter()
+            .map(|buckets| merge_shard(buckets.into_iter().flatten()))
+            .collect();
+
+        let total = shard_maps.iter().map(|shard_map| shard_map.len()).sum();
+        let mut merged = HashMap::with_capacity(total);
+        for shard_map in shard_maps {
+            merged.extend(shard_map);
+        }
+        merged
+    };
+
+    match get_thread_pool() {
+        Some(pool) => pool.install(merge),
+        None => merge(),
+    }
+}
+
+/// Sum term statistics from an iterator of `(term, stats)` pairs into one map.
+fn merge_shard<I>(entries: I) -> HashMap<String, TermStats>
+where
+    I: Iterator<Item = (String, TermStats)>,
+{
+    let mut map: HashMap<String, TermStats> = HashMap::new();
+    for (term, stats) in entries {
+        let entry = map.entry(term).or_default();
+        entry.document_frequency += stats.document_frequency;
+        entry.term_frequency += stats.term_frequency;
+        entry.first_occurrence = entry.first_occurrence.min(stats.first_occurrence);
+    }
+    map
+}
+
+fn emit_weighted_chunk<S: AsRef<str>>(
+    documents: &[S],
+    model: &Model,
+    feature_order: Option<&[DiscoveryOrder]>,
+) -> CsrChunk {
+    let mut scratch = ChunkScratch::new(model.n_features());
+    let mut data = Vec::new();
+    let mut indices = Vec::new();
+    let mut indptr = Vec::with_capacity(documents.len() + 1);
+    indptr.push(0);
+
+    for document in documents {
+        count_features_into(
+            document.as_ref(),
+            &model.options,
+            &model.vocabulary,
+            &mut scratch,
+        );
+        if let Some(feature_order) = feature_order {
+            scratch
+                .features
+                .sort_unstable_by_key(|&(feature, _)| feature_order[feature as usize]);
+        } else {
+            scratch
+                .features
+                .sort_unstable_by_key(|&(feature, _)| feature);
+        }
+
+        let row_start = data.len();
+        for &(feature, count) in &scratch.features {
+            let mut value = tf_value(count, &model.options);
+            if model.options.use_idf {
+                value *= model.idf[feature as usize];
+            }
+            indices.push(feature);
+            data.push(value);
+        }
+        normalize(&mut data[row_start..], model.options.norm);
+        indptr.push(indices.len() as i64);
+    }
+
+    CsrChunk {
+        data,
+        indices,
+        indptr,
+    }
+}
+
+fn emit_tf_chunk<S: AsRef<str>>(
+    documents: &[S],
+    vocabulary: &HashMap<String, i32>,
+    n_features: usize,
+    options: &Options,
+) -> CsrChunk {
+    let mut scratch = ChunkScratch::new(n_features);
+    let mut data = Vec::new();
+    let mut indices = Vec::new();
+    let mut indptr = Vec::with_capacity(documents.len() + 1);
+    indptr.push(0);
+
+    for document in documents {
+        count_features_into(document.as_ref(), options, vocabulary, &mut scratch);
+        scratch
+            .features
+            .sort_unstable_by_key(|&(feature, _)| feature);
+
+        for &(feature, count) in &scratch.features {
+            indices.push(feature);
+            data.push(tf_value(count, options));
+        }
+        indptr.push(indices.len() as i64);
+    }
+
+    CsrChunk {
+        data,
+        indices,
+        indptr,
+    }
+}
+
+fn fixed_vocabulary_idf(
+    chunks: &[CsrChunk],
+    n_features: usize,
+    document_count: usize,
+    options: &Options,
+) -> Vec<f64> {
+    if !options.use_idf {
+        return vec![1.0; n_features];
+    }
+
+    let mut df = vec![0u64; n_features];
+    for chunk in chunks {
+        for &feature in &chunk.indices {
+            df[feature as usize] += 1;
+        }
+    }
+    df.into_iter()
+        .map(|document_frequency| compute_idf(document_count as u64, document_frequency, options))
+        .collect()
+}
+
+fn assemble_chunks(chunks: Vec<CsrChunk>, n_docs: usize) -> (Vec<f64>, Vec<i32>, Vec<i64>) {
+    let nonzero_count = chunks.iter().map(|chunk| chunk.indices.len()).sum();
+    let mut data = Vec::with_capacity(nonzero_count);
+    let mut indices = Vec::with_capacity(nonzero_count);
+    let mut indptr = Vec::with_capacity(n_docs + 1);
+    indptr.push(0);
+
+    let mut nnz_offset = 0i64;
+    for chunk in chunks {
+        let row_count = chunk.indptr.len().saturating_sub(1);
+        for row in 0..row_count {
+            indptr.push(nnz_offset + chunk.indptr[row + 1]);
+        }
+        nnz_offset += chunk.indices.len() as i64;
+        data.extend(chunk.data);
+        indices.extend(chunk.indices);
+    }
+
+    debug_assert_eq!(indptr.len(), n_docs + 1);
+    (data, indices, indptr)
+}
+
+fn apply_idf_and_normalize(
+    data: &mut [f64],
+    indices: &[i32],
+    indptr: &[i64],
+    idf: &[f64],
+    options: &Options,
+) {
+    let n_rows = indptr.len().saturating_sub(1);
+    for row in 0..n_rows {
+        let start = indptr[row] as usize;
+        let end = indptr[row + 1] as usize;
+        if options.use_idf {
+            for offset in start..end {
+                data[offset] *= idf[indices[offset] as usize];
+            }
+        }
+        normalize(&mut data[start..end], options.norm);
+    }
+}
+
+#[inline]
+fn tf_value(count: u64, options: &Options) -> f64 {
+    let mut value = if options.binary { 1.0 } else { count as f64 };
+    if options.sublinear_tf {
+        value = value.ln() + 1.0;
+    }
+    value
+}
+
+#[cfg(test)]
+fn count_document_into(document: &str, options: &Options, counts: &mut HashMap<String, u64>) {
+    counts.clear();
+    for_each_document_term(document, options, |term| {
+        if let Some(count) = counts.get_mut(term) {
+            *count += 1;
+        } else {
+            counts.insert(term.to_owned(), 1);
+        }
+    });
+}
+
+fn count_features_into(
+    document: &str,
+    options: &Options,
+    vocabulary: &HashMap<String, i32>,
+    scratch: &mut ChunkScratch,
+) {
+    scratch.features.clear();
+    match &mut scratch.feature_counts {
+        FeatureCounts::Dense(counts) => {
+            for_each_document_term(document, options, |term| {
+                if let Some(&feature) = vocabulary.get(term) {
+                    let count = &mut counts[feature as usize];
+                    if *count == 0 {
+                        scratch.features.push((feature, 0));
+                    }
+                    *count += 1;
+                }
+            });
+            for (feature, count) in &mut scratch.features {
+                let dense_count = &mut counts[*feature as usize];
+                *count = *dense_count;
+                *dense_count = 0;
+            }
+        }
+        FeatureCounts::Sparse(counts) => {
+            counts.clear();
+            for_each_document_term(document, options, |term| {
+                if let Some(&feature) = vocabulary.get(term) {
+                    *counts.entry(feature).or_insert(0) += 1;
+                }
+            });
+            scratch.features.extend(counts.drain());
+        }
+    }
+}
+
+fn for_each_document_term<F: FnMut(&str)>(document: &str, options: &Options, mut visit: F) {
+    debug_assert!(document.is_ascii());
+
+    if !options.lowercase {
+        for_each_term_from_ascii_text(document, options, &mut visit);
+        return;
+    }
+
+    if document.as_bytes().iter().any(u8::is_ascii_uppercase) {
+        // ASCII upper: byte lowercasing matches `str.lower()` without Unicode tables.
+        let lowered = document.to_ascii_lowercase();
+        for_each_term_from_ascii_text(&lowered, options, &mut visit);
+    } else {
+        for_each_term_from_ascii_text(document, options, &mut visit);
+    }
+}
+
+fn for_each_term_from_ascii_text<F: FnMut(&str)>(text: &str, options: &Options, visit: &mut F) {
+    if options.nmin == 1 && options.nmax == 1 {
+        for_each_word_token_ascii(text, visit);
+        return;
+    }
+
+    let mut tokens = Vec::with_capacity(16);
+    word_tokens_ascii(text, &mut tokens);
+    for_each_term_from_tokens(&tokens, options, visit);
+}
+
+fn for_each_term_from_tokens<F: FnMut(&str)>(tokens: &[&str], options: &Options, visit: &mut F) {
+    if options.nmin == 1 {
+        for &token in tokens {
+            visit(token);
+        }
+    }
+    if options.nmax >= 2 {
+        for_each_word_ngram(tokens, options.nmin.max(2), options.nmax, |ngram| {
+            visit(ngram);
+        });
+    }
+}
+
+#[cfg(test)]
+fn fill_counts_from_ascii_text(text: &str, options: &Options, counts: &mut HashMap<String, u64>) {
+    for_each_term_from_ascii_text(text, options, &mut |term| {
+        if let Some(count) = counts.get_mut(term) {
+            *count += 1;
+        } else {
+            counts.insert(term.to_owned(), 1);
+        }
+    });
+}
+
+#[inline]
+fn ensure_feature_count_fits_i32(n_features: usize) -> Result<(), Error> {
+    if n_features > i32::MAX as usize {
+        return Err(Error::TooManyFeatures);
+    }
+    Ok(())
+}
+
+fn select_terms<'a>(
+    stats: impl Iterator<Item = (&'a String, &'a TermStats)>,
+    min_document_count: f64,
+    max_document_count: f64,
+    max_features: Option<usize>,
+    exact_integer_limit: u64,
+) -> Result<Vec<String>, Error> {
+    let mut candidates: Vec<(&String, &TermStats)> = stats
+        .filter(|(_, term_stats)| {
+            let df = term_stats.document_frequency as f64;
+            df >= min_document_count && df <= max_document_count
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return Err(Error::NoTermsAfterPruning);
+    }
+
+    // Lexicographic order first (sklearn), then use it as the TF tie-breaker.
+    candidates.sort_unstable();
+    if let Some(limit) = max_features {
+        if candidates.len() > limit {
+            candidates.sort_by(|(left_term, left_stats), (right_term, right_stats)| {
+                right_stats
+                    .term_frequency
+                    .cmp(&left_stats.term_frequency)
+                    .then_with(|| left_term.cmp(right_term))
+            });
+            // sklearn casts counts to the configured matrix dtype before
+            // summing them for max_features. Above the dtype's consecutive
+            // integer range, rounding can change which term lies at the
+            // boundary. The exact u64 ranking cannot safely predict that
+            // result, so delegate this rare case to sklearn.
+            if candidates[limit - 1].1.term_frequency > exact_integer_limit {
+                return Err(Error::AmbiguousMaxFeatures);
+            }
+            // NumPy's unstable sort can break TF ties either way across releases.
+            // Fall back when a tie sits on the max_features boundary.
+            if candidates[limit - 1].1.term_frequency == candidates[limit].1.term_frequency {
+                return Err(Error::AmbiguousMaxFeatures);
+            }
+            candidates.truncate(limit);
+            candidates.sort_unstable();
+        }
+    }
+
+    Ok(candidates
+        .into_iter()
+        .map(|(term, _)| term.clone())
+        .collect())
+}
+
+fn compute_idf(document_count: u64, document_frequency: u64, options: &Options) -> f64 {
+    if !options.use_idf {
+        return 1.0;
+    }
+
+    let smoothing = u64::from(options.smooth_idf);
+    let numerator = (document_count + smoothing) as f64;
+    let denominator = (document_frequency + smoothing) as f64;
+    (numerator / denominator).ln() + 1.0
+}
+
+fn normalize(data: &mut [f64], norm: Norm) {
+    let denominator = match norm {
+        Norm::None => return,
+        Norm::L1 => data.iter().map(|value| value.abs()).sum(),
+        Norm::L2 => data.iter().map(|value| value * value).sum::<f64>().sqrt(),
+    };
+    if denominator > 0.0 {
+        for value in data {
+            *value /= denominator;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> Options {
+        Options {
+            nmin: 1,
+            nmax: 1,
+            lowercase: true,
+            binary: false,
+            norm: Norm::L2,
+            use_idf: true,
+            smooth_idf: true,
+            sublinear_tf: false,
+            output_dtype: OutputDtype::Float64,
+        }
+    }
+
+    #[test]
+    fn feature_count_above_i32_max_is_rejected() {
+        assert!(matches!(
+            ensure_feature_count_fits_i32(i32::MAX as usize),
+            Ok(())
+        ));
+        assert!(matches!(
+            ensure_feature_count_fits_i32((i32::MAX as usize) + 1),
+            Err(Error::TooManyFeatures)
+        ));
+    }
+
+    #[test]
+    fn fit_orders_vocabulary_lexicographically() {
+        let documents = vec!["zebra apple apple".to_owned(), "pear".to_owned()];
+        let output = fit(&documents, defaults(), None, 1.0, 2.0, None).unwrap();
+        assert_eq!(output.model.terms(), &["apple", "pear", "zebra"]);
+        assert_eq!(output.indices, vec![2, 0, 1]);
+        assert_eq!(output.indptr, vec![0, 2, 3]);
+    }
+
+    #[test]
+    fn learned_fit_preserves_discovery_order_after_feature_remapping() {
+        let documents = vec!["one two three four".to_owned()];
+        let output = fit(
+            &documents,
+            Options {
+                nmax: 2,
+                norm: Norm::None,
+                use_idf: false,
+                ..defaults()
+            },
+            None,
+            1.0,
+            1.0,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            output.model.terms(),
+            &[
+                "four",
+                "one",
+                "one two",
+                "three",
+                "three four",
+                "two",
+                "two three",
+            ]
+        );
+        assert_eq!(output.vocabulary_order, vec![1, 5, 3, 0, 2, 6, 4]);
+        assert_eq!(output.indices, vec![1, 5, 3, 0, 2, 6, 4]);
+    }
+
+    #[test]
+    fn learned_fit_preserves_discovery_order_across_chunks() {
+        // Put "apple" only in the last doc (second chunk) so its discovery
+        // order is after "zebra" from the first chunk.
+        let n_docs = CHUNK_DOCS_MIN * 2;
+        assert!(
+            target_chunk_count(n_docs) >= 2,
+            "test needs multiple chunks"
+        );
+        let mut documents = vec!["zebra".to_owned(); n_docs];
+        documents[n_docs - 1] = "zebra apple".to_owned();
+        let output = fit(
+            &documents,
+            Options {
+                norm: Norm::None,
+                use_idf: false,
+                ..defaults()
+            },
+            None,
+            1.0,
+            documents.len() as f64,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(output.model.terms(), &["apple", "zebra"]);
+        assert_eq!(output.vocabulary_order, vec![1, 0]);
+        assert_eq!(&output.indices[output.indices.len() - 2..], &[1, 0],);
+    }
+
+    #[test]
+    fn max_features_uses_corpus_term_frequency() {
+        let documents = vec!["zebra apple apple".to_owned(), "pear apple".to_owned()];
+        let output = fit(&documents, defaults(), None, 1.0, 2.0, Some(1)).unwrap();
+        assert_eq!(output.model.terms(), &["apple"]);
+    }
+
+    #[test]
+    fn float32_max_features_falls_back_beyond_exact_integer_range() {
+        let stats = HashMap::from([
+            (
+                "aa".to_owned(),
+                TermStats {
+                    document_frequency: 1,
+                    term_frequency: 1 << 24,
+                    ..TermStats::default()
+                },
+            ),
+            (
+                "bb".to_owned(),
+                TermStats {
+                    document_frequency: 1,
+                    term_frequency: (1 << 24) + 1,
+                    ..TermStats::default()
+                },
+            ),
+        ]);
+
+        let float32_result = select_terms(
+            stats.iter(),
+            1.0,
+            1.0,
+            Some(1),
+            OutputDtype::Float32.exact_integer_limit(),
+        );
+        assert!(matches!(float32_result, Err(Error::AmbiguousMaxFeatures)));
+
+        let float64_result = select_terms(
+            stats.iter(),
+            1.0,
+            1.0,
+            Some(1),
+            OutputDtype::Float64.exact_integer_limit(),
+        )
+        .unwrap();
+        assert_eq!(float64_result, vec!["bb"]);
+    }
+
+    #[test]
+    fn chunk_stats_count_binary_tf_once_per_document() {
+        let documents = ["apple apple banana", "apple banana banana"];
+        let mut options = defaults();
+        options.binary = true;
+
+        let stats = accumulate_chunk_stats(&documents, &options);
+        assert_eq!(stats["apple"].document_frequency, 2);
+        assert_eq!(stats["apple"].term_frequency, 2);
+        assert_eq!(stats["banana"].document_frequency, 2);
+        assert_eq!(stats["banana"].term_frequency, 2);
+
+        options.binary = false;
+        let stats = accumulate_chunk_stats(&documents, &options);
+        assert_eq!(stats["apple"].document_frequency, 2);
+        assert_eq!(stats["apple"].term_frequency, 3);
+        assert_eq!(stats["banana"].document_frequency, 2);
+        assert_eq!(stats["banana"].term_frequency, 3);
+    }
+
+    #[test]
+    fn dense_and_sparse_feature_counters_match() {
+        let vocabulary = HashMap::from([("apple".to_owned(), 0), ("banana".to_owned(), 1)]);
+        let options = defaults();
+
+        let mut dense = ChunkScratch::new(vocabulary.len());
+        count_features_into(
+            "banana apple apple unknown",
+            &options,
+            &vocabulary,
+            &mut dense,
+        );
+        dense.features.sort_unstable();
+
+        let mut sparse = ChunkScratch::new(DENSE_COUNT_FEATURE_LIMIT + 1);
+        count_features_into(
+            "banana apple apple unknown",
+            &options,
+            &vocabulary,
+            &mut sparse,
+        );
+        sparse.features.sort_unstable();
+
+        assert_eq!(dense.features, vec![(0, 2), (1, 1)]);
+        assert_eq!(sparse.features, dense.features);
+    }
+
+    #[test]
+    fn max_features_zero_returns_an_error_instead_of_panicking() {
+        let documents = vec!["apple banana".to_owned()];
+        let result =
+            std::panic::catch_unwind(|| fit(&documents, defaults(), None, 1.0, 1.0, Some(0)));
+        assert!(result.is_ok(), "max_features=0 must not panic");
+        assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn transform_ignores_unknown_terms_and_normalizes_rows() {
+        let documents = vec!["known token".to_owned(), "known".to_owned()];
+        let output = fit(&documents, defaults(), None, 1.0, 2.0, None).unwrap();
+        let transformed = output
+            .model
+            .transform(&["known missing missing".to_owned()]);
+        assert_eq!(transformed.1.len(), 1);
+        assert!((transformed.0[0] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn fixed_vocabulary_keeps_unseen_terms() {
+        let documents = vec!["known token".to_owned()];
+        let terms = vec!["known".to_owned(), "unseen".to_owned()];
+        let output = fit(&documents, defaults(), Some(terms), 1.0, 1.0, None).unwrap();
+        assert_eq!(output.model.n_features(), 2);
+        assert_eq!(output.vocabulary_order, vec![0, 1]);
+        assert!(output.model.idf()[1] > output.model.idf()[0]);
+    }
+
+    #[test]
+    fn fixed_vocabulary_rejects_duplicate_terms() {
+        let documents = vec!["duplicate".to_owned()];
+        let terms = vec!["duplicate".to_owned(), "duplicate".to_owned()];
+        let result = fit(&documents, defaults(), Some(terms), 1.0, 1.0, None);
+
+        assert!(matches!(
+            result,
+            Err(Error::DuplicateVocabularyTerm(term)) if term == "duplicate"
+        ));
+    }
+
+    #[test]
+    fn fixed_vocabulary_document_frequency_counts_each_feature_once_per_document() {
+        let documents = vec![
+            "known known known shared".to_owned(),
+            "known shared shared".to_owned(),
+            "shared irrelevant-token".to_owned(),
+        ];
+        let terms = vec!["known".to_owned(), "shared".to_owned(), "unseen".to_owned()];
+        let vocabulary = vocabulary_from_terms(&terms);
+        let chunk = emit_tf_chunk(&documents, &vocabulary, terms.len(), &defaults());
+        let mut df = vec![0u64; terms.len()];
+        for feature in chunk.indices {
+            df[feature as usize] += 1;
+        }
+        assert_eq!(df, vec![2, 3, 0]);
+    }
+
+    #[test]
+    fn fixed_vocabulary_idf_reduces_sparse_indices_across_chunks() {
+        let chunks = vec![
+            CsrChunk {
+                data: vec![1.0, 1.0],
+                indices: vec![0, 1],
+                indptr: vec![0, 2],
+            },
+            CsrChunk {
+                data: vec![1.0],
+                indices: vec![1],
+                indptr: vec![0, 1],
+            },
+        ];
+        let options = Options {
+            norm: Norm::None,
+            smooth_idf: false,
+            ..defaults()
+        };
+        let idf = fixed_vocabulary_idf(&chunks, 3, 2, &options);
+
+        assert_eq!(idf[0], (2.0f64).ln() + 1.0);
+        assert_eq!(idf[1], 1.0);
+        assert!(idf[2].is_infinite());
+    }
+
+    #[test]
+    fn fixed_vocabulary_skips_document_frequency_scan_when_idf_is_disabled() {
+        let chunks = vec![CsrChunk {
+            data: vec![1.0],
+            // This deliberately invalid index would panic if the DF scan ran.
+            indices: vec![i32::MAX],
+            indptr: vec![0, 1],
+        }];
+        let options = Options {
+            use_idf: false,
+            ..defaults()
+        };
+        assert_eq!(
+            fixed_vocabulary_idf(&chunks, 2, 1, &options),
+            vec![1.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn fixed_vocabulary_weighting_combinations_preserve_sorted_sparse_rows() {
+        let documents = vec!["banana banana apple".to_owned(), "banana carrot".to_owned()];
+        let terms = vec![
+            "apple".to_owned(),
+            "banana".to_owned(),
+            "carrot".to_owned(),
+            "unseen".to_owned(),
+        ];
+
+        for &binary in &[false, true] {
+            for &sublinear_tf in &[false, true] {
+                for &use_idf in &[false, true] {
+                    for &smooth_idf in &[false, true] {
+                        let options = Options {
+                            binary,
+                            sublinear_tf,
+                            use_idf,
+                            smooth_idf,
+                            norm: Norm::None,
+                            ..defaults()
+                        };
+                        let output =
+                            fit(&documents, options, Some(terms.clone()), 1.0, 2.0, None).unwrap();
+                        assert_eq!(output.indices, vec![0, 1, 1, 2]);
+                        assert_eq!(output.indptr, vec![0, 2, 4]);
+                        assert_eq!(output.model.n_features(), 4);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_vocabulary_document_frequency_is_correct_across_chunks() {
+        let n_docs = CHUNK_DOCS_MIN * 2;
+        assert!(
+            target_chunk_count(n_docs) >= 2,
+            "test needs multiple chunks"
+        );
+        let documents: Vec<String> = (0..n_docs)
+            .map(|index| {
+                if index % 2 == 0 {
+                    "alpha alpha shared".to_owned()
+                } else {
+                    "beta shared shared".to_owned()
+                }
+            })
+            .collect();
+        let terms = vec![
+            "alpha".to_owned(),
+            "beta".to_owned(),
+            "shared".to_owned(),
+            "unseen".to_owned(),
+        ];
+        let output = fit(
+            &documents,
+            Options {
+                norm: Norm::None,
+                smooth_idf: false,
+                ..defaults()
+            },
+            Some(terms),
+            1.0,
+            documents.len() as f64,
+            None,
+        )
+        .unwrap();
+
+        let document_count = documents.len() as f64;
+        let alpha_df = documents.len().div_ceil(2) as f64;
+        let beta_df = (documents.len() / 2) as f64;
+        assert!((output.model.idf()[0] - ((document_count / alpha_df).ln() + 1.0)).abs() < 1e-12);
+        assert!((output.model.idf()[1] - ((document_count / beta_df).ln() + 1.0)).abs() < 1e-12);
+        assert_eq!(output.model.idf()[2], 1.0);
+        assert!(output.model.idf()[3].is_infinite());
+    }
+
+    #[test]
+    fn chunk_count_respects_threads_and_min_docs() {
+        assert_eq!(chunk_size(1), 1);
+        assert_eq!(target_chunk_count(1), 1);
+        // Below CHUNK_DOCS_MIN → a single chunk regardless of thread count.
+        assert_eq!(target_chunk_count(CHUNK_DOCS_MIN - 1), 1);
+        assert_eq!(chunk_size(CHUNK_DOCS_MIN - 1), CHUNK_DOCS_MIN - 1);
+
+        let by_threads = worker_threads().max(1) * CHUNKS_PER_THREAD;
+        // 10k docs: min-docs cap is 10, so high thread counts cannot over-split.
+        assert_eq!(
+            target_chunk_count(10_000),
+            by_threads.min(10_000 / CHUNK_DOCS_MIN)
+        );
+        // 1M docs: thread cap binds before the min-docs cap.
+        assert_eq!(
+            target_chunk_count(1_000_000),
+            by_threads.min(1_000_000 / CHUNK_DOCS_MIN)
+        );
+        assert!(chunk_size(10_000) >= CHUNK_DOCS_MIN);
+        assert!(target_chunk_count(100) <= 100);
+        assert!(chunk_size(100) * target_chunk_count(100) >= 100);
+    }
+
+    #[test]
+    fn merge_term_stats_sums_overlapping_terms_across_many_chunks() {
+        // Overlapping terms across many chunks so the merge has to sum.
+        let terms = ["apple", "banana", "cherry", "date", "elderberry", "fig"];
+        let chunk_count = 200;
+        let mut chunk_stats = Vec::with_capacity(chunk_count);
+        let mut expected: std::collections::BTreeMap<String, TermStats> = Default::default();
+
+        for chunk in 0..chunk_count {
+            let mut map: HashMap<String, TermStats> = HashMap::new();
+            for (index, term) in terms.iter().enumerate() {
+                // Vary participation so different terms accrue different totals.
+                if (chunk + index) % 3 != 0 {
+                    let stats = TermStats {
+                        document_frequency: 1 + index as u64,
+                        term_frequency: 2 + (chunk as u64 % 5),
+                        first_occurrence: DiscoveryOrder {
+                            chunk,
+                            position: index,
+                        },
+                        last_document: usize::MAX,
+                    };
+                    map.insert((*term).to_owned(), stats);
+                    let entry = expected.entry((*term).to_owned()).or_default();
+                    entry.document_frequency += stats.document_frequency;
+                    entry.term_frequency += stats.term_frequency;
+                    entry.first_occurrence = entry.first_occurrence.min(stats.first_occurrence);
+                }
+            }
+            chunk_stats.push(map);
+        }
+
+        let merged = merge_term_stats(chunk_stats);
+        assert_eq!(merged.len(), expected.len());
+        for (term, stats) in expected {
+            let got = merged
+                .get(term.as_str())
+                .unwrap_or_else(|| panic!("missing term {term}"));
+            assert_eq!(
+                got.document_frequency, stats.document_frequency,
+                "df {term}"
+            );
+            assert_eq!(got.term_frequency, stats.term_frequency, "tf {term}");
+            assert_eq!(
+                got.first_occurrence, stats.first_occurrence,
+                "first occurrence {term}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_term_stats_handles_empty_and_single_chunk() {
+        assert!(merge_term_stats(Vec::new()).is_empty());
+
+        let mut single: HashMap<String, TermStats> = HashMap::new();
+        single.insert(
+            "solo".to_owned(),
+            TermStats {
+                document_frequency: 2,
+                term_frequency: 5,
+                first_occurrence: DiscoveryOrder {
+                    chunk: 0,
+                    position: 3,
+                },
+                last_document: usize::MAX,
+            },
+        );
+        let merged = merge_term_stats(vec![single]);
+        assert_eq!(merged.len(), 1);
+        let stats = merged.get("solo").unwrap();
+        assert_eq!(stats.document_frequency, 2);
+        assert_eq!(stats.term_frequency, 5);
+        assert_eq!(
+            stats.first_occurrence,
+            DiscoveryOrder {
+                chunk: 0,
+                position: 3
+            }
+        );
+    }
+
+    fn reference_counts(document: &str, options: &Options) -> HashMap<String, u64> {
+        let mut counts: HashMap<String, u64> = HashMap::new();
+        if options.lowercase {
+            let lowered = document.to_ascii_lowercase();
+            fill_counts_from_ascii_text(&lowered, options, &mut counts);
+        } else {
+            fill_counts_from_ascii_text(document, options, &mut counts);
+        }
+        counts
+    }
+
+    fn assert_counts_match(document: &str, options: &Options) {
+        let mut got: HashMap<String, u64> = HashMap::new();
+        count_document_into(document, options, &mut got);
+        let expected = reference_counts(document, options);
+        assert_eq!(got, expected, "document {document:?} options {options:?}");
+    }
+
+    fn tokenizer_option_sets() -> Vec<Options> {
+        let mut sets = Vec::new();
+        for &lowercase in &[true, false] {
+            for &(nmin, nmax) in &[(1usize, 1usize), (1, 2), (2, 3)] {
+                sets.push(Options {
+                    nmin,
+                    nmax,
+                    lowercase,
+                    ..defaults()
+                });
+            }
+        }
+        sets
+    }
+
+    #[test]
+    fn ascii_tokenizer_matches_reference_on_curated_corpus() {
+        let corpus = [
+            "the quick brown fox jumps over the lazy dog",
+            "The Quick BROWN Fox",
+            "HELLO, WORLD! hello.",
+            "MIXED123 under_score X_Y a b cc",
+            "",
+            "a",
+            "42 4 seven_eight under_score",
+            "  spaced   OUT   text  ",
+        ];
+        for document in corpus {
+            for options in tokenizer_option_sets() {
+                assert_counts_match(document, &options);
+            }
+        }
+    }
+
+    #[test]
+    fn ascii_tokenizer_matches_reference_on_random_documents() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let alphabet: Vec<char> = "abcdeXYZ0129_ \t.,!?-".chars().collect();
+        let option_sets = tokenizer_option_sets();
+        let mut rng = StdRng::seed_from_u64(0x05EE_D1DF);
+
+        for _ in 0..3000 {
+            let length = rng.random_range(0..24);
+            let document: String = (0..length)
+                .map(|_| alphabet[rng.random_range(0..alphabet.len())])
+                .collect();
+            for options in &option_sets {
+                assert_counts_match(&document, options);
+            }
+        }
+    }
+}

--- a/_rust/src/tokenize.rs
+++ b/_rust/src/tokenize.rs
@@ -33,6 +33,82 @@ pub fn char_ngrams<'a>(s: &'a str, nmin: usize, nmax: usize, buf: &mut Vec<&'a s
     }
 }
 
+/// ASCII fast path for the default word token pattern.
+///
+/// Callers that already established ASCII input can use this directly and
+/// avoid Unicode classification.
+#[inline]
+pub fn word_tokens_ascii<'a>(text: &'a str, out: &mut Vec<&'a str>) {
+    for_each_word_token_ascii(text, |token| out.push(token));
+}
+
+#[inline]
+pub fn for_each_word_token_ascii<'a, F>(text: &'a str, mut visit: F)
+where
+    F: FnMut(&'a str),
+{
+    debug_assert!(text.is_ascii());
+
+    let bytes = text.as_bytes();
+    let mut token_start = 0usize;
+    let mut in_token = false;
+
+    for (offset, &byte) in bytes.iter().enumerate() {
+        let is_word = byte.is_ascii_alphanumeric() || byte == b'_';
+        if is_word {
+            if !in_token {
+                token_start = offset;
+                in_token = true;
+            }
+        } else if in_token {
+            if offset - token_start >= 2 {
+                visit(&text[token_start..offset]);
+            }
+            in_token = false;
+        }
+    }
+
+    if in_token && bytes.len() - token_start >= 2 {
+        visit(&text[token_start..]);
+    }
+}
+
+/// Word n-grams in sklearn order. Unigrams are borrowed; higher-order grams
+/// are joined with a shared scratch buffer.
+pub fn for_each_word_ngram<F>(tokens: &[&str], nmin: usize, nmax: usize, mut visit: F)
+where
+    F: FnMut(&str),
+{
+    let token_count = tokens.len();
+    let start = nmin.max(1);
+    let end = nmax.min(token_count);
+    if start > end {
+        return;
+    }
+
+    let mut joined = String::new();
+
+    for n in start..=end {
+        if n == 1 {
+            for &token in tokens {
+                visit(token);
+            }
+            continue;
+        }
+
+        for start in 0..=token_count - n {
+            joined.clear();
+            for (position, &token) in tokens[start..start + n].iter().enumerate() {
+                if position != 0 {
+                    joined.push(' ');
+                }
+                joined.push_str(token);
+            }
+            visit(&joined);
+        }
+    }
+}
+
 pub fn char_wb_ngrams(str: &str, nmin: usize, nmax: usize, buf: &mut Vec<String>) {
     // Pad with spaces at word boundaries and then extract like char_ngrams
     // TODO: Implement proper word-boundary padding
@@ -45,5 +121,65 @@ pub fn char_wb_ngrams(str: &str, nmin: usize, nmax: usize, buf: &mut Vec<String>
             let j = i + n;
             buf.push(padded[i..j].to_string()); //FIXME (perf): allocations
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_word_pattern_drops_single_character_tokens() {
+        let mut tokens = Vec::new();
+        word_tokens_ascii("a fox 42 _ x_y cafe", &mut tokens);
+        assert_eq!(tokens, vec!["fox", "42", "x_y", "cafe"]);
+    }
+
+    #[test]
+    fn word_ngrams_follow_sklearn_order() {
+        let tokens = vec!["one", "two", "three"];
+        let mut grams = Vec::new();
+        for_each_word_ngram(&tokens, 1, 2, |gram| grams.push(gram.to_owned()));
+        assert_eq!(grams, vec!["one", "two", "three", "one two", "two three"]);
+    }
+
+    #[test]
+    fn word_ngrams_support_ordinary_ranges_and_empty_ranges() {
+        let tokens = vec!["one", "two", "three"];
+
+        let mut unigrams = Vec::new();
+        for_each_word_ngram(&tokens, 1, 1, |gram| unigrams.push(gram.to_owned()));
+        assert_eq!(unigrams, vec!["one", "two", "three"]);
+
+        let mut higher_order = Vec::new();
+        for_each_word_ngram(&tokens, 2, 3, |gram| higher_order.push(gram.to_owned()));
+        assert_eq!(higher_order, vec!["one two", "two three", "one two three"]);
+
+        let mut beyond_token_count = Vec::new();
+        for_each_word_ngram(&tokens, 4, 8, |gram| {
+            beyond_token_count.push(gram.to_owned())
+        });
+        assert!(beyond_token_count.is_empty());
+    }
+
+    #[test]
+    fn word_ngrams_cap_extreme_bounds_at_the_token_count() {
+        let mut empty_output = Vec::new();
+        for_each_word_ngram(&[], 1, usize::MAX, |gram| {
+            empty_output.push(gram.to_owned())
+        });
+        assert!(empty_output.is_empty());
+
+        let mut one_token_output = Vec::new();
+        for_each_word_ngram(&["one"], 1, usize::MAX, |gram| {
+            one_token_output.push(gram.to_owned())
+        });
+        assert_eq!(one_token_output, vec!["one"]);
+
+        let mut range_above_tokens = Vec::new();
+        for_each_word_ngram(&["one", "two"], 3, usize::MAX, |gram| {
+            range_above_tokens.push(gram.to_owned())
+        });
+        assert!(range_above_tokens.is_empty());
     }
 }

--- a/stratum/_rust_backend.py
+++ b/stratum/_rust_backend.py
@@ -50,16 +50,28 @@ def print_timing(msg, start_time):
         print(f"[python] {msg}: {(end_time - start_time):8.3f}s")
 
 
-# pandas or polars series -> list (best-effort, minimal overhead)
+# Container -> list (best-effort, minimal overhead).
+# Prefer pandas/NumPy ``.tolist()`` and Polars ``.to_list()`` over generic
+# ``list(...)`` iteration, which is much slower for large Series/arrays.
 def _to_list(col):
-    try:
-        return col.tolist()
-    except Exception:
-        pass
-    try:
-        return col.to_list()
-    except Exception:
-        pass
+    if isinstance(col, list):
+        return list(col)
+    tolist = getattr(col, "tolist", None)
+    if callable(tolist):
+        try:
+            materialized = tolist()
+            if isinstance(materialized, list):
+                return materialized
+        except Exception:
+            pass
+    to_list = getattr(col, "to_list", None)
+    if callable(to_list):
+        try:
+            materialized = to_list()
+            if isinstance(materialized, list):
+                return materialized
+        except Exception:
+            pass
     return list(col)
 
 #---------------------------------------------
@@ -69,6 +81,11 @@ hashing_tfidf_fit = getattr(native, "hashing_tfidf_csr", None) if native else No
 hashing_tfidf_transform = getattr(native, "hashing_tfidf_csr_with_idf", None) if native else None
 tfidf_fit = getattr(native, "tfidf_fit_csr", None) if native else None
 tfidf_transform = getattr(native, "tfidf_transform_csr", None) if native else None
+tfidf_vectorizer_fit = getattr(native, "tfidf_vectorizer_fit", None) if native else None
+tfidf_vectorizer_transform = getattr(native, "tfidf_vectorizer_transform", None) if native else None
+TfidfVectorizerFallback = (
+    getattr(native, "TfidfVectorizerFallback", ()) if native else ()
+)
 fd_fit= getattr(native, "fd_fit_from_csr", None) if native else None
 fd_transform= getattr(native, "fd_transform_from_csr", None) if native else None
 truncated_svd_fit = getattr(native, "truncated_svd_fit_from_csr", None) if native else None

--- a/stratum/adapters/tfidf_vectorizer.py
+++ b/stratum/adapters/tfidf_vectorizer.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import logging
+import operator
+import warnings
+from collections.abc import Mapping
+from numbers import Integral, Real
+
+import numpy as np
+import scipy.sparse as sp
+from sklearn.feature_extraction.text import TfidfTransformer
+from sklearn.feature_extraction.text import TfidfVectorizer as _TV
+from sklearn.utils.validation import check_is_fitted
+
+from .. import _rust_backend as rb
+from .._config import get_config
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOKEN_PATTERN = r"(?u)\b\w\w+\b"
+_NATIVE_USIZE_MAX = int(np.iinfo(np.uintp).max)
+
+
+def _supported_integral(value) -> bool:
+    return isinstance(value, Integral) and not isinstance(value, (bool, np.bool_))
+
+
+def _valid_document_frequency(value) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return False
+    if isinstance(value, Integral):
+        return value >= 1
+    if isinstance(value, Real):
+        return 0.0 <= value <= 1.0
+    return False
+
+
+def _fits_native_usize(value) -> bool:
+    """Return whether an integer can cross the native ``usize`` boundary."""
+    return _supported_integral(value) and 0 <= operator.index(value) <= _NATIVE_USIZE_MAX
+
+
+def _rust_supported_subset(vectorizer: _TV) -> tuple[bool, str]:
+    """Return whether the vectorizer params are supported by the Rust kernel."""
+    if getattr(vectorizer, "analyzer", "word") != "word":
+        return False, "analyzer != 'word'"
+    if getattr(vectorizer, "token_pattern", _DEFAULT_TOKEN_PATTERN) != _DEFAULT_TOKEN_PATTERN:
+        return False, "non-default token_pattern"
+    if getattr(vectorizer, "stop_words", None) is not None:
+        return False, "stop_words not supported"
+    if getattr(vectorizer, "preprocessor", None) is not None:
+        return False, "custom preprocessor not supported"
+    if getattr(vectorizer, "tokenizer", None) is not None:
+        return False, "custom tokenizer not supported"
+    if getattr(vectorizer, "strip_accents", None) is not None:
+        return False, "strip_accents not supported"
+    if getattr(vectorizer, "input", "content") != "content":
+        return False, "input != 'content'"
+    if getattr(vectorizer, "norm", "l2") not in (None, "l1", "l2"):
+        return False, "unsupported norm"
+
+    for parameter in ("lowercase", "binary", "use_idf", "smooth_idf", "sublinear_tf"):
+        # Plain Python bool only (rejects numpy bools), matching HashingVectorizer.
+        if not isinstance(getattr(vectorizer, parameter), bool):
+            return False, f"non-bool {parameter}"
+
+    ngram_range = getattr(vectorizer, "ngram_range", (1, 1))
+    if not (
+        isinstance(ngram_range, tuple)
+        and len(ngram_range) == 2
+        and all(_fits_native_usize(value) for value in ngram_range)
+    ):
+        return False, f"invalid ngram_range {ngram_range!r}"
+    ngram_min, ngram_max = map(operator.index, ngram_range)
+    if not 1 <= ngram_min <= ngram_max:
+        return False, f"invalid ngram_range {ngram_range!r}"
+
+    if not _valid_document_frequency(getattr(vectorizer, "min_df", 1)):
+        return False, "invalid min_df"
+    if not _valid_document_frequency(getattr(vectorizer, "max_df", 1.0)):
+        return False, "invalid max_df"
+
+    max_features = getattr(vectorizer, "max_features", None)
+    if max_features is not None and not (
+        _fits_native_usize(max_features)
+        and operator.index(max_features) >= 1
+    ):
+        return False, "invalid max_features"
+
+    try:
+        dtype = np.dtype(getattr(vectorizer, "dtype", np.float64))
+    except (TypeError, ValueError):
+        return False, "invalid dtype"
+    if dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+        return False, "dtype is not float32 or float64"
+
+    vocabulary = getattr(vectorizer, "vocabulary", None)
+    if isinstance(vocabulary, Mapping) and not all(
+        isinstance(term, str) for term in vocabulary
+    ):
+        return False, "fixed vocabulary contains non-string terms"
+    return True, ""
+
+
+def _materialize_documents(raw_documents):
+    """Turn raw_documents into a list. Lists are returned as-is; pandas/NumPy/
+    Polars use ``tolist`` / ``to_list`` via ``_to_list``.
+    """
+    if isinstance(raw_documents, list):
+        return raw_documents
+    return rb._to_list(raw_documents)
+
+
+def _prepare_documents(raw_documents, encoding: str, decode_error: str):
+    """Materialize and decode content input.
+
+    All-``str`` lists are reused for Rust and sklearn (no copy). A decoded
+    copy is built only after the first ``bytes`` element. Non-str/non-bytes
+    force sklearn fallback with the materialized values kept (needed for
+    consumed generators).
+    """
+    if isinstance(raw_documents, str):
+        return None, raw_documents
+
+    documents = _materialize_documents(raw_documents)
+    decoded = None
+    for index, document in enumerate(documents):
+        if isinstance(document, str):
+            if decoded is not None:
+                decoded.append(document)
+        elif isinstance(document, bytes):
+            if decoded is None:
+                decoded = list(documents[:index])
+            decoded.append(document.decode(encoding, errors=decode_error))
+        else:
+            # sklearn owns the error behavior for non-content objects.
+            return None, documents
+    if decoded is None:
+        return documents, documents
+    return decoded, documents
+
+
+def _documents_are_ascii(documents) -> bool:
+    """Return whether every decoded document is safe for Rust tokenization."""
+    return all(document.isascii() for document in documents)
+
+
+def _transform_signature(vectorizer: _TV):
+    """Parameters that sklearn consults while transforming fitted data."""
+    return (
+        vectorizer.analyzer,
+        vectorizer.token_pattern,
+        vectorizer.stop_words,
+        vectorizer.preprocessor,
+        vectorizer.tokenizer,
+        vectorizer.strip_accents,
+        vectorizer.input,
+        bool(vectorizer.lowercase),
+        tuple(vectorizer.ngram_range),
+        bool(vectorizer.binary),
+        np.dtype(vectorizer.dtype),
+        vectorizer.norm,
+        bool(vectorizer.use_idf),
+        bool(vectorizer.smooth_idf),
+        bool(vectorizer.sublinear_tf),
+    )
+
+
+def _fitted_state_matches_native_snapshot(vectorizer: _TV) -> bool:
+    """Return whether mutable sklearn fitted state still matches the Rust model."""
+    vocabulary = getattr(vectorizer, "vocabulary_", None)
+    vocabulary_snapshot = getattr(vectorizer, "_rust_vocabulary_snapshot_", None)
+    try:
+        if vocabulary_snapshot is None or vocabulary != vocabulary_snapshot:
+            return False
+    except (TypeError, ValueError):
+        return False
+
+    if not vectorizer.use_idf:
+        return True
+
+    transformer = getattr(vectorizer, "_tfidf", None)
+    idf = getattr(transformer, "idf_", None)
+    idf_snapshot = getattr(vectorizer, "_rust_idf_snapshot_", None)
+    if idf is None or idf_snapshot is None:
+        return False
+    try:
+        idf = np.asarray(idf)
+        return (
+            idf.shape == idf_snapshot.shape
+            and idf.dtype == idf_snapshot.dtype
+            and np.array_equal(idf, idf_snapshot)
+        )
+    except (TypeError, ValueError):
+        return False
+
+
+class RustyTfidfVectorizer(_TV):
+    """sklearn ``TfidfVectorizer`` with a Rust backend for the default word
+    analyzer on ASCII content. Everything else (Unicode, custom analyzers,
+    tokenizers, preprocessors, accent stripping, stop words) uses sklearn.
+    """
+
+    def _rust_enabled(self) -> bool:
+        config = get_config()
+        return bool(
+            config["allow_patch"]
+            and config["rust_backend"]
+            and rb.HAVE_RUST
+            and rb.tfidf_vectorizer_fit is not None
+            and rb.tfidf_vectorizer_transform is not None
+        )
+
+    def _invalidate_rust_model(self) -> None:
+        self._rust_tfidf_model_ = None
+        self.__dict__.pop("_rust_vocabulary_snapshot_", None)
+        self.__dict__.pop("_rust_idf_snapshot_", None)
+
+    def _fit_transform_with_rust(self, raw_documents):
+        supported, reason = _rust_supported_subset(self)
+        if not supported:
+            logger.debug("TfidfVectorizer Rust fallback: %s", reason)
+            return None, raw_documents
+        if not self._rust_enabled():
+            return None, raw_documents
+
+        # Native fit skips sklearn's decorated fit, so validate params ourselves.
+        self._validate_params()
+
+        t_mat = rb.start_timing()
+        documents, fallback_documents = _prepare_documents(
+            raw_documents, self.encoding, self.decode_error
+        )
+        rb.print_timing("tv py_materialize", t_mat)
+        if documents is None:
+            return None, fallback_documents
+        t_ascii = rb.start_timing()
+        non_ascii = not _documents_are_ascii(documents)
+        rb.print_timing("tv ascii_prescan", t_ascii)
+        if non_ascii:
+            return None, fallback_documents
+        if not documents:
+            return None, fallback_documents
+
+        # Match CountVectorizer/TfidfVectorizer's validation and fitted state.
+        self._check_params()
+        self._validate_ngram_range()
+        self._warn_for_unused_params()
+        self._validate_vocabulary()
+
+        fixed_terms = None
+        if self.fixed_vocabulary_:
+            if not all(isinstance(term, str) for term in self.vocabulary_):
+                return None, fallback_documents
+            fixed_terms = [None] * len(self.vocabulary_)
+            for term, feature in self.vocabulary_.items():
+                fixed_terms[feature] = term
+            if self.lowercase and any(any(map(str.isupper, term)) for term in fixed_terms):
+                warnings.warn(
+                    "Upper case characters found in vocabulary while 'lowercase' is True. "
+                    "These entries will not be matched with any documents",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        document_count = len(documents)
+        max_document_count = (
+            float(self.max_df)
+            if isinstance(self.max_df, Integral)
+            else float(self.max_df) * document_count
+        )
+        min_document_count = (
+            float(self.min_df)
+            if isinstance(self.min_df, Integral)
+            else float(self.min_df) * document_count
+        )
+        if not self.fixed_vocabulary_ and max_document_count < min_document_count:
+            raise ValueError("max_df corresponds to < documents than min_df")
+
+        t_prep = rb.start_timing()
+        ngram_min, ngram_max = map(operator.index, self.ngram_range)
+        max_features = (
+            None if self.max_features is None else operator.index(self.max_features)
+        )
+        norm = "none" if self.norm is None else self.norm
+        output_dtype = np.dtype(self.dtype)
+        rb.print_timing("tv prep", t_prep)
+        try:
+            (
+                model,
+                data,
+                indices,
+                indptr,
+                n_rows,
+                n_cols,
+                terms,
+                vocabulary_order,
+                idf,
+            ) = rb.tfidf_vectorizer_fit(
+                documents,
+                ngram_min,
+                ngram_max,
+                self.lowercase,
+                self.binary,
+                norm,
+                self.use_idf,
+                self.smooth_idf,
+                self.sublinear_tf,
+                min_document_count,
+                max_document_count,
+                max_features,
+                fixed_terms,
+                output_dtype.name,
+            )
+        except rb.TfidfVectorizerFallback:
+            return None, fallback_documents
+
+        if self.fixed_vocabulary_:
+            self.vocabulary_ = dict(self.vocabulary_)
+        else:
+            self.vocabulary_ = {
+                terms[feature]: feature for feature in vocabulary_order
+            }
+        self._tfidf = TfidfTransformer(
+            norm=self.norm,
+            use_idf=self.use_idf,
+            smooth_idf=self.smooth_idf,
+            sublinear_tf=self.sublinear_tf,
+        )
+        self._tfidf.n_features_in_ = n_cols
+        if self.use_idf:
+            self._tfidf.idf_ = np.asarray(idf, dtype=output_dtype)
+
+        self._rust_tfidf_model_ = model
+        self._rust_transform_signature_ = _transform_signature(self)
+        native_transform_is_safe = not (
+            self.use_idf
+            and self.norm is not None
+            and not np.isfinite(self._tfidf.idf_).all()
+        )
+        if native_transform_is_safe:
+            self._rust_vocabulary_snapshot_ = self.vocabulary_.copy()
+            self._rust_idf_snapshot_ = (
+                np.array(self._tfidf.idf_, copy=True) if self.use_idf else None
+            )
+        else:
+            self._invalidate_rust_model()
+
+        t_csr = rb.start_timing()
+        matrix = sp.csr_matrix(
+            (
+                np.asarray(data, dtype=output_dtype),
+                indices,
+                indptr,
+            ),
+            shape=(n_rows, n_cols),
+            dtype=output_dtype,
+        )
+        rb.print_timing("tv csr_wrap", t_csr)
+        return matrix, fallback_documents
+
+    def fit(self, raw_documents, y=None):
+        matrix, fallback_documents = self._fit_transform_with_rust(raw_documents)
+        if matrix is not None:
+            return self
+        self._invalidate_rust_model()
+        return super().fit(fallback_documents, y)
+
+    def fit_transform(self, raw_documents, y=None):
+        t_total = rb.start_timing()
+        matrix, fallback_documents = self._fit_transform_with_rust(raw_documents)
+        if matrix is not None:
+            rb.print_timing("tv fit_transform total", t_total)
+            return matrix
+        self._invalidate_rust_model()
+        return super().fit_transform(fallback_documents, y)
+
+    def transform(self, raw_documents):
+        check_is_fitted(self, msg="The TF-IDF vectorizer is not fitted")
+
+        model = getattr(self, "_rust_tfidf_model_", None)
+        if model is not None and not _fitted_state_matches_native_snapshot(self):
+            self._invalidate_rust_model()
+            model = None
+        supported = True
+        reason = ""
+        if model is not None:
+            supported, reason = _rust_supported_subset(self)
+            if not supported:
+                logger.debug("TfidfVectorizer Rust fallback: %s", reason)
+        if (
+            model is None
+            or not self._rust_enabled()
+            or not supported
+            or _transform_signature(self) != getattr(self, "_rust_transform_signature_", None)
+        ):
+            return super().transform(raw_documents)
+
+        t_total = rb.start_timing()
+        t_mat = rb.start_timing()
+        documents, fallback_documents = _prepare_documents(
+            raw_documents, self.encoding, self.decode_error
+        )
+        rb.print_timing("tv py_materialize", t_mat)
+        if documents is None:
+            return super().transform(fallback_documents)
+        t_ascii = rb.start_timing()
+        non_ascii = not _documents_are_ascii(documents)
+        rb.print_timing("tv ascii_prescan", t_ascii)
+        if not documents:
+            return super().transform(fallback_documents)
+        if non_ascii:
+            return super().transform(fallback_documents)
+
+        try:
+            data, indices, indptr, n_rows, n_cols = rb.tfidf_vectorizer_transform(
+                model, documents
+            )
+        except rb.TfidfVectorizerFallback:
+            return super().transform(fallback_documents)
+
+        output_dtype = np.dtype(self.dtype)
+        t_csr = rb.start_timing()
+        matrix = sp.csr_matrix(
+            (np.asarray(data, dtype=output_dtype), indices, indptr),
+            shape=(n_rows, n_cols),
+            dtype=output_dtype,
+        )
+        rb.print_timing("tv csr_wrap", t_csr)
+        rb.print_timing("tv transform total", t_total)
+        return matrix
+
+    @property
+    def idf_(self):
+        return _TV.idf_.fget(self)
+
+    @idf_.setter
+    def idf_(self, value):
+        _TV.idf_.fset(self, value)
+        self._invalidate_rust_model()
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        # PyO3 handles aren't picklable; sklearn state alone is enough to restore.
+        state["_rust_tfidf_model_"] = None
+        state.pop("_rust_vocabulary_snapshot_", None)
+        state.pop("_rust_idf_snapshot_", None)
+        return state

--- a/stratum/patching/_patching.py
+++ b/stratum/patching/_patching.py
@@ -3,6 +3,10 @@
 Rust estimator implementations are registered with the physical operator
 registry. They are no longer installed by replacing upstream skrub or sklearn
 classes at import time.
+
+TfidfVectorizer is an exception: it is a sklearn class used directly by
+skrub (e.g. StringEncoder) and by user pipelines, so we still swap in the
+Rusty adapter at import time.
 """
 from __future__ import annotations
 
@@ -11,6 +15,7 @@ import threading
 from types import ModuleType
 from typing import Dict, Tuple, List
 
+from stratum.adapters.tfidf_vectorizer import RustyTfidfVectorizer
 from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSearch
 
 # ------------------------
@@ -18,6 +23,7 @@ from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSear
 # ------------------------
 # Definition: (module, symbol) -> adapter
 _DEFINITION_REPLACEMENTS: Dict[Tuple[str, str], object] = {
+    ("sklearn.feature_extraction.text", "TfidfVectorizer"): RustyTfidfVectorizer,
 }
 
 # Method-level replacements (for methods on classes)
@@ -29,11 +35,13 @@ _METHOD_REPLACEMENTS: Dict[Tuple[str, str, str], object] = {
 # Replace/override names in these upstream usage modules if present.
 # Keep this list manually maintained. Add to it if skrub adds new direct imports.
 _USAGE_MODULES: List[str] = [
+    "skrub._string_encoder",  # imports TfidfVectorizer directly
 ]
 
 # Symbol-level overrides for usage modules and top-level exposure on `skrub`
 # (symbol name) -> adapter
 _SYMBOL_OVERRIDES: Dict[str, object] = {
+    "TfidfVectorizer": RustyTfidfVectorizer,
 }
 
 # Idempotence sentinel + lock

--- a/stratum/tests/adapters/test_rust_backend.py
+++ b/stratum/tests/adapters/test_rust_backend.py
@@ -346,3 +346,51 @@ class TestToList:
         result = _rust_backend._to_list(series)
         assert result == [1, 2, 3, 4, 5]
 
+    def test_to_list_falls_back_when_tolist_raises(self):
+        """Prefer to_list when tolist exists but fails."""
+        from stratum import _rust_backend
+
+        class TolistFails:
+            def tolist(self):
+                raise RuntimeError("tolist failed")
+
+            def to_list(self):
+                return ["via", "to_list"]
+
+            def __iter__(self):
+                raise AssertionError("list() iteration should not run")
+
+        assert _rust_backend._to_list(TolistFails()) == ["via", "to_list"]
+
+    def test_to_list_ignores_non_list_helper_results(self):
+        """Invalid scalar helper results preserve normal iteration errors."""
+        from stratum import _rust_backend
+
+        class ScalarTolist:
+            def tolist(self):
+                return "not a materialized document collection"
+
+            def to_list(self):
+                return 42
+
+            def __iter__(self):
+                raise TypeError("source is not iterable")
+
+        with pytest.raises(TypeError, match="source is not iterable"):
+            _rust_backend._to_list(ScalarTolist())
+
+    def test_to_list_falls_back_to_list_when_both_helpers_raise(self):
+        """Fall through to list() when tolist and to_list both fail."""
+        from stratum import _rust_backend
+
+        class BothFail:
+            def tolist(self):
+                raise RuntimeError("tolist failed")
+
+            def to_list(self):
+                raise RuntimeError("to_list failed")
+
+            def __iter__(self):
+                return iter(("a", "b"))
+
+        assert _rust_backend._to_list(BothFail()) == ["a", "b"]

--- a/stratum/tests/adapters/test_tfidf_vectorizer.py
+++ b/stratum/tests/adapters/test_tfidf_vectorizer.py
@@ -1,0 +1,1412 @@
+import os
+
+os.environ.setdefault("SKRUB_RUST", "1")  # opt-in fastpath before any imports
+
+import pickle
+import warnings
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import stratum
+from stratum import _rust_backend as rb
+from stratum.adapters.tfidf_vectorizer import (
+    RustyTfidfVectorizer,
+    _TV as SklearnTfidfVectorizer,
+    _fitted_state_matches_native_snapshot,
+    _materialize_documents,
+    _prepare_documents,
+    _rust_supported_subset,
+    _valid_document_frequency,
+)
+
+
+pytestmark = pytest.mark.skipif(not rb.HAVE_RUST, reason="Rust backend not built")
+
+_DOCUMENTS = [
+    "The quick brown fox jumps over the lazy dog",
+    "the Lazy dog, the CAT!!!",
+    "",
+    "foo a b cc dd foo foo",
+    "Hello, WORLD! hello.",
+    "unicode cafe test cafe",
+    "a",
+    "123 45 6 seven_eight under_score",
+]
+
+_TRANSFORM_DOCUMENTS = ["foo lazy dog", "unknown only", "CAFE cafe", "a"]
+
+
+def _fit_rust(documents, **params):
+    vectorizer = RustyTfidfVectorizer(**params)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        matrix = vectorizer.fit_transform(documents).tocsr()
+    return vectorizer, matrix
+
+
+def _fit_sklearn(documents, **params):
+    vectorizer = SklearnTfidfVectorizer(**params)
+    return vectorizer, vectorizer.fit_transform(documents).tocsr()
+
+
+def _assert_sparse_close(got, expected, *, atol=2e-12):
+    assert sp.isspmatrix_csr(got)
+    assert sp.isspmatrix_csr(expected)
+    assert got.shape == expected.shape
+    assert got.dtype == expected.dtype
+    assert got.indices.dtype == expected.indices.dtype
+    assert got.indptr.dtype == expected.indptr.dtype
+    np.testing.assert_array_equal(got.indices, expected.indices)
+    np.testing.assert_array_equal(got.indptr, expected.indptr)
+    np.testing.assert_allclose(got.data, expected.data, rtol=0, atol=atol)
+
+
+def _assert_matching_exceptions(expected_error, got_error):
+    assert type(got_error.value) is type(expected_error.value)
+    assert str(got_error.value).replace(
+        "RustyTfidfVectorizer", "TfidfVectorizer"
+    ) == str(expected_error.value)
+
+
+def _assert_vectorizers_match(documents=_DOCUMENTS, **params):
+    expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+    tolerance = 2e-6 if np.dtype(params.get("dtype", np.float64)) == np.float32 else 2e-12
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    assert np.array_equal(
+        got_vectorizer.get_feature_names_out(),
+        expected_vectorizer.get_feature_names_out(),
+    )
+    _assert_sparse_close(got, expected, atol=tolerance)
+    if params.get("use_idf", True):
+        np.testing.assert_allclose(
+            got_vectorizer.idf_, expected_vectorizer.idf_, atol=tolerance, rtol=tolerance
+        )
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got_vectorizer.transform(_TRANSFORM_DOCUMENTS).tocsr()
+    expected_transformed = expected_vectorizer.transform(_TRANSFORM_DOCUMENTS).tocsr()
+    _assert_sparse_close(transformed, expected_transformed, atol=tolerance)
+    return got_vectorizer
+
+
+def test_default_configuration_matches_sklearn():
+    vectorizer = _assert_vectorizers_match()
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize(
+    ("documents", "params"),
+    [
+        (["one two three four"], {}),
+        (["two one three"], {"ngram_range": (1, 2)}),
+        (
+            ["zebra apple", "zebra banana apple"],
+            {"min_df": 2},
+        ),
+        (
+            [
+                "zebra banana zebra zebra zebra",
+                "banana banana apple",
+                "apple carrot",
+            ],
+            {"max_features": 2},
+        ),
+    ],
+)
+def test_learned_fit_transform_matches_sklearn_csr_layout(documents, params):
+    _, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+
+    assert not expected.has_sorted_indices
+    _assert_sparse_close(got, expected)
+    assert got.has_sorted_indices == expected.has_sorted_indices
+    assert got.has_canonical_format == expected.has_canonical_format
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"norm": None, "use_idf": False},
+        {"norm": "l1"},
+        {"binary": True},
+        {"smooth_idf": False},
+        {"sublinear_tf": True},
+        {"binary": True, "sublinear_tf": True, "norm": None},
+        {"dtype": np.float32},
+    ],
+)
+def test_weighting_parameter_grid_matches_sklearn(params):
+    vectorizer = _assert_vectorizers_match(**params)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_float32_high_count_and_idf_stress_matches_with_explicit_tolerance():
+    documents = [
+        " ".join(["common"] * 10_000 + ["rare"]),
+        *(f"common filler{index}" for index in range(1, 128)),
+    ]
+    params = {
+        "dtype": np.float32,
+        "norm": "l2",
+        "sublinear_tf": True,
+    }
+    expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+    tolerance = 2e-6
+
+    assert got.dtype == expected.dtype == np.dtype(np.float32)
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected, atol=tolerance)
+    np.testing.assert_allclose(
+        got_vectorizer.idf_,
+        expected_vectorizer.idf_,
+        atol=tolerance,
+        rtol=tolerance,
+    )
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize("ngram_range", [(1, 2), (2, 3), (1, 3)])
+def test_word_ngram_ranges_match_sklearn(ngram_range):
+    vectorizer = _assert_vectorizers_match(ngram_range=ngram_range)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_large_word_ngram_upper_bound_matches_sklearn():
+    documents = ["one token", "token"]
+    ngram_range = (1, 1_000_000)
+    expected_vectorizer, expected = _fit_sklearn(
+        documents, ngram_range=ngram_range
+    )
+    got_vectorizer, got = _fit_rust(documents, ngram_range=ngram_range)
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected)
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"ngram_range": (1, 2**128)},
+        {"max_features": 2**128},
+    ],
+)
+def test_oversized_native_integer_falls_back_and_matches_sklearn(params):
+    documents = ["one token", "token"]
+    expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected)
+    assert got_vectorizer._rust_tfidf_model_ is None
+
+
+def test_lowercase_false_and_bytes_match_sklearn():
+    documents = [b"Hello WORLD", "hello world", b"CAFE cafe"]
+    vectorizer = _assert_vectorizers_match(documents, lowercase=False)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize("lowercase", [True, False])
+@pytest.mark.parametrize("ngram_range", [(1, 1), (1, 2), (2, 3)])
+@pytest.mark.parametrize("as_generator", [False, True])
+def test_non_ascii_fit_falls_back_and_matches_sklearn(
+    lowercase, ngram_range, as_generator
+):
+    documents = [
+        "plain ascii text",
+        "café déjà vu",
+        "שָׁלוֹם עולם",
+        "اَلْعَرَبِيَّة العربية",
+        "A\u0345B",
+        "中文 混合 English",
+    ]
+    expected_vectorizer, expected = _fit_sklearn(
+        documents, lowercase=lowercase, ngram_range=ngram_range
+    )
+    raw_documents = (document for document in documents) if as_generator else documents
+    got_vectorizer, got = _fit_rust(
+        raw_documents, lowercase=lowercase, ngram_range=ngram_range
+    )
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    assert np.array_equal(
+        got_vectorizer.get_feature_names_out(),
+        expected_vectorizer.get_feature_names_out(),
+    )
+    _assert_sparse_close(got, expected)
+    np.testing.assert_allclose(got_vectorizer.idf_, expected_vectorizer.idf_)
+    assert got_vectorizer._rust_tfidf_model_ is None
+
+
+@pytest.mark.parametrize("as_generator", [False, True])
+def test_non_ascii_fixed_vocabulary_fit_falls_back_and_matches_sklearn(as_generator):
+    documents = ["plain cafe", "café déjà vu", "A\u0345B"]
+    vocabulary = {"plain": 0, "café": 1, "vu": 2, "ab": 3, "unseen": 4}
+    expected_vectorizer, expected = _fit_sklearn(documents, vocabulary=vocabulary)
+    raw_documents = (document for document in documents) if as_generator else documents
+    got_vectorizer, got = _fit_rust(raw_documents, vocabulary=vocabulary)
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected)
+    np.testing.assert_allclose(got_vectorizer.idf_, expected_vectorizer.idf_)
+    assert got_vectorizer._rust_tfidf_model_ is None
+
+
+def test_non_ascii_transform_bypasses_native_binding_and_matches_sklearn(monkeypatch):
+    documents = ["apple banana", "banana carrot"]
+    expected = SklearnTfidfVectorizer().fit(documents)
+    got, _ = _fit_rust(documents)
+    assert got._rust_tfidf_model_ is not None
+
+    native_called = False
+    native_transform = rb.tfidf_vectorizer_transform
+
+    def recording_native_transform(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        return native_transform(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "tfidf_vectorizer_transform", recording_native_transform)
+    probes = (document for document in ["café déjà vu", "A\u0345B"])
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got.transform(probes).tocsr()
+
+    _assert_sparse_close(
+        transformed,
+        expected.transform(["café déjà vu", "A\u0345B"]).tocsr(),
+    )
+    assert not native_called
+    assert got._rust_tfidf_model_ is not None
+
+
+def test_native_boundary_rejects_non_ascii_fit_and_transform():
+    native_args = (
+        1,
+        1,
+        True,
+        False,
+        "l2",
+        True,
+        True,
+        False,
+        1.0,
+        2.0,
+        None,
+        None,
+    )
+    with pytest.raises(rb.TfidfVectorizerFallback, match="non-ASCII"):
+        rb.tfidf_vectorizer_fit(["plain ascii", "café"], *native_args)
+
+    model = rb.tfidf_vectorizer_fit(["plain ascii", "more text"], *native_args)[0]
+    with pytest.raises(rb.TfidfVectorizerFallback, match="non-ASCII"):
+        rb.tfidf_vectorizer_transform(model, ["café"])
+
+
+def test_native_boundary_rejects_duplicate_fixed_terms_without_panicking():
+    native_args = (
+        1,
+        1,
+        True,
+        False,
+        "l2",
+        True,
+        True,
+        False,
+        1.0,
+        1.0,
+        None,
+        ["duplicate", "duplicate"],
+    )
+    with pytest.raises(ValueError, match="Duplicate term in vocabulary"):
+        rb.tfidf_vectorizer_fit(["duplicate"], *native_args)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"min_df": 2},
+        {"min_df": 0.25},
+        {"max_df": 0.5},
+    ],
+)
+def test_document_frequency_pruning_matches_sklearn(params):
+    vectorizer = _assert_vectorizers_match(**params)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_max_features_uses_rust_when_boundary_is_unambiguous():
+    documents = [
+        "alpha alpha alpha alpha beta beta beta gamma gamma delta",
+        "alpha beta gamma epsilon",
+    ]
+    vectorizer = _assert_vectorizers_match(documents, max_features=3)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_float32_max_features_uses_rust_while_frequencies_are_exact():
+    documents = [
+        "alpha alpha alpha alpha beta beta beta gamma gamma delta",
+        "alpha beta gamma epsilon",
+    ]
+    vectorizer = _assert_vectorizers_match(
+        documents,
+        dtype=np.float32,
+        max_features=3,
+    )
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_tied_max_features_falls_back_for_numpy_exactness():
+    vectorizer = _assert_vectorizers_match(max_features=5)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+def test_tied_max_features_fallback_preserves_materialized_generator(
+    monkeypatch,
+):
+    expected = SklearnTfidfVectorizer(max_features=5).fit_transform(_DOCUMENTS).tocsr()
+    original_fit_transform = SklearnTfidfVectorizer.fit_transform
+    fallback_documents = None
+
+    def recording_fit_transform(self, raw_documents, y=None):
+        nonlocal fallback_documents
+        fallback_documents = raw_documents
+        return original_fit_transform(self, raw_documents, y)
+
+    monkeypatch.setattr(
+        SklearnTfidfVectorizer,
+        "fit_transform",
+        recording_fit_transform,
+    )
+    vectorizer = RustyTfidfVectorizer(max_features=5)
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        with stratum.config(rust_backend=True, allow_patch=True):
+            got = vectorizer.fit_transform(
+                document for document in _DOCUMENTS
+            ).tocsr()
+
+    _assert_sparse_close(got, expected)
+    assert fallback_documents == _DOCUMENTS
+    assert isinstance(fallback_documents, list)
+    assert vectorizer._rust_tfidf_model_ is None
+    assert not recorded
+
+
+@pytest.mark.parametrize(
+    "vocabulary",
+    [
+        {"dog": 0, "foo": 1, "unseen": 2},
+        ["dog", "foo", "unseen"],
+    ],
+)
+def test_fixed_vocabulary_matches_sklearn(vocabulary):
+    vectorizer = _assert_vectorizers_match(vocabulary=vocabulary)
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_fixed_vocabulary_mapping_preserves_insertion_order():
+    vocabulary = {"banana": 1, "apple": 0}
+    documents = ["apple banana"]
+
+    expected_vectorizer, _ = _fit_sklearn(documents, vocabulary=vocabulary)
+    got_vectorizer, _ = _fit_rust(documents, vocabulary=vocabulary)
+
+    assert list(got_vectorizer.vocabulary_.items()) == list(
+        expected_vectorizer.vocabulary_.items()
+    )
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+def test_learned_vocabulary_preserves_discovery_order():
+    documents = ["zebra apple", "banana zebra"]
+
+    expected_vectorizer, _ = _fit_sklearn(documents)
+    got_vectorizer, _ = _fit_rust(documents)
+
+    assert list(got_vectorizer.vocabulary_.items()) == list(
+        expected_vectorizer.vocabulary_.items()
+    )
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize("norm", ["l1", "l2", None])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("probe", ["seen", "unseen"])
+def test_nonfinite_fixed_vocabulary_idf_uses_safe_transform_path(
+    norm, dtype, probe
+):
+    documents = ["seen"]
+    params = {
+        "vocabulary": ["seen", "unseen"],
+        "smooth_idf": False,
+        "norm": norm,
+        "dtype": dtype,
+    }
+    with np.errstate(divide="ignore"):
+        expected_vectorizer, expected = _fit_sklearn(documents, **params)
+        got_vectorizer, got = _fit_rust(documents, **params)
+
+    _assert_sparse_close(got, expected)
+    np.testing.assert_allclose(
+        got_vectorizer.idf_,
+        expected_vectorizer.idf_,
+        rtol=0,
+        atol=0,
+    )
+
+    if norm is None:
+        assert got_vectorizer._rust_tfidf_model_ is not None
+        with np.errstate(invalid="ignore"):
+            expected_transformed = expected_vectorizer.transform([probe]).toarray()
+            with stratum.config(rust_backend=True, allow_patch=True):
+                got_transformed = got_vectorizer.transform([probe]).toarray()
+        np.testing.assert_allclose(
+            got_transformed,
+            expected_transformed,
+            rtol=0,
+            atol=0,
+        )
+    else:
+        assert got_vectorizer._rust_tfidf_model_ is None
+        try:
+            expected_transformed = expected_vectorizer.transform([probe]).tocsr()
+        except Exception as error:
+            expected_error = error
+        else:
+            expected_error = None
+
+        with stratum.config(rust_backend=True, allow_patch=True):
+            if expected_error is None:
+                got_transformed = got_vectorizer.transform([probe]).tocsr()
+                _assert_sparse_close(got_transformed, expected_transformed)
+            else:
+                with pytest.raises(type(expected_error)) as got_error:
+                    got_vectorizer.transform([probe])
+                assert str(got_error.value) == str(expected_error)
+
+
+def test_randomized_differential_includes_nonfinite_fixed_vocabulary_idf():
+    rng = np.random.default_rng(20260726)
+    vocabulary = ["seen", "unseen", *(f"term{index}" for index in range(12))]
+    documents = [
+        " ".join(rng.choice(vocabulary[2:], size=8, replace=True))
+        for _ in range(24)
+    ]
+    documents[0] += " seen"
+    params = {
+        "vocabulary": vocabulary,
+        "smooth_idf": False,
+        "norm": "l2",
+    }
+
+    with np.errstate(divide="ignore"):
+        expected_vectorizer, expected = _fit_sklearn(documents, **params)
+        got_vectorizer, got = _fit_rust(documents, **params)
+    _assert_sparse_close(got, expected)
+    np.testing.assert_allclose(got_vectorizer.idf_, expected_vectorizer.idf_)
+    assert got_vectorizer._rust_tfidf_model_ is None
+
+    probe = [" ".join(rng.choice(vocabulary, size=6, replace=True)) + " unseen"]
+    with pytest.raises(Exception) as expected_error:
+        expected_vectorizer.transform(probe)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            got_vectorizer.transform(probe)
+    _assert_matching_exceptions(expected_error, got_error)
+
+
+@pytest.mark.parametrize("use_idf", [False, True])
+def test_large_mostly_unseen_fixed_vocabulary_matches_sklearn(use_idf):
+    vocabulary = [f"term{index:05d}" for index in range(10_000)]
+    documents = [
+        "term00001 term00001 term05000",
+        "term05000 unknown",
+        "term09999",
+    ]
+    params = {
+        "vocabulary": vocabulary,
+        "use_idf": use_idf,
+        "norm": None,
+        "binary": False,
+        "sublinear_tf": True,
+    }
+    expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected)
+    if use_idf:
+        np.testing.assert_allclose(got_vectorizer.idf_, expected_vectorizer.idf_)
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+def test_fixed_vocabulary_above_dense_counter_limit_matches_sklearn():
+    # The Rust kernel switches from dense to sparse feature counting above
+    # 2**18 features. Exercise that selection through the public adapter.
+    vocabulary_size = (1 << 18) + 1
+    vocabulary = [f"term{index:06d}" for index in range(vocabulary_size)]
+    documents = [
+        "term000001 term000001 term131072 unknown",
+        "term131072 term262144",
+    ]
+    params = {
+        "vocabulary": vocabulary,
+        "use_idf": False,
+        "norm": None,
+    }
+
+    expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    got_vectorizer, got = _fit_rust(documents, **params)
+
+    _assert_sparse_close(got, expected)
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+    probes = ["term262144 term262144 term000001 unseen", ""]
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got_vectorizer.transform(probes).tocsr()
+    _assert_sparse_close(
+        transformed,
+        expected_vectorizer.transform(probes).tocsr(),
+    )
+
+
+def test_fit_then_transform_matches_sklearn():
+    expected = SklearnTfidfVectorizer().fit(_DOCUMENTS)
+    got = RustyTfidfVectorizer()
+    with stratum.config(rust_backend=True, allow_patch=True):
+        returned = got.fit((document for document in _DOCUMENTS))
+        transformed = got.transform(_TRANSFORM_DOCUMENTS).tocsr()
+
+    assert returned is got
+    assert got._rust_tfidf_model_ is not None
+    _assert_sparse_close(transformed, expected.transform(_TRANSFORM_DOCUMENTS).tocsr())
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"analyzer": "char"},
+        {"stop_words": "english"},
+        {"token_pattern": r"(?u)\b\w+\b"},
+        {"preprocessor": str.strip},
+        {"tokenizer": str.split},
+        {"strip_accents": "unicode"},
+        {"dtype": np.int32},
+    ],
+)
+def test_unsupported_configuration_falls_back(params):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        vectorizer = _assert_vectorizers_match(**params)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+def test_filename_input_falls_back_and_matches_sklearn(tmp_path):
+    paths = []
+    for index, document in enumerate(_DOCUMENTS):
+        path = tmp_path / f"document-{index}.txt"
+        path.write_text(document)
+        paths.append(path)
+
+    expected_vectorizer, expected = _fit_sklearn(paths, input="filename")
+    got_vectorizer, got = _fit_rust(paths, input="filename")
+
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    _assert_sparse_close(got, expected)
+    assert got_vectorizer._rust_tfidf_model_ is None
+
+
+def test_fit_after_configuration_fallback_matches_sklearn():
+    params = {"preprocessor": str.strip}
+    expected = SklearnTfidfVectorizer(**params).fit(_DOCUMENTS)
+    got = RustyTfidfVectorizer(**params)
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        returned = got.fit(document for document in _DOCUMENTS)
+        transformed = got.transform(_TRANSFORM_DOCUMENTS).tocsr()
+
+    assert returned is got
+    _assert_sparse_close(
+        transformed,
+        expected.transform(_TRANSFORM_DOCUMENTS).tocsr(),
+    )
+    assert got._rust_tfidf_model_ is None
+
+
+def test_disabled_backend_falls_back_to_sklearn():
+    vectorizer = RustyTfidfVectorizer()
+    with stratum.config(rust_backend=False, allow_patch=True):
+        got = vectorizer.fit_transform(_DOCUMENTS).tocsr()
+    expected = SklearnTfidfVectorizer().fit_transform(_DOCUMENTS).tocsr()
+    _assert_sparse_close(got, expected)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+def test_transform_before_fit_raises_sklearn_error():
+    with pytest.raises(Exception, match="not fitted"):
+        RustyTfidfVectorizer().transform(_DOCUMENTS)
+
+
+def test_empty_vocabulary_raises_sklearn_error_without_rust_warning():
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match="empty vocabulary"):
+            _fit_rust(["a", "b", ""])
+    assert not recorded
+
+
+def test_empty_documents_bypass_native_fit_and_raise_sklearn_error(monkeypatch):
+    native_called = False
+    native_fit = rb.tfidf_vectorizer_fit
+
+    def recording_native_fit(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        return native_fit(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "tfidf_vectorizer_fit", recording_native_fit)
+    with pytest.raises(
+        ValueError,
+        match="empty vocabulary; perhaps the documents only contain stop words",
+    ):
+        _fit_rust([])
+    assert not native_called
+
+
+@pytest.mark.parametrize(
+    "container",
+    ["list", "tuple", "generator", "numpy"],
+)
+def test_empty_transform_matches_sklearn_without_native_call(monkeypatch, container):
+    documents = ["one token"]
+    expected = SklearnTfidfVectorizer().fit(documents)
+    got, _ = _fit_rust(documents)
+    model = got._rust_tfidf_model_
+
+    def make_empty():
+        if container == "list":
+            return []
+        if container == "tuple":
+            return ()
+        if container == "generator":
+            return (document for document in ())
+        return np.array([], dtype=object)
+
+    native_called = False
+
+    def recording_native_transform(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        raise AssertionError("native transform must not receive an empty corpus")
+
+    monkeypatch.setattr(
+        rb,
+        "tfidf_vectorizer_transform",
+        recording_native_transform,
+    )
+    with pytest.raises(Exception) as expected_error:
+        expected.transform(make_empty())
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            got.transform(make_empty())
+
+    _assert_matching_exceptions(expected_error, got_error)
+    assert not native_called
+    assert got._rust_tfidf_model_ is model
+
+
+@pytest.mark.parametrize(
+    "documents",
+    [
+        [],
+        [None],
+        [np.nan],
+        ["valid", 42],
+    ],
+)
+@pytest.mark.parametrize("as_generator", [False, True])
+def test_invalid_documents_match_sklearn_exception(documents, as_generator):
+    expected_documents = (
+        (document for document in documents) if as_generator else documents
+    )
+    got_documents = (
+        (document for document in documents) if as_generator else documents
+    )
+
+    with pytest.raises(Exception) as expected_error:
+        SklearnTfidfVectorizer().fit_transform(expected_documents)
+    vectorizer = RustyTfidfVectorizer()
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            vectorizer.fit_transform(got_documents)
+
+    assert type(got_error.value) is type(expected_error.value)
+    assert str(got_error.value).replace(
+        "RustyTfidfVectorizer", "TfidfVectorizer"
+    ) == str(expected_error.value)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+@pytest.mark.parametrize("method", ["fit_transform", "transform"])
+def test_zero_dimensional_numpy_input_matches_sklearn_exception(method):
+    expected = SklearnTfidfVectorizer()
+    got = RustyTfidfVectorizer()
+    if method == "transform":
+        expected.fit(_DOCUMENTS)
+        with stratum.config(rust_backend=True, allow_patch=True):
+            got.fit(_DOCUMENTS)
+
+    raw_documents = np.array("hello world")
+    with pytest.raises(Exception) as expected_error:
+        getattr(expected, method)(raw_documents)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            getattr(got, method)(raw_documents)
+
+    _assert_matching_exceptions(expected_error, got_error)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"binary": 1},
+        {"lowercase": 1},
+        {"ngram_range": (1.0, 2.0)},
+        {"max_features": 1.5},
+        {"min_df": np.nan},
+        {"max_df": np.inf},
+        {"norm": "invalid"},
+        {"encoding": None},
+        {"encoding": 123},
+        {"decode_error": None},
+        {"decode_error": 123},
+        {"decode_error": "bogus"},
+    ],
+)
+@pytest.mark.parametrize("method", ["fit", "fit_transform"])
+def test_invalid_parameter_types_match_sklearn_exception(params, method):
+    documents = ["valid text", "other text"]
+    with pytest.raises(Exception) as expected_error:
+        getattr(SklearnTfidfVectorizer(**params), method)(documents)
+
+    vectorizer = RustyTfidfVectorizer(**params)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            getattr(vectorizer, method)(documents)
+
+    assert type(got_error.value) is type(expected_error.value)
+    assert str(got_error.value).replace(
+        "RustyTfidfVectorizer", "TfidfVectorizer"
+    ) == str(expected_error.value)
+    assert getattr(vectorizer, "_rust_tfidf_model_", None) is None
+
+
+@pytest.mark.parametrize(
+    "vocabulary",
+    [
+        {1: 0, "one": 1},
+        [1, "one"],
+    ],
+)
+def test_non_string_fixed_vocabulary_falls_back_to_sklearn(vocabulary):
+    documents = ["one token"]
+    with pytest.raises(Exception) as expected_error:
+        SklearnTfidfVectorizer(vocabulary=vocabulary).fit_transform(documents)
+
+    vectorizer = RustyTfidfVectorizer(vocabulary=vocabulary)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            vectorizer.fit_transform(documents)
+
+    _assert_matching_exceptions(expected_error, got_error)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+def test_fixed_vocabulary_uppercase_warning_matches_sklearn():
+    documents = ["apple"]
+    params = {"vocabulary": ["Apple", "apple"]}
+
+    with warnings.catch_warnings(record=True) as expected_warnings:
+        warnings.simplefilter("always")
+        expected_vectorizer, expected = _fit_sklearn(documents, **params)
+    with warnings.catch_warnings(record=True) as got_warnings:
+        warnings.simplefilter("always")
+        got_vectorizer, got = _fit_rust(documents, **params)
+
+    assert [(warning.category, str(warning.message)) for warning in got_warnings] == [
+        (warning.category, str(warning.message)) for warning in expected_warnings
+    ]
+    _assert_sparse_close(got, expected)
+    assert got_vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+    assert got_vectorizer._rust_tfidf_model_ is not None
+
+
+def test_max_df_below_min_df_matches_sklearn_exception():
+    documents = ["one token", "other token"]
+    params = {"min_df": 2, "max_df": 0.5}
+
+    with pytest.raises(Exception) as expected_error:
+        SklearnTfidfVectorizer(**params).fit_transform(documents)
+    vectorizer = RustyTfidfVectorizer(**params)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            vectorizer.fit_transform(documents)
+
+    _assert_matching_exceptions(expected_error, got_error)
+
+
+@pytest.mark.parametrize("error_type", [MemoryError, RuntimeError])
+def test_unexpected_native_fit_error_propagates_without_sklearn_retry(
+    monkeypatch, error_type
+):
+    sklearn_called = False
+    original_fit_transform = SklearnTfidfVectorizer.fit_transform
+
+    def failing_native_fit(*args, **kwargs):
+        raise error_type("native fit failed")
+
+    def recording_sklearn_fit_transform(self, raw_documents, y=None):
+        nonlocal sklearn_called
+        sklearn_called = True
+        return original_fit_transform(self, raw_documents, y)
+
+    monkeypatch.setattr(rb, "tfidf_vectorizer_fit", failing_native_fit)
+    monkeypatch.setattr(
+        SklearnTfidfVectorizer,
+        "fit_transform",
+        recording_sklearn_fit_transform,
+    )
+
+    with pytest.raises(error_type, match="native fit failed"):
+        _fit_rust(["apple banana", "banana carrot"])
+    assert not sklearn_called
+
+
+@pytest.mark.parametrize("error_type", [MemoryError, RuntimeError])
+def test_unexpected_native_transform_error_propagates_without_sklearn_retry(
+    monkeypatch, error_type
+):
+    vectorizer, _ = _fit_rust(["apple banana", "banana carrot"])
+    sklearn_called = False
+    original_transform = SklearnTfidfVectorizer.transform
+
+    def failing_native_transform(*args, **kwargs):
+        raise error_type("native transform failed")
+
+    def recording_sklearn_transform(self, raw_documents):
+        nonlocal sklearn_called
+        sklearn_called = True
+        return original_transform(self, raw_documents)
+
+    monkeypatch.setattr(rb, "tfidf_vectorizer_transform", failing_native_transform)
+    monkeypatch.setattr(
+        SklearnTfidfVectorizer,
+        "transform",
+        recording_sklearn_transform,
+    )
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(error_type, match="native transform failed"):
+            vectorizer.transform(["apple"])
+    assert not sklearn_called
+
+
+def test_native_transform_fallback_exception_delegates_to_sklearn(monkeypatch):
+    documents = ["apple banana", "banana carrot"]
+    probe = ["apple carrot"]
+    expected = SklearnTfidfVectorizer().fit(documents)
+    got, _ = _fit_rust(documents)
+
+    def unsupported_native_transform(*args, **kwargs):
+        raise rb.TfidfVectorizerFallback("use sklearn")
+
+    monkeypatch.setattr(
+        rb,
+        "tfidf_vectorizer_transform",
+        unsupported_native_transform,
+    )
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got.transform(probe).tocsr()
+
+    _assert_sparse_close(transformed, expected.transform(probe).tocsr())
+    assert got._rust_tfidf_model_ is not None
+
+
+@pytest.mark.parametrize(
+    ("fit_dtype", "transform_dtype"),
+    [
+        (np.float64, np.float32),
+        (np.float32, np.float64),
+        (np.float64, np.int32),
+        (np.float64, np.bool_),
+        (np.float64, np.longdouble),
+        (np.float64, np.complex128),
+        (np.float64, ("i4", (-1,))),
+    ],
+)
+def test_transform_dtype_mutation_bypasses_native_and_matches_sklearn(
+    monkeypatch, fit_dtype, transform_dtype
+):
+    # On Windows and macOS, longdouble is an alias of float64, so mutating
+    # dtype to longdouble is a no-op for np.dtype() and the native path is
+    # correctly kept.
+    try:
+        dtypes_equal = np.dtype(fit_dtype) == np.dtype(transform_dtype)
+    except (TypeError, ValueError):
+        dtypes_equal = False
+    if dtypes_equal:
+        pytest.skip(
+            f"{fit_dtype!r} and {transform_dtype!r} normalize to the same dtype"
+        )
+
+    documents = ["apple apple banana", "banana carrot"]
+    probe = ["apple banana"]
+    expected = SklearnTfidfVectorizer(dtype=fit_dtype).fit(documents)
+    got = RustyTfidfVectorizer(dtype=fit_dtype)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        got.fit(documents)
+    model = got._rust_tfidf_model_
+
+    expected.dtype = transform_dtype
+    got.dtype = transform_dtype
+    native_called = False
+
+    def unexpected_native_transform(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        raise AssertionError("a changed dtype must use sklearn")
+
+    monkeypatch.setattr(
+        rb,
+        "tfidf_vectorizer_transform",
+        unexpected_native_transform,
+    )
+
+    try:
+        expected_transformed = expected.transform(probe).tocsr()
+    except Exception as error:
+        expected_error = error
+    else:
+        expected_error = None
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        if expected_error is None:
+            got_transformed = got.transform(probe).tocsr()
+            _assert_sparse_close(got_transformed, expected_transformed)
+        else:
+            with pytest.raises(type(expected_error)) as got_error:
+                got.transform(probe)
+            assert str(got_error.value) == str(expected_error)
+
+    assert not native_called
+    assert got._rust_tfidf_model_ is model
+
+
+@pytest.mark.parametrize("container", ["list", "generator", "string"])
+def test_invalid_transform_input_matches_sklearn_without_native_call(
+    monkeypatch, container
+):
+    documents = ["apple banana", "banana carrot"]
+    expected = SklearnTfidfVectorizer().fit(documents)
+    got, _ = _fit_rust(documents)
+    model = got._rust_tfidf_model_
+
+    def make_invalid():
+        if container == "list":
+            return [None]
+        if container == "generator":
+            return (document for document in [None])
+        return "not a document collection"
+
+    native_called = False
+
+    def recording_native_transform(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        raise AssertionError("invalid objects must be validated by sklearn")
+
+    monkeypatch.setattr(
+        rb,
+        "tfidf_vectorizer_transform",
+        recording_native_transform,
+    )
+    with pytest.raises(Exception) as expected_error:
+        expected.transform(make_invalid())
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as got_error:
+            got.transform(make_invalid())
+
+    _assert_matching_exceptions(expected_error, got_error)
+    assert not native_called
+    assert got._rust_tfidf_model_ is model
+
+
+def test_pickle_round_trip_retains_correct_sklearn_fallback():
+    vectorizer, _ = _fit_rust(_DOCUMENTS)
+    state = vectorizer.__getstate__()
+    assert "_rust_vocabulary_snapshot_" not in state
+    assert "_rust_idf_snapshot_" not in state
+    restored = pickle.loads(pickle.dumps(vectorizer))
+    assert restored._rust_tfidf_model_ is None
+    _assert_sparse_close(
+        restored.transform(_TRANSFORM_DOCUMENTS).tocsr(),
+        vectorizer.transform(_TRANSFORM_DOCUMENTS).tocsr(),
+    )
+
+
+def test_assigning_idf_invalidates_native_model():
+    vectorizer, _ = _fit_rust(_DOCUMENTS)
+    vectorizer.idf_ = np.ones_like(vectorizer.idf_)
+    assert vectorizer._rust_tfidf_model_ is None
+
+
+@pytest.mark.parametrize("mutation", ["slice", "alias", "ufunc"])
+def test_in_place_idf_mutation_invalidates_native_model_and_matches_sklearn(mutation):
+    documents = ["apple apple banana", "banana carrot"]
+    expected = SklearnTfidfVectorizer(norm=None).fit(documents)
+    got, _ = _fit_rust(documents, norm=None)
+    assert got._rust_tfidf_model_ is not None
+
+    if mutation == "slice":
+        expected.idf_[:] = 1.0
+        got.idf_[:] = 1.0
+    elif mutation == "alias":
+        expected_idf = expected.idf_
+        got_idf = got.idf_
+        expected_idf[0] = 1.0
+        got_idf[0] = 1.0
+    else:
+        np.add(expected.idf_, 1.0, out=expected.idf_)
+        np.add(got.idf_, 1.0, out=got.idf_)
+
+    probe = ["apple banana"]
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got.transform(probe).tocsr()
+    _assert_sparse_close(transformed, expected.transform(probe).tocsr())
+    assert got._rust_tfidf_model_ is None
+
+
+def test_in_place_vocabulary_mutation_invalidates_native_model_and_matches_sklearn():
+    documents = ["apple banana", "banana carrot"]
+    expected = SklearnTfidfVectorizer(norm=None, use_idf=False).fit(documents)
+    got, _ = _fit_rust(documents, norm=None, use_idf=False)
+    assert got._rust_tfidf_model_ is not None
+
+    for vectorizer in (expected, got):
+        vocabulary = vectorizer.vocabulary_
+        vocabulary["apple"], vocabulary["banana"] = (
+            vocabulary["banana"],
+            vocabulary["apple"],
+        )
+
+    probe = ["apple"]
+    with stratum.config(rust_backend=True, allow_patch=True):
+        transformed = got.transform(probe).tocsr()
+    _assert_sparse_close(transformed, expected.transform(probe).tocsr())
+    assert got._rust_tfidf_model_ is None
+
+
+def test_unmodified_fitted_state_continues_using_native_transform(monkeypatch):
+    vectorizer, _ = _fit_rust(_DOCUMENTS)
+    native_transform = rb.tfidf_vectorizer_transform
+    call_count = 0
+
+    def recording_native_transform(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return native_transform(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "tfidf_vectorizer_transform", recording_native_transform)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        first = vectorizer.transform(_TRANSFORM_DOCUMENTS).tocsr()
+        second = vectorizer.transform(_TRANSFORM_DOCUMENTS).tocsr()
+
+    _assert_sparse_close(first, second)
+    assert call_count == 2
+    assert vectorizer._rust_tfidf_model_ is not None
+
+
+def test_refit_after_fitted_state_mutation_restores_native_model():
+    documents = ["apple apple banana", "banana carrot"]
+    expected = SklearnTfidfVectorizer(norm=None).fit(documents)
+    got, _ = _fit_rust(documents, norm=None)
+    got.idf_[:] = 1.0
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        got.transform(["apple"])
+        assert got._rust_tfidf_model_ is None
+        returned = got.fit(documents)
+        transformed = got.transform(["apple banana"]).tocsr()
+
+    assert returned is got
+    assert got._rust_tfidf_model_ is not None
+    _assert_sparse_close(
+        transformed,
+        expected.transform(["apple banana"]).tocsr(),
+    )
+
+
+def test_supported_subset_gate():
+    assert _rust_supported_subset(RustyTfidfVectorizer())[0]
+    supported, reason = _rust_supported_subset(RustyTfidfVectorizer(analyzer="char"))
+    assert not supported
+    assert "analyzer" in reason
+    supported, reason = _rust_supported_subset(
+        RustyTfidfVectorizer(lowercase=np.bool_(True))
+    )
+    assert not supported
+    assert "non-bool lowercase" in reason
+    assert issubclass(rb.TfidfVectorizerFallback, Exception)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, True),
+        (0.5, True),
+        (True, False),
+        (False, False),
+        (np.bool_(True), False),
+        ("x", False),
+        (None, False),
+        (object(), False),
+    ],
+)
+def test_valid_document_frequency_rejects_non_numeric_and_bool(value, expected):
+    assert _valid_document_frequency(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("params", "reason_fragment"),
+    [
+        ({"min_df": True}, "invalid min_df"),
+        ({"max_df": False}, "invalid max_df"),
+        ({"min_df": "x"}, "invalid min_df"),
+        ({"ngram_range": (2, 1)}, "invalid ngram_range"),
+        ({"ngram_range": (0, 1)}, "invalid ngram_range"),
+    ],
+)
+def test_invalid_df_and_ngram_gates_fall_back(params, reason_fragment):
+    supported, reason = _rust_supported_subset(RustyTfidfVectorizer(**params))
+    assert not supported
+    assert reason_fragment in reason
+
+    documents = ["one two", "two three"]
+    expected_vectorizer = SklearnTfidfVectorizer(**params)
+    try:
+        expected = expected_vectorizer.fit_transform(documents).tocsr()
+    except Exception as error:
+        expected_error = error
+        expected = None
+    else:
+        expected_error = None
+
+    vectorizer = RustyTfidfVectorizer(**params)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        if expected_error is None:
+            got = vectorizer.fit_transform(documents).tocsr()
+            _assert_sparse_close(got, expected)
+            assert vectorizer.vocabulary_ == expected_vectorizer.vocabulary_
+        else:
+            with pytest.raises(type(expected_error)) as got_error:
+                vectorizer.fit_transform(documents)
+            assert type(got_error.value) is type(expected_error)
+            assert str(got_error.value).replace(
+                "RustyTfidfVectorizer", "TfidfVectorizer"
+            ) == str(expected_error)
+    assert getattr(vectorizer, "_rust_tfidf_model_", None) is None
+
+
+def test_fitted_state_snapshot_defensive_paths():
+    class RaisingEq:
+        def __eq__(self, other):
+            raise TypeError("cannot compare vocabulary")
+
+        def __bool__(self):
+            return True
+
+    class BrokenAsArray:
+        def __array__(self, dtype=None, copy=None):
+            raise ValueError("cannot convert idf")
+
+    vectorizer = RustyTfidfVectorizer()
+    vectorizer.vocabulary_ = RaisingEq()
+    vectorizer._rust_vocabulary_snapshot_ = {"a": 0}
+    assert _fitted_state_matches_native_snapshot(vectorizer) is False
+
+    vectorizer = RustyTfidfVectorizer()
+    vectorizer.use_idf = True
+    vectorizer.vocabulary_ = {"a": 0}
+    vectorizer._rust_vocabulary_snapshot_ = {"a": 0}
+    vectorizer._tfidf = type("T", (), {})()
+    vectorizer._rust_idf_snapshot_ = np.ones(1)
+    assert _fitted_state_matches_native_snapshot(vectorizer) is False
+
+    vectorizer._tfidf = type("T", (), {"idf_": BrokenAsArray()})()
+    assert _fitted_state_matches_native_snapshot(vectorizer) is False
+
+
+def test_unsupported_gate_is_logged(caplog):
+    vectorizer = RustyTfidfVectorizer(analyzer="char")
+    with (
+        caplog.at_level("DEBUG", logger="stratum.adapters.tfidf_vectorizer"),
+        stratum.config(rust_backend=True, allow_patch=True),
+    ):
+        vectorizer.fit_transform(["alpha beta"])
+    assert "TfidfVectorizer Rust fallback" in caplog.text
+    assert "analyzer" in caplog.text
+
+
+def test_sklearn_symbol_is_patched():
+    import sklearn.feature_extraction.text as text
+
+    assert text.TfidfVectorizer is RustyTfidfVectorizer
+    assert stratum.TfidfVectorizer is RustyTfidfVectorizer
+
+
+class TestMaterializeDocuments:
+    def test_list_is_returned_as_is(self):
+        documents = ["a", "b"]
+        assert _materialize_documents(documents) is documents
+
+    def test_tuple_and_generator(self):
+        assert _materialize_documents(("a", "b")) == ["a", "b"]
+        assert _materialize_documents(document for document in ("a", "b")) == ["a", "b"]
+
+    def test_empty_input(self):
+        assert _materialize_documents([]) == []
+        assert _materialize_documents(()) == []
+
+    def test_pandas_series(self):
+        pd = pytest.importorskip("pandas")
+        series = pd.Series(["foo", "bar", "baz"])
+        assert _materialize_documents(series) == ["foo", "bar", "baz"]
+
+    def test_numpy_object_and_string_array(self):
+        object_array = np.array(["foo", "bar"], dtype=object)
+        assert _materialize_documents(object_array) == ["foo", "bar"]
+        string_array = np.array(["foo", "bar"])
+        assert _materialize_documents(string_array) == ["foo", "bar"]
+
+    def test_polars_series(self):
+        pl = pytest.importorskip("polars")
+        series = pl.Series(["foo", "bar", "baz"])
+        assert _materialize_documents(series) == ["foo", "bar", "baz"]
+
+
+class TestPrepareDocuments:
+    def test_string_input_forces_sklearn_fallback(self):
+        assert _prepare_documents("not a corpus", "utf-8", "strict") == (
+            None,
+            "not a corpus",
+        )
+
+    def test_all_string_list_reuses_same_object(self):
+        documents = ["hello", "world"]
+        rust_docs, fallback = _prepare_documents(documents, "utf-8", "strict")
+        assert rust_docs is documents
+        assert fallback is documents
+        assert rust_docs is fallback
+
+    def test_empty_list_reuses_same_object(self):
+        documents = []
+        rust_docs, fallback = _prepare_documents(documents, "utf-8", "strict")
+        assert rust_docs is documents
+        assert fallback is documents
+
+    def test_tuple_of_strings(self):
+        rust_docs, fallback = _prepare_documents(("a", "b"), "utf-8", "strict")
+        assert rust_docs == ["a", "b"]
+        assert rust_docs is fallback
+
+    def test_bytes_are_decoded_lazily(self):
+        documents = ["hello", b"world", "again"]
+        rust_docs, fallback = _prepare_documents(documents, "utf-8", "strict")
+        assert rust_docs == ["hello", "world", "again"]
+        assert fallback is documents
+        assert rust_docs is not fallback
+        assert fallback[1] == b"world"
+
+    def test_mixed_string_bytes_encoding_and_decode_error(self):
+        documents = [b"caf\xe9", "plain"]
+        rust_docs, fallback = _prepare_documents(documents, "latin-1", "strict")
+        assert rust_docs == ["café", "plain"]
+        assert fallback is documents
+
+        replaced, _ = _prepare_documents([b"\xff"], "utf-8", "replace")
+        assert replaced == ["\ufffd"]
+
+        ignored, _ = _prepare_documents([b"a\xffb"], "utf-8", "ignore")
+        assert ignored == ["ab"]
+
+    def test_invalid_object_falls_back_with_original_values(self):
+        documents = ["ok", 123, "also"]
+        rust_docs, fallback = _prepare_documents(documents, "utf-8", "strict")
+        assert rust_docs is None
+        assert fallback is documents
+        assert fallback[1] == 123
+
+    def test_missing_values_fall_back(self):
+        pd = pytest.importorskip("pandas")
+        series = pd.Series(["ok", None, "also"])
+        rust_docs, fallback = _prepare_documents(series, "utf-8", "strict")
+        assert rust_docs is None
+        assert fallback[0] == "ok"
+        assert fallback[1] is None or (isinstance(fallback[1], float) and np.isnan(fallback[1]))
+
+    def test_consumed_generator_preserves_fallback_values(self):
+        generator = (document for document in ("alpha", "beta", b"gamma"))
+        rust_docs, fallback = _prepare_documents(generator, "utf-8", "strict")
+        assert rust_docs == ["alpha", "beta", "gamma"]
+        assert fallback == ["alpha", "beta", b"gamma"]
+        assert list(generator) == []
+
+    def test_invalid_in_generator_preserves_materialized_fallback(self):
+        generator = (document for document in ("alpha", object(), "beta"))
+        rust_docs, fallback = _prepare_documents(generator, "utf-8", "strict")
+        assert rust_docs is None
+        assert fallback[0] == "alpha"
+        assert not isinstance(fallback[1], (str, bytes))
+
+    def test_pandas_series_all_strings(self):
+        pd = pytest.importorskip("pandas")
+        series = pd.Series(["foo", "bar"])
+        rust_docs, fallback = _prepare_documents(series, "utf-8", "strict")
+        assert rust_docs == ["foo", "bar"]
+        assert rust_docs is fallback
+
+    def test_numpy_object_array(self):
+        array = np.array(["foo", "bar"], dtype=object)
+        rust_docs, fallback = _prepare_documents(array, "utf-8", "strict")
+        assert rust_docs == ["foo", "bar"]
+        assert rust_docs is fallback
+
+    def test_polars_series_all_strings(self):
+        pl = pytest.importorskip("polars")
+        series = pl.Series(["foo", "bar"])
+        rust_docs, fallback = _prepare_documents(series, "utf-8", "strict")
+        assert rust_docs == ["foo", "bar"]
+        assert rust_docs is fallback
+
+
+def test_fit_transform_accepts_pandas_series():
+    pd = pytest.importorskip("pandas")
+    series = pd.Series(_DOCUMENTS)
+    _assert_vectorizers_match(series)
+
+
+def test_fit_transform_accepts_generator():
+    vectorizer = RustyTfidfVectorizer()
+    with stratum.config(rust_backend=True, allow_patch=True):
+        matrix = vectorizer.fit_transform(document for document in _DOCUMENTS).tocsr()
+    expected = SklearnTfidfVectorizer().fit_transform(_DOCUMENTS).tocsr()
+    _assert_sparse_close(matrix, expected)
+    assert vectorizer._rust_tfidf_model_ is not None


### PR DESCRIPTION
  - Reimplement sklearn's TfidfVectorizer in Rust: chunked two-pass vocabulary learning (DF/TF stats, then CSR emit), fixed- vocabulary fits, IDF / binary / sublinear_tf weighting, and L1/L2 normalization.
  - Learned fits preserve sklearn's discovery-order CSR layout; max_features ties that would depend on NumPy's unstable sort fall back instead of guessing.
  - Wire it through RustyTfidfVectorizer with a narrow supported subset (default token pattern, ASCII content, float32/float64) and keep sklearn for everything else — Unicode, custom analyzers, mutated fitted state, pickle, and ambiguous max_features.
  - Patch the sklearn and skrub symbols; cover parity and fallbacks on both sides.

## Supported params (Rust Kernel)
  Requires defaults for `input="content"`, `analyzer="word"`, `token_pattern`, and `stop_words` / `preprocessor` / `tokenizer` / `strip_accents` all `None`. Documents must be 
  ASCII `str`/`bytes` (`encoding` / `decode_error` used for bytes).

  Supported: `lowercase`, `ngram_range`, `min_df`, `max_df`, `max_features` (TF tie on the cutoff → sklearn fallback; NumPy sort order is unstable), `vocabulary` (learned or fixed string terms), `binary`, `dtype` in `{float32, 
  float64}`, `norm` in `{None, "l1", "l2"}`, `use_idf`, `smooth_idf`, `sublinear_tf` (bool flags must be plain `bool`).
  ## Sklearn fallbacks
  `input` in `{filename, file}`, non-default analyzer/token pattern, stop words / custom hooks / accent stripping, Unicode docs, non-float dtypes, ambiguous `max_features`, 
  mutated fitted state, pickle.