### PR TITLE
[HashingVectorizer] Add Rust-backed hashing vectorizer

### DIFF
--- a/_rust/src/hashing.rs
+++ b/_rust/src/hashing.rs
@@ -6,3 +6,175 @@ pub fn bucket_id(token: &str, n_features: usize) -> usize {
     token.hash(&mut hasher);
     (hasher.finish() as usize) % n_features
 }
+
+// ---------------------------------------------------------------------------
+// MurmurHash3 (x86_32) — bit-exact port of the canonical Austin Appleby
+// implementation that scikit-learn vendors in `src/MurmurHash3.cpp` and calls
+// via `murmurhash3_bytes_s32`. Matching this exactly is what lets the Rust
+// HashingVectorizer produce the *same* buckets/signs as sklearn's FeatureHasher.
+// ---------------------------------------------------------------------------
+
+#[inline(always)]
+fn rotl32(x: u32, r: u32) -> u32 {
+    x.rotate_left(r)
+}
+
+#[inline(always)]
+fn fmix32(mut h: u32) -> u32 {
+    h ^= h >> 16;
+    h = h.wrapping_mul(0x85eb_ca6b);
+    h ^= h >> 13;
+    h = h.wrapping_mul(0xc2b2_ae35);
+    h ^= h >> 16;
+    h
+}
+
+#[inline]
+fn ascii_byte<const LOWERCASE: bool>(byte: u8) -> u8 {
+    if LOWERCASE {
+        byte.to_ascii_lowercase()
+    } else {
+        byte
+    }
+}
+
+/// MurmurHash3_x86_32 over `data` with `seed` (little-endian block reads).
+///
+/// The const-generic lowercase variant hashes as though the ASCII input had
+/// first been copied through `to_ascii_lowercase`, without that allocation.
+#[inline]
+fn murmurhash3_x86_32_impl<const LOWERCASE: bool>(data: &[u8], seed: u32) -> u32 {
+    let len = data.len();
+    let nblocks = len / 4;
+    let mut h1 = seed;
+    const C1: u32 = 0xcc9e_2d51;
+    const C2: u32 = 0x1b87_3593;
+
+    // body — process 4-byte blocks
+    for i in 0..nblocks {
+        let j = i * 4;
+        let mut k1 = u32::from_le_bytes([
+            ascii_byte::<LOWERCASE>(data[j]),
+            ascii_byte::<LOWERCASE>(data[j + 1]),
+            ascii_byte::<LOWERCASE>(data[j + 2]),
+            ascii_byte::<LOWERCASE>(data[j + 3]),
+        ]);
+        k1 = k1.wrapping_mul(C1);
+        k1 = rotl32(k1, 15);
+        k1 = k1.wrapping_mul(C2);
+        h1 ^= k1;
+        h1 = rotl32(h1, 13);
+        h1 = h1.wrapping_mul(5).wrapping_add(0xe654_6b64);
+    }
+
+    // tail — remaining 1..=3 bytes
+    let tail = &data[nblocks * 4..];
+    let mut k1: u32 = 0;
+    match len & 3 {
+        3 => {
+            k1 ^= (ascii_byte::<LOWERCASE>(tail[2]) as u32) << 16;
+            k1 ^= (ascii_byte::<LOWERCASE>(tail[1]) as u32) << 8;
+            k1 ^= ascii_byte::<LOWERCASE>(tail[0]) as u32;
+            k1 = k1.wrapping_mul(C1);
+            k1 = rotl32(k1, 15);
+            k1 = k1.wrapping_mul(C2);
+            h1 ^= k1;
+        }
+        2 => {
+            k1 ^= (ascii_byte::<LOWERCASE>(tail[1]) as u32) << 8;
+            k1 ^= ascii_byte::<LOWERCASE>(tail[0]) as u32;
+            k1 = k1.wrapping_mul(C1);
+            k1 = rotl32(k1, 15);
+            k1 = k1.wrapping_mul(C2);
+            h1 ^= k1;
+        }
+        1 => {
+            k1 ^= ascii_byte::<LOWERCASE>(tail[0]) as u32;
+            k1 = k1.wrapping_mul(C1);
+            k1 = rotl32(k1, 15);
+            k1 = k1.wrapping_mul(C2);
+            h1 ^= k1;
+        }
+        _ => {}
+    }
+
+    // finalization
+    h1 ^= len as u32;
+    fmix32(h1)
+}
+
+#[inline]
+pub fn murmurhash3_x86_32(data: &[u8], seed: u32) -> u32 {
+    murmurhash3_x86_32_impl::<false>(data, seed)
+}
+
+/// sklearn's `murmurhash3_bytes_s32(key, seed)` — the 32-bit hash reinterpreted
+/// as a signed int32. The sign bit drives `alternate_sign` in FeatureHasher.
+#[inline]
+pub fn murmurhash3_bytes_s32(data: &[u8], seed: u32) -> i32 {
+    murmurhash3_x86_32(data, seed) as i32
+}
+
+/// Map a token to a (bucket, sign) pair exactly as sklearn's FeatureHasher does:
+/// `index = abs(h) % n_features`, `sign = +1 if h >= 0 else -1`.
+///
+/// sklearn handles `h == i32::MIN` as a magnitude of `2^31` before taking the
+/// modulo. Widening to `i64` makes that absolute value well-defined and matches
+/// sklearn for every valid `n_features`.
+#[inline]
+pub fn signed_bucket(token: &[u8], n_features: usize, alternate_sign: bool) -> (i32, i8) {
+    debug_assert!(n_features <= i32::MAX as usize);
+    signed_bucket_from_hash(murmurhash3_bytes_s32(token, 0), n_features, alternate_sign)
+}
+
+/// [`signed_bucket`] after virtual ASCII lowercasing, avoiding a temporary
+/// lowercase string for mixed-case documents.
+#[inline]
+pub fn signed_bucket_ascii_lowercase(
+    token: &[u8],
+    n_features: usize,
+    alternate_sign: bool,
+) -> (i32, i8) {
+    debug_assert!(token.is_ascii());
+    debug_assert!(n_features <= i32::MAX as usize);
+    signed_bucket_from_hash(
+        murmurhash3_x86_32_impl::<true>(token, 0) as i32,
+        n_features,
+        alternate_sign,
+    )
+}
+
+#[inline]
+fn signed_bucket_from_hash(h: i32, n_features: usize, alternate_sign: bool) -> (i32, i8) {
+    let index = ((h as i64).unsigned_abs() as usize % n_features) as i32;
+    let sign = if alternate_sign && h < 0 { -1 } else { 1 };
+    (index, sign)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference values from scikit-learn:
+    //   from sklearn.utils.murmurhash import murmurhash3_bytes_s32
+    //   murmurhash3_bytes_s32(b"...", 0)
+    #[test]
+    fn murmur_matches_sklearn_reference() {
+        assert_eq!(murmurhash3_bytes_s32(b"", 0), 0);
+        assert_eq!(murmurhash3_bytes_s32(b"hello", 0), 613153351);
+        assert_eq!(murmurhash3_bytes_s32(b"foo", 0), -156908512);
+        assert_eq!(murmurhash3_bytes_s32(b"the", 0), -1132748958);
+        assert_eq!(murmurhash3_bytes_s32(b"quick", 0), 771291085);
+    }
+
+    #[test]
+    fn virtual_ascii_lowercase_matches_allocated_lowercase() {
+        for token in [b"hello".as_slice(), b"HELLO", b"MiXeD123", b"under_SCORE"] {
+            let lowered = token.to_ascii_lowercase();
+            assert_eq!(
+                signed_bucket_ascii_lowercase(token, 1 << 20, true),
+                signed_bucket(&lowered, 1 << 20, true),
+            );
+        }
+    }
+}

--- a/_rust/src/hashing_vectorizer.rs
+++ b/_rust/src/hashing_vectorizer.rs
@@ -1,0 +1,500 @@
+//! sklearn `HashingVectorizer` (word analyzer) — the stateless hashing trick.
+//!
+//! Documents are processed in parallel chunks. Each chunk reuses a compact
+//! `(bucket, sign)` scratch vector across rows, sorts and reduces collisions,
+//! and emits one flat CSR block. The blocks are then concatenated into the
+//! final CSR arrays without per-row maps or copies.
+
+use ahash::AHashMap as HashMap;
+use rayon::prelude::*;
+
+use crate::hashing::{signed_bucket, signed_bucket_ascii_lowercase};
+use crate::threads::get_thread_pool;
+#[cfg(test)]
+use crate::tokenize::word_tokens;
+use crate::tokenize::{for_each_word_ngram, for_each_word_token_ascii, word_tokens_ascii};
+
+/// Target number of chunks per Rayon worker.
+const CHUNKS_PER_THREAD: usize = 4;
+/// Avoid tiny chunks on small corpora where Rayon and merge overhead dominate.
+const CHUNK_DOCS_MIN: usize = 1000;
+/// Compact sort/reduce wins for ordinary text rows. Beyond this point, switch
+/// to a sparse map so very long documents or broad n-gram ranges cannot retain
+/// memory proportional to every generated term.
+const COMPACT_FEATURE_LIMIT: usize = 256;
+
+/// Row-wise normalization matching sklearn `HashingVectorizer.norm`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Norm {
+    None,
+    L1,
+    L2,
+}
+
+/// Options mirroring the sklearn parameters we support on the fast path.
+#[derive(Debug)]
+pub struct HashingOptions {
+    pub n_features: usize,
+    pub nmin: usize,
+    pub nmax: usize,
+    pub binary: bool,
+    pub alternate_sign: bool,
+    pub lowercase: bool,
+    pub norm: Norm,
+}
+
+/// Flat CSR block for one document chunk. `indptr` is local and starts at zero.
+struct CsrChunk {
+    data: Vec<f64>,
+    indices: Vec<i32>,
+    indptr: Vec<i64>,
+}
+
+/// Reusable scratch for compact bucket accumulation and canonical ordering.
+struct ChunkScratch {
+    compact_features: Vec<(i32, i8)>,
+    sparse_counts: HashMap<i32, i64>,
+    sparse_features: Vec<(i32, i64)>,
+    sparse_mode: bool,
+}
+
+impl ChunkScratch {
+    fn new() -> Self {
+        Self {
+            compact_features: Vec::new(),
+            sparse_counts: HashMap::new(),
+            sparse_features: Vec::new(),
+            sparse_mode: false,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.compact_features.clear();
+        self.sparse_counts.clear();
+        self.sparse_features.clear();
+        self.sparse_mode = false;
+    }
+
+    #[inline]
+    fn add(&mut self, feature: (i32, i8)) {
+        if !self.sparse_mode && self.compact_features.len() < COMPACT_FEATURE_LIMIT {
+            self.compact_features.push(feature);
+            return;
+        }
+
+        if !self.sparse_mode {
+            for (column, sign) in self.compact_features.drain(..) {
+                *self.sparse_counts.entry(column).or_insert(0) += i64::from(sign);
+            }
+            self.sparse_mode = true;
+        }
+        *self.sparse_counts.entry(feature.0).or_insert(0) += i64::from(feature.1);
+    }
+}
+
+/// Transform `documents` into CSR parts `(data, indices, indptr)` of shape
+/// `(documents.len(), n_features)`.
+///
+/// `AsRef<str>` lets the PyO3 boundary pass `PyBackedStr` values, so the kernel
+/// reads Python's UTF-8 buffers directly instead of copying every document into
+/// an owned Rust `String`.
+pub fn transform<S: AsRef<str> + Sync>(
+    documents: &[S],
+    options: &HashingOptions,
+) -> (Vec<f64>, Vec<i32>, Vec<i64>) {
+    debug_assert!(
+        documents
+            .iter()
+            .all(|document| document.as_ref().is_ascii()),
+        "the HashingVectorizer word kernel requires ASCII documents",
+    );
+    let t0 = crate::util::start_timing();
+    let chunks = map_document_chunks(documents, |chunk| transform_chunk(chunk, options));
+    crate::util::print_timing("hv map_chunks", t0);
+
+    let t1 = crate::util::start_timing();
+    let out = assemble_chunks(chunks, documents.len());
+    crate::util::print_timing("hv assemble_csr", t1);
+    out
+}
+
+/// Target a few tasks per worker for load balance, but avoid over-parallelizing
+/// small corpora into chunks below [`CHUNK_DOCS_MIN`].
+fn target_chunk_count(n_docs: usize) -> usize {
+    if n_docs == 0 {
+        return 0;
+    }
+    let by_threads = worker_threads().max(1).saturating_mul(CHUNKS_PER_THREAD);
+    let by_min_docs = (n_docs / CHUNK_DOCS_MIN).max(1);
+    by_threads.min(by_min_docs).min(n_docs).max(1)
+}
+
+/// Documents per chunk from [`target_chunk_count`], never larger than
+/// `n_docs`.
+fn chunk_size(n_docs: usize) -> usize {
+    if n_docs == 0 {
+        return 1;
+    }
+    n_docs.div_ceil(target_chunk_count(n_docs)).max(1)
+}
+
+fn worker_threads() -> usize {
+    match get_thread_pool() {
+        Some(pool) => pool.current_num_threads(),
+        None => rayon::current_num_threads(),
+    }
+}
+
+fn map_document_chunks<S, T, F>(documents: &[S], map: F) -> Vec<T>
+where
+    S: Sync,
+    T: Send,
+    F: Fn(&[S]) -> T + Sync + Send,
+{
+    if documents.is_empty() {
+        return Vec::new();
+    }
+    let size = chunk_size(documents.len());
+    let run = || documents.par_chunks(size).map(&map).collect();
+    match get_thread_pool() {
+        Some(pool) => pool.install(run),
+        None => run(),
+    }
+}
+
+fn transform_chunk<S: AsRef<str>>(documents: &[S], options: &HashingOptions) -> CsrChunk {
+    let mut scratch = ChunkScratch::new();
+    let mut data = Vec::new();
+    let mut indices = Vec::new();
+    let mut indptr = Vec::with_capacity(documents.len() + 1);
+    indptr.push(0);
+
+    for document in documents {
+        transform_document_into(
+            document.as_ref(),
+            options,
+            &mut scratch,
+            &mut data,
+            &mut indices,
+        );
+        indptr.push(indices.len() as i64);
+    }
+
+    CsrChunk {
+        data,
+        indices,
+        indptr,
+    }
+}
+
+fn transform_document_into(
+    document: &str,
+    options: &HashingOptions,
+    scratch: &mut ChunkScratch,
+    data: &mut Vec<f64>,
+    indices: &mut Vec<i32>,
+) {
+    scratch.clear();
+    accumulate_document(document, options, scratch);
+
+    let row_start = data.len();
+    if scratch.sparse_mode {
+        scratch
+            .sparse_features
+            .extend(scratch.sparse_counts.drain());
+        scratch
+            .sparse_features
+            .sort_unstable_by_key(|&(column, _)| column);
+        for &(column, value) in &scratch.sparse_features {
+            indices.push(column);
+            data.push(if options.binary { 1.0 } else { value as f64 });
+        }
+    } else {
+        scratch
+            .compact_features
+            .sort_unstable_by_key(|&(column, _)| column);
+        let mut offset = 0;
+        while offset < scratch.compact_features.len() {
+            let column = scratch.compact_features[offset].0;
+            let mut value = 0i64;
+            while offset < scratch.compact_features.len()
+                && scratch.compact_features[offset].0 == column
+            {
+                value += i64::from(scratch.compact_features[offset].1);
+                offset += 1;
+            }
+            indices.push(column);
+            data.push(if options.binary { 1.0 } else { value as f64 });
+        }
+    }
+
+    normalize(&mut data[row_start..], options.norm);
+}
+
+fn accumulate_document(document: &str, options: &HashingOptions, scratch: &mut ChunkScratch) {
+    debug_assert!(document.is_ascii());
+    accumulate_ascii_text(document, options, &mut |feature| scratch.add(feature));
+}
+
+#[cfg(test)]
+fn accumulate_text(text: &str, options: &HashingOptions, features: &mut Vec<(i32, i8)>) {
+    let mut tokens = Vec::with_capacity(16);
+    word_tokens(text, &mut tokens);
+    for_each_word_ngram(&tokens, options.nmin, options.nmax, |ngram| {
+        features.push(signed_bucket(
+            ngram.as_bytes(),
+            options.n_features,
+            options.alternate_sign,
+        ));
+    });
+}
+
+fn accumulate_ascii_text<F>(text: &str, options: &HashingOptions, add_feature: &mut F)
+where
+    F: FnMut((i32, i8)),
+{
+    debug_assert!(text.is_ascii());
+
+    let mut hash_term = |term: &str| {
+        let feature = if options.lowercase {
+            signed_bucket_ascii_lowercase(
+                term.as_bytes(),
+                options.n_features,
+                options.alternate_sign,
+            )
+        } else {
+            signed_bucket(term.as_bytes(), options.n_features, options.alternate_sign)
+        };
+        add_feature(feature);
+    };
+
+    if options.nmin == 1 && options.nmax == 1 {
+        for_each_word_token_ascii(text, &mut hash_term);
+        return;
+    }
+
+    let mut tokens = Vec::with_capacity(16);
+    word_tokens_ascii(text, &mut tokens);
+    for_each_word_ngram(&tokens, options.nmin, options.nmax, hash_term);
+}
+
+fn normalize(data: &mut [f64], norm: Norm) {
+    let denominator = match norm {
+        Norm::None => return,
+        Norm::L1 => data.iter().map(|value| value.abs()).sum(),
+        Norm::L2 => data.iter().map(|value| value * value).sum::<f64>().sqrt(),
+    };
+    if denominator > 0.0 {
+        for value in data {
+            *value /= denominator;
+        }
+    }
+}
+
+fn assemble_chunks(chunks: Vec<CsrChunk>, document_count: usize) -> (Vec<f64>, Vec<i32>, Vec<i64>) {
+    let nonzero_count = chunks.iter().map(|chunk| chunk.indices.len()).sum();
+    let mut data = Vec::with_capacity(nonzero_count);
+    let mut indices = Vec::with_capacity(nonzero_count);
+    let mut indptr = Vec::with_capacity(document_count + 1);
+    indptr.push(0);
+
+    let mut nonzero_offset = 0i64;
+    for chunk in chunks {
+        for &local_end in &chunk.indptr[1..] {
+            indptr.push(nonzero_offset + local_end);
+        }
+        nonzero_offset += chunk.indices.len() as i64;
+        data.extend(chunk.data);
+        indices.extend(chunk.indices);
+    }
+
+    debug_assert_eq!(indptr.len(), document_count + 1);
+    (data, indices, indptr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_default(n_features: usize) -> HashingOptions {
+        HashingOptions {
+            n_features,
+            nmin: 1,
+            nmax: 1,
+            binary: false,
+            alternate_sign: true,
+            lowercase: true,
+            norm: Norm::L2,
+        }
+    }
+
+    /// Reference implementation of the original per-document code path.
+    fn transform_reference(
+        documents: &[String],
+        options: &HashingOptions,
+    ) -> (Vec<f64>, Vec<i32>, Vec<i64>) {
+        let mut data = Vec::new();
+        let mut indices = Vec::new();
+        let mut indptr = vec![0];
+
+        for document in documents {
+            let lowered;
+            let text = if options.lowercase {
+                lowered = document.to_lowercase();
+                lowered.as_str()
+            } else {
+                document.as_str()
+            };
+
+            let mut features = Vec::new();
+            accumulate_text(text, options, &mut features);
+            features.sort_unstable_by_key(|&(column, _)| column);
+
+            let row_start = data.len();
+            let mut offset = 0;
+            while offset < features.len() {
+                let column = features[offset].0;
+                let mut value = 0i64;
+                while offset < features.len() && features[offset].0 == column {
+                    value += i64::from(features[offset].1);
+                    offset += 1;
+                }
+                indices.push(column);
+                data.push(if options.binary { 1.0 } else { value as f64 });
+            }
+            normalize(&mut data[row_start..], options.norm);
+            indptr.push(indices.len() as i64);
+        }
+        (data, indices, indptr)
+    }
+
+    fn assert_matches_reference(documents: &[String], options: &HashingOptions) {
+        let got = transform(documents, options);
+        let expected = transform_reference(documents, options);
+        assert_eq!(got.0, expected.0);
+        assert_eq!(got.1, expected.1);
+        assert_eq!(got.2, expected.2);
+    }
+
+    #[test]
+    fn empty_docs_produce_empty_rows() {
+        let documents = vec![String::new(), "a".to_owned()];
+        let (data, indices, indptr) = transform(&documents, &opts_default(1 << 10));
+        assert_eq!(indptr, vec![0, 0, 0]);
+        assert!(data.is_empty());
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn rows_are_l2_normalized() {
+        let documents = vec!["the quick brown fox".to_owned()];
+        let (data, _indices, indptr) = transform(&documents, &opts_default(1 << 18));
+        assert_eq!(indptr.len(), 2);
+        let norm = data.iter().map(|value| value * value).sum::<f64>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-9, "row norm = {norm}");
+    }
+
+    #[test]
+    fn rows_are_l1_normalized() {
+        let documents = vec!["the quick brown fox".to_owned()];
+        let options = HashingOptions {
+            norm: Norm::L1,
+            ..opts_default(1 << 18)
+        };
+        let (data, _indices, indptr) = transform(&documents, &options);
+        assert_eq!(indptr.len(), 2);
+        let norm = data.iter().map(|value| value.abs()).sum::<f64>();
+        assert!((norm - 1.0).abs() < 1e-9, "row l1 norm = {norm}");
+    }
+
+    #[test]
+    fn lowercase_folds_case() {
+        let options = opts_default(1 << 18);
+        let lower = transform(&["hello world"], &options);
+        let upper = transform(&["HELLO WORLD"], &options);
+        assert_eq!(lower.1, upper.1);
+    }
+
+    #[test]
+    fn optimized_lowercasing_matches_reference() {
+        let documents = [
+            "the quick brown fox",
+            "The Quick BROWN Fox",
+            "HELLO, WORLD! hello.",
+            "MIXED123 under_score X_Y a b cc",
+            "",
+            "a",
+        ]
+        .map(str::to_owned);
+
+        for &(nmin, nmax) in &[(1, 1), (1, 2), (2, 3)] {
+            for &binary in &[false, true] {
+                for &alternate_sign in &[false, true] {
+                    for &norm in &[Norm::None, Norm::L1, Norm::L2] {
+                        let options = HashingOptions {
+                            n_features: 1 << 16,
+                            nmin,
+                            nmax,
+                            binary,
+                            alternate_sign,
+                            lowercase: true,
+                            norm,
+                        };
+                        assert_matches_reference(&documents, &options);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn chunk_boundaries_preserve_rows() {
+        let documents: Vec<String> = (0..(CHUNK_DOCS_MIN * 3 + 17))
+            .map(|row| format!("document number {row} repeated repeated"))
+            .collect();
+        let options = HashingOptions {
+            nmin: 1,
+            nmax: 2,
+            ..opts_default(1 << 18)
+        };
+        assert_matches_reference(&documents, &options);
+    }
+
+    #[test]
+    fn long_ngram_rows_use_sparse_accumulation() {
+        let document = (0..300)
+            .map(|index| format!("token{index}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let options = HashingOptions {
+            n_features: 1 << 12,
+            nmin: 1,
+            nmax: 3,
+            ..opts_default(1 << 12)
+        };
+        assert_matches_reference(&[document], &options);
+    }
+
+    #[test]
+    fn chunk_count_respects_threads_and_min_docs() {
+        assert_eq!(target_chunk_count(0), 0);
+        assert_eq!(chunk_size(0), 1);
+        assert_eq!(chunk_size(1), 1);
+        assert_eq!(target_chunk_count(1), 1);
+        assert_eq!(target_chunk_count(CHUNK_DOCS_MIN - 1), 1);
+        assert_eq!(chunk_size(CHUNK_DOCS_MIN - 1), CHUNK_DOCS_MIN - 1);
+
+        let by_threads = worker_threads().max(1) * CHUNKS_PER_THREAD;
+        assert_eq!(
+            target_chunk_count(10_000),
+            by_threads.min(10_000 / CHUNK_DOCS_MIN),
+        );
+        assert_eq!(
+            target_chunk_count(1_000_000),
+            by_threads.min(1_000_000 / CHUNK_DOCS_MIN),
+        );
+        assert!(chunk_size(100_000) >= CHUNK_DOCS_MIN);
+        assert!(target_chunk_count(100) <= 100);
+        assert!(chunk_size(100) * target_chunk_count(100) >= 100);
+    }
+}

--- a/_rust/src/lib.rs
+++ b/_rust/src/lib.rs
@@ -1,24 +1,26 @@
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use crate::threads::get_thread_pool;
+use crate::util::{print_timing, start_timing};
 use ndarray::{Array2, Axis};
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyAny, PyIterator, PyList, PyModule};
-use pyo3::{PyErr, exceptions::PyValueError};
+use pyo3::{exceptions::PyValueError, PyErr};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rayon::prelude::*;
-use crate::threads::{get_thread_pool};
-use crate::util::{start_timing, print_timing};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-mod tokenize;   //n-gram extraction for char/char_wb
-mod hashing;    //stable fast hashing to [0, n_features)
-mod tfidf;      //DF counting, IDF vector, TF*IDF, per-row L2 norm
 mod csr;
-mod fd;         //Frequent Directions
-mod truncated_svd;  //TruncatedSVD using randomized SVD
-mod util;
-mod threads;
+mod fd; //Frequent Directions
+mod hashing; //stable fast hashing to [0, n_features) + MurmurHash3 (sklearn-exact)
+mod hashing_vectorizer; //sklearn HashingVectorizer (word analyzer, stateless hashing trick)
 mod one_hot_encoder;
+mod tfidf; //DF counting, IDF vector, TF*IDF, per-row L2 norm
+mod threads;
+mod tokenize; //n-gram extraction for char/char_wb + word tokenizer
+mod truncated_svd; //TruncatedSVD using randomized SVD
+mod util;
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex};
 
@@ -28,6 +30,7 @@ use std::sync::{Arc, Mutex};
 // ---- Global registry for models (TODO: Return pointer to Python) ----
 static TFIDF_MODELS: Lazy<Mutex<Vec<tfidf::TfidfModel>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
+#[allow(dead_code)]
 struct TruncatedSvdModel {
     n_cols: usize,
     k: usize,
@@ -36,8 +39,10 @@ struct TruncatedSvdModel {
     singular_values: Vec<f32>,
 }
 static TSVD_NEXT_ID: AtomicU64 = AtomicU64::new(1);
-static TSVD_MODELS: Lazy<Mutex<HashMap<u64, TruncatedSvdModel>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static TSVD_MODELS: Lazy<Mutex<HashMap<u64, TruncatedSvdModel>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
+#[allow(dead_code)]
 struct FdEmbedModel {
     n_cols: usize,
     k: usize,
@@ -47,10 +52,11 @@ struct FdEmbedModel {
     // Random matrix Ω: (n_cols × m) stored column-major for efficient CSR matmul
     // omega[j * m + t] = Ω[j, t]
     omega: Arc<Vec<f32>>,
-    m: usize,  // m = k + oversample, width of reduced space
+    m: usize, // m = k + oversample, width of reduced space
 }
 static FD_EMBED_NEXT_ID: AtomicU64 = AtomicU64::new(1);
-static FD_EMBED_MODELS: Lazy<Mutex<HashMap<u64, FdEmbedModel>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static FD_EMBED_MODELS: Lazy<Mutex<HashMap<u64, FdEmbedModel>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 // Simple mapping from domain error to PyErr
 fn to_pyerr(err: tfidf::Error) -> PyErr {
@@ -58,7 +64,7 @@ fn to_pyerr(err: tfidf::Error) -> PyErr {
     let msg = match err {
         InvalidAnalyzer => "Invalid analyzer".to_string(),
         InvalidNgramRange => "Invalid ngram_range".to_string(),
-        Internal => "Internal error".to_string()
+        Internal => "Internal error".to_string(),
     };
     PyErr::new::<PyValueError, _>(msg)
 }
@@ -66,6 +72,7 @@ fn to_pyerr(err: tfidf::Error) -> PyErr {
 // Helper: CSR × Omega matmul: X @ Ω -> Y
 // Omega is stored column-major: omega[j * m + t] = Ω[j, t]
 // Result Y is (n_rows × m)
+#[allow(clippy::too_many_arguments, unused_variables)]
 fn csr_matmul_omega(
     data: &[f32],
     indices: &[i32],
@@ -102,9 +109,17 @@ fn csr_matmul_omega(
     y
 }
 
-fn compute_fd_embed(data: &[f32], indices: &[i32], indptr: &[i64],
-    n_rows: usize, n_cols: usize, k: usize, oversample: usize, seed: Option<u64>) -> Result<Array2<f32>, PyErr>
-{
+#[allow(clippy::too_many_arguments)]
+fn compute_fd_embed(
+    data: &[f32],
+    indices: &[i32],
+    indptr: &[i64],
+    n_rows: usize,
+    n_cols: usize,
+    k: usize,
+    oversample: usize,
+    seed: Option<u64>,
+) -> Result<Array2<f32>, PyErr> {
     // Step 2: Gather the parameters
     let out_w = k + oversample; //k+p
     let s = seed.unwrap_or(0xC0FFEE); //I love coffee :)
@@ -137,7 +152,7 @@ fn compute_fd_embed(data: &[f32], indices: &[i32], indptr: &[i64],
             .enumerate()
             .for_each(|(row, mut yrow)| {
                 let start = indptr[row] as usize;
-                let end   = indptr[row + 1] as usize;
+                let end = indptr[row + 1] as usize;
                 for t in 0..out_w {
                     let mut acc = 0.0f32;
                     for p in start..end {
@@ -151,7 +166,7 @@ fn compute_fd_embed(data: &[f32], indices: &[i32], indptr: &[i64],
     };
     match pool {
         Some(p) => p.install(build_y), //use custom threadpool
-        None => build_y() //use global threadpool
+        None => build_y(),             //use global threadpool
     }
     print_timing("build y", t0);
 
@@ -165,10 +180,18 @@ fn compute_fd_embed(data: &[f32], indices: &[i32], indptr: &[i64],
 
 #[pyfunction]
 #[pyo3(signature = (data, indices, indptr, n_rows, n_cols, k, oversample=16, seed=None))]
-fn fd_embed_from_csr(py: Python<'_>, data: Bound<PyArray1<f32>>, indices: Bound<PyArray1<i32>>,
-    indptr: Bound<PyArray1<i64>>, n_rows: usize, n_cols: usize, k: usize,
-    oversample: usize, seed: Option<u64>) -> PyResult<Py<PyArray2<f32>>>
-{
+#[allow(dead_code, clippy::too_many_arguments)]
+fn fd_embed_from_csr(
+    py: Python<'_>,
+    data: Bound<PyArray1<f32>>,
+    indices: Bound<PyArray1<i32>>,
+    indptr: Bound<PyArray1<i64>>,
+    n_rows: usize,
+    n_cols: usize,
+    k: usize,
+    oversample: usize,
+    seed: Option<u64>,
+) -> PyResult<Py<PyArray2<f32>>> {
     // Step 1: Zero-copy view of NumPy arrays
     let data = unsafe { data.as_slice()? };
     let indices = unsafe { indices.as_slice()? };
@@ -183,6 +206,7 @@ fn fd_embed_from_csr(py: Python<'_>, data: Bound<PyArray1<f32>>, indices: Bound<
     Ok(Py::from(py_z))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_fd_fit(
     data: &[f32],
     indices: &[i32],
@@ -238,6 +262,8 @@ fn compute_fd_fit(
 
 #[pyfunction]
 #[pyo3(signature = (data, indices, indptr, n_rows, n_cols, k, oversample=16, seed=None))]
+// The arguments are the stable Python API; grouping them would be a breaking change.
+#[allow(clippy::too_many_arguments)]
 fn fd_fit_from_csr(
     py: Python<'_>,
     data: Bound<PyArray1<f32>>,
@@ -273,13 +299,13 @@ fn compute_fd_transform(
 ) -> Result<Array2<f32>, PyErr> {
     // Fetch model
     let (projection, omega, model_n_cols, m) = {
-        let guard = FD_EMBED_MODELS
-            .lock()
-            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("FD_EMBED_MODELS mutex poisoned"))?;
+        let guard = FD_EMBED_MODELS.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("FD_EMBED_MODELS mutex poisoned")
+        })?;
 
-        let model = guard
-            .get(&model_id)
-            .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(format!("Unknown model_id {model_id}")))?;
+        let model = guard.get(&model_id).ok_or_else(|| {
+            pyo3::exceptions::PyKeyError::new_err(format!("Unknown model_id {model_id}"))
+        })?;
 
         (
             Arc::clone(&model.projection),
@@ -355,20 +381,22 @@ fn fd_transform_from_csr(
     Ok(Py::from(py_z))
 }
 
-fn compute_truncated_svd_fit(data: &[f32], indices: &[i32], indptr: &[i64],
-    n_rows: usize, n_cols: usize, k: usize, seed: Option<u64>) -> Result<(u64, Array2<f32>), PyErr>
-{
+fn compute_truncated_svd_fit(
+    data: &[f32],
+    indices: &[i32],
+    indptr: &[i64],
+    n_rows: usize,
+    n_cols: usize,
+    k: usize,
+    seed: Option<u64>,
+) -> Result<(u64, Array2<f32>), PyErr> {
     // Hardcoded sklearn defaults: n_iter = 5 or 7, oversample=10
     const N_ITER: usize = 5;
     const OVERSAMPLE: usize = 10;
     let pool = get_thread_pool();
 
     let (z, components_t, s) = truncated_svd::truncated_svd_csr(
-        data, indices, indptr,
-        n_rows, n_cols,
-        k, N_ITER, OVERSAMPLE,
-        seed,
-        pool,
+        data, indices, indptr, n_rows, n_cols, k, N_ITER, OVERSAMPLE, seed, pool,
     )?;
 
     let model_id = TSVD_NEXT_ID.fetch_add(1, Ordering::Relaxed);
@@ -389,10 +417,18 @@ fn compute_truncated_svd_fit(data: &[f32], indices: &[i32], indptr: &[i64],
 
 #[pyfunction]
 #[pyo3(signature = (data, indices, indptr, n_rows, n_cols, k, seed=None))]
-fn truncated_svd_fit_from_csr(py: Python<'_>, data: Bound<PyArray1<f32>>, indices: Bound<PyArray1<i32>>,
-    indptr: Bound<PyArray1<i64>>, n_rows: usize, n_cols: usize, k: usize,
-    seed: Option<u64>) -> PyResult<(u64, Py<PyArray2<f32>>)>
-{
+// The arguments are the stable Python API; grouping them would be a breaking change.
+#[allow(clippy::too_many_arguments)]
+fn truncated_svd_fit_from_csr(
+    py: Python<'_>,
+    data: Bound<PyArray1<f32>>,
+    indices: Bound<PyArray1<i32>>,
+    indptr: Bound<PyArray1<i64>>,
+    n_rows: usize,
+    n_cols: usize,
+    k: usize,
+    seed: Option<u64>,
+) -> PyResult<(u64, Py<PyArray2<f32>>)> {
     // Step 1: Zero-copy view of NumPy arrays
     let data = unsafe { data.as_slice()? };
     let indices = unsafe { indices.as_slice()? };
@@ -417,13 +453,13 @@ fn compute_truncated_svd_transform(
 ) -> Result<Array2<f32>, PyErr> {
     // Fetch model
     let (components_t, model_n_cols) = {
-        let guard = TSVD_MODELS
-            .lock()
-            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("TSVD model cache mutex poisoned"))?;
+        let guard = TSVD_MODELS.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("TSVD model cache mutex poisoned")
+        })?;
 
-        let m = guard
-            .get(&model_id)
-            .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(format!("Unknown model_id {model_id}")))?;
+        let m = guard.get(&model_id).ok_or_else(|| {
+            pyo3::exceptions::PyKeyError::new_err(format!("Unknown model_id {model_id}"))
+        })?;
 
         (Arc::clone(&m.components_t), m.n_cols)
     };
@@ -437,7 +473,15 @@ fn compute_truncated_svd_transform(
     }
 
     let pool = get_thread_pool();
-    truncated_svd::truncated_svd_transform_csr(data, indices, indptr, n_rows, n_cols, &components_t, pool)
+    truncated_svd::truncated_svd_transform_csr(
+        data,
+        indices,
+        indptr,
+        n_rows,
+        n_cols,
+        &components_t,
+        pool,
+    )
 }
 
 #[pyfunction]
@@ -465,18 +509,21 @@ fn truncated_svd_transform_from_csr(
 
 #[pyfunction]
 #[pyo3(signature = (seq, analyzer, ngram_min, ngram_max, n_features))]
+#[allow(clippy::type_complexity, clippy::let_and_return)]
 fn hashing_tfidf_csr(
     py: Python<'_>,
-    seq: Bound<PyAny>,    //iterable of strings (empty for nulls)
-    analyzer: &str, //"char"/"char_wb"
-    ngram_min: usize, ngram_max: usize, n_features: usize
+    seq: Bound<PyAny>, //iterable of strings (empty for nulls)
+    analyzer: &str,    //"char"/"char_wb"
+    ngram_min: usize,
+    ngram_max: usize,
+    n_features: usize,
 ) -> PyResult<(
-    Py<PyArray1<f32>>,  //data
-    Py<PyArray1<i32>>,  //indices
-    Py<PyArray1<i64>>,  //indptr
-    usize,              //n_rows
-    usize,              //n_cols (n_features)
-    Py<PyArray1<f32>>   //idf (length of n_features)
+    Py<PyArray1<f32>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
+    Py<PyArray1<f32>>,
 )> {
     // Collect input into a vector. TODO: zero-copy
     let mut docs: Vec<String> = Vec::new();
@@ -484,7 +531,11 @@ fn hashing_tfidf_csr(
     for item in iter {
         let obj = item?;
         // Treat none as empty string. Python pre-fill should already do this.
-        let s: String = if obj.is_none() {String::new()} else {obj.extract()?};
+        let s: String = if obj.is_none() {
+            String::new()
+        } else {
+            obj.extract()?
+        };
         docs.push(s);
     }
     let n_rows = docs.len();
@@ -503,24 +554,33 @@ fn hashing_tfidf_csr(
     let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
     let py_idf = idf.into_pyarray(py).to_owned();
 
-    Ok((Py::from(py_data), Py::from(py_indices), Py::from(py_indptr), n_rows, n_features, Py::from(py_idf)))
-
+    Ok((
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_features,
+        Py::from(py_idf),
+    ))
 }
 
 #[pyfunction]
 #[pyo3(signature = (seq, analyzer, ngram_min, ngram_max, n_features, idf))]
+#[allow(clippy::type_complexity, clippy::let_and_return)]
 fn hashing_tfidf_csr_with_idf(
     py: Python<'_>,
-    seq: Bound<PyAny>,    //iterable of strings (empty for nulls)
-    analyzer: &str, //"char"/"char_wb"
-    ngram_min: usize, ngram_max: usize, n_features: usize,
-    idf: PyReadonlyArray1<f32>  //pre-computed IDF vector
+    seq: Bound<PyAny>, //iterable of strings (empty for nulls)
+    analyzer: &str,    //"char"/"char_wb"
+    ngram_min: usize,
+    ngram_max: usize,
+    n_features: usize,
+    idf: PyReadonlyArray1<f32>, //pre-computed IDF vector
 ) -> PyResult<(
-    Py<PyArray1<f32>>,  //data
-    Py<PyArray1<i32>>,  //indices
-    Py<PyArray1<i64>>,  //indptr
-    usize,              //n_rows
-    usize,              //n_cols (n_features)
+    Py<PyArray1<f32>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
 )> {
     // Collect input into a vector. TODO: zero-copy
     let mut docs: Vec<String> = Vec::new();
@@ -528,7 +588,11 @@ fn hashing_tfidf_csr_with_idf(
     for item in iter {
         let obj = item?;
         // Treat none as empty string. Python pre-fill should already do this.
-        let s: String = if obj.is_none() {String::new()} else {obj.extract()?};
+        let s: String = if obj.is_none() {
+            String::new()
+        } else {
+            obj.extract()?
+        };
         docs.push(s);
     }
     let n_rows = docs.len();
@@ -536,9 +600,11 @@ fn hashing_tfidf_csr_with_idf(
     // Get IDF slice (zero-copy read)
     let idf_slice = idf.as_slice()?;
     if idf_slice.len() != n_features {
-        return Err(PyErr::new::<PyValueError, _>(
-            format!("IDF length {} does not match n_features {}", idf_slice.len(), n_features)
-        ));
+        return Err(PyErr::new::<PyValueError, _>(format!(
+            "IDF length {} does not match n_features {}",
+            idf_slice.len(),
+            n_features
+        )));
     }
 
     // Work buffers to be produced by tfidf::build_csr_with_idf
@@ -554,13 +620,126 @@ fn hashing_tfidf_csr_with_idf(
     let py_indices = PyArray1::<i32>::from_vec(py, indices).to_owned();
     let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
 
-    Ok((Py::from(py_data), Py::from(py_indices), Py::from(py_indptr), n_rows, n_features))
+    Ok((
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_features,
+    ))
+}
 
+// ---- HashingVectorizer (word analyzer): stateless transform -> CSR ----
+/// Extract documents into Python-backed UTF-8 views without copying their
+/// contents into Rust-owned `String`s. Lists use indexed access to avoid the
+/// generic iterator protocol on the adapter's hot path.
+fn extract_hashing_documents(seq: &Bound<'_, PyAny>) -> PyResult<Vec<PyBackedStr>> {
+    if let Ok(list) = seq.cast::<PyList>() {
+        let mut documents = Vec::with_capacity(list.len());
+        for index in 0..list.len() {
+            documents.push(list.get_item(index)?.extract::<PyBackedStr>()?);
+        }
+        return Ok(documents);
+    }
+
+    let mut documents = Vec::new();
+    let iterator = PyIterator::from_object(seq)?;
+    for item in iterator {
+        documents.push(item?.extract::<PyBackedStr>()?);
+    }
+    Ok(documents)
+}
+
+fn ensure_ascii_hashing_documents(documents: &[PyBackedStr]) -> PyResult<()> {
+    if documents.iter().all(|document| document.is_ascii()) {
+        return Ok(());
+    }
+    Err(PyValueError::new_err(
+        "non-ASCII documents require sklearn fallback",
+    ))
+}
+
+#[pyfunction]
+#[pyo3(signature = (seq, n_features, ngram_min, ngram_max, binary=false, alternate_sign=true, lowercase=true, norm="l2"))]
+// The arguments are the stable Python API; grouping them would be a breaking change.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn hashing_vectorizer_transform(
+    py: Python<'_>,
+    seq: Bound<PyAny>, // iterable of strings, normalized by the Python adapter
+    n_features: usize,
+    ngram_min: usize,
+    ngram_max: usize,
+    binary: bool,
+    alternate_sign: bool,
+    lowercase: bool,
+    norm: &str,
+) -> PyResult<(
+    Py<PyArray1<f64>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
+)> {
+    let t_extract = start_timing();
+    if n_features == 0 {
+        return Err(PyValueError::new_err("n_features must be > 0"));
+    }
+    if n_features > i32::MAX as usize {
+        return Err(PyValueError::new_err(
+            "n_features must be at most 2147483647",
+        ));
+    }
+    if ngram_min == 0 || ngram_min > ngram_max {
+        return Err(PyValueError::new_err("invalid ngram_range"));
+    }
+    let norm = match norm {
+        "none" => hashing_vectorizer::Norm::None,
+        "l1" => hashing_vectorizer::Norm::L1,
+        "l2" => hashing_vectorizer::Norm::L2,
+        _ => {
+            return Err(PyValueError::new_err(
+                "norm must be 'none', 'l1', or 'l2'",
+            ))
+        }
+    };
+
+    let docs = extract_hashing_documents(&seq)?;
+    ensure_ascii_hashing_documents(&docs)?;
+    print_timing("hv ffi_extract", t_extract);
+    let n_rows = docs.len();
+
+    let opts = hashing_vectorizer::HashingOptions {
+        n_features,
+        nmin: ngram_min,
+        nmax: ngram_max,
+        binary,
+        alternate_sign,
+        lowercase,
+        norm,
+    };
+
+    // Heavy work without the GIL.
+    let (data, indices, indptr) = py.detach(|| hashing_vectorizer::transform(&docs, &opts));
+
+    let t_numpy = start_timing();
+    let py_data = PyArray1::<f64>::from_vec(py, data).to_owned();
+    let py_indices = PyArray1::<i32>::from_vec(py, indices).to_owned();
+    let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
+    print_timing("hv numpy_handoff", t_numpy);
+
+    Ok((
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_features,
+    ))
 }
 
 // ---- Fit TF-IDF vocabulary + return CSR ----
 #[pyfunction]
 #[pyo3(signature = (seq, analyzer, ngram_min, ngram_max))]
+#[allow(clippy::type_complexity)]
 fn tfidf_fit_csr(
     py: Python<'_>,
     seq: Vec<String>, //Fixme: reference (&PyList) instead of copying
@@ -568,12 +747,12 @@ fn tfidf_fit_csr(
     ngram_min: usize,
     ngram_max: usize,
 ) -> PyResult<(
-    u64,               // model_id
-    Py<PyArray1<f32>>, // data
-    Py<PyArray1<i32>>, // indices
-    Py<PyArray1<i64>>, // indptr
-    usize,             // n_rows
-    usize,             // n_cols (vocab size)
+    u64,
+    Py<PyArray1<f32>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
 )> {
     let docs = seq;
     let n_rows = docs.len();
@@ -607,22 +786,30 @@ fn tfidf_fit_csr(
     let py_indices = PyArray1::<i32>::from_vec(py, indices).to_owned();
     let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
 
-    Ok((model_id, Py::from(py_data), Py::from(py_indices), Py::from(py_indptr), n_rows, n_cols))
+    Ok((
+        model_id,
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_cols,
+    ))
 }
 
 // ---- Transform using stored vocab/idf + return CSR ----
 #[pyfunction]
 #[pyo3(signature = (model_id, seq))]
+#[allow(clippy::type_complexity)]
 fn tfidf_transform_csr(
     py: Python<'_>,
     model_id: u64,
     seq: Vec<String>,
 ) -> PyResult<(
-    Py<PyArray1<f32>>, // data
-    Py<PyArray1<i32>>, // indices
-    Py<PyArray1<i64>>, // indptr
-    usize,             // n_rows
-    usize,             // n_cols
+    Py<PyArray1<f32>>,
+    Py<PyArray1<i32>>,
+    Py<PyArray1<i64>>,
+    usize,
+    usize,
 )> {
     let docs = seq;
     let n_rows = docs.len();
@@ -636,7 +823,9 @@ fn tfidf_transform_csr(
         })?;
         let idx = model_id as usize;
         if idx >= guard.len() {
-            return Err(PyValueError::new_err(format!("Invalid model_id {model_id}")));
+            return Err(PyValueError::new_err(format!(
+                "Invalid model_id {model_id}"
+            )));
         }
         guard[idx].clone()
     };
@@ -651,7 +840,13 @@ fn tfidf_transform_csr(
     let py_indices = PyArray1::<i32>::from_vec(py, indices).to_owned();
     let py_indptr = PyArray1::<i64>::from_vec(py, indptr).to_owned();
 
-    Ok((Py::from(py_data), Py::from(py_indices), Py::from(py_indptr), n_rows, n_cols))
+    Ok((
+        Py::from(py_data),
+        Py::from(py_indices),
+        Py::from(py_indptr),
+        n_rows,
+        n_cols,
+    ))
 }
 
 // ---- Expose module ----
@@ -667,5 +862,6 @@ fn _rust_backend_native(_py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(one_hot_encoder::csr_to_dense, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_fit_csr, m)?)?;
     m.add_function(wrap_pyfunction!(tfidf_transform_csr, m)?)?;
+    m.add_function(wrap_pyfunction!(hashing_vectorizer_transform, m)?)?;
     Ok(())
 }

--- a/_rust/src/tokenize.rs
+++ b/_rust/src/tokenize.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Result};
 
+#[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Analyzer {
     Char,
-    Char_wb
+    Char_wb,
 }
 
+#[allow(dead_code)]
 pub fn parse_analyzer(s: &str) -> Result<Analyzer> {
     match s {
         "char" => Ok(Analyzer::Char),
@@ -21,7 +23,8 @@ pub fn char_ngrams<'a>(s: &'a str, nmin: usize, nmax: usize, buf: &mut Vec<&'a s
 
     // Gather all n-grams for all n between nmin and nmax
     for n in nmin..=nmax {
-        if n == 0 || idx.len() < n+1 { //coherence check
+        if n == 0 || idx.len() < n + 1 {
+            //coherence check
             continue;
         }
         for start in 0..=idx.len().saturating_sub(n + 1) {
@@ -29,6 +32,113 @@ pub fn char_ngrams<'a>(s: &'a str, nmin: usize, nmax: usize, buf: &mut Vec<&'a s
             let i = idx[start];
             let j = idx[end];
             buf.push(&s[i..j]); // slice is valid UTF-8 by construction
+        }
+    }
+}
+
+/// sklearn default `\w`: alphanumeric or underscore.
+#[cfg(test)]
+#[inline(always)]
+pub fn is_word_char(c: char) -> bool {
+    c == '_' || c.is_alphanumeric()
+}
+
+/// Tokenize like sklearn's default `token_pattern=r"(?u)\b\w\w+\b"`.
+/// Tokens borrow from `text` (no per-token allocation).
+#[cfg(test)]
+pub fn word_tokens<'a>(text: &'a str, out: &mut Vec<&'a str>) {
+    let mut start: Option<usize> = None;
+    let mut nchars: usize = 0;
+    for (i, c) in text.char_indices() {
+        if is_word_char(c) {
+            if start.is_none() {
+                start = Some(i);
+                nchars = 0;
+            }
+            nchars += 1;
+        } else if let Some(s) = start.take() {
+            if nchars >= 2 {
+                out.push(&text[s..i]);
+            }
+        }
+    }
+    if let Some(s) = start {
+        if nchars >= 2 {
+            out.push(&text[s..]);
+        }
+    }
+}
+
+/// Tokenize ASCII text like sklearn's default
+/// `token_pattern=r"(?u)\b\w\w+\b"`.
+///
+/// Callers that have already established ASCII input can avoid UTF-8
+/// decoding and Unicode character classification with this path.
+#[inline]
+pub fn word_tokens_ascii<'a>(text: &'a str, out: &mut Vec<&'a str>) {
+    for_each_word_token_ascii(text, |token| out.push(token));
+}
+
+/// Visit tokens from [`word_tokens_ascii`] without first materializing a token
+/// vector. This is the common unigram-only fast path.
+#[inline]
+pub fn for_each_word_token_ascii<'a, F>(text: &'a str, mut visit: F)
+where
+    F: FnMut(&'a str),
+{
+    debug_assert!(text.is_ascii());
+
+    let bytes = text.as_bytes();
+    let mut token_start = 0usize;
+    let mut in_token = false;
+
+    for (offset, &byte) in bytes.iter().enumerate() {
+        let is_word = byte.is_ascii_alphanumeric() || byte == b'_';
+        if is_word {
+            if !in_token {
+                token_start = offset;
+                in_token = true;
+            }
+        } else if in_token {
+            if offset - token_start >= 2 {
+                visit(&text[token_start..offset]);
+            }
+            in_token = false;
+        }
+    }
+
+    if in_token && bytes.len() - token_start >= 2 {
+        visit(&text[token_start..]);
+    }
+}
+
+/// Word n-grams in sklearn order. Unigrams are borrowed; higher-order grams
+/// are joined with a shared scratch buffer.
+pub fn for_each_word_ngram<F: FnMut(&str)>(tokens: &[&str], nmin: usize, nmax: usize, mut f: F) {
+    let ntok = tokens.len();
+    let start = nmin.max(1);
+    let end = nmax.min(ntok);
+    if start > end {
+        return;
+    }
+
+    let mut buf = String::new();
+    for n in start..=end {
+        if n == 1 {
+            for &t in tokens {
+                f(t);
+            }
+        } else {
+            for i in 0..=ntok - n {
+                buf.clear();
+                for (j, &t) in tokens[i..i + n].iter().enumerate() {
+                    if j > 0 {
+                        buf.push(' ');
+                    }
+                    buf.push_str(t);
+                }
+                f(&buf);
+            }
         }
     }
 }
@@ -45,5 +155,103 @@ pub fn char_wb_ngrams(str: &str, nmin: usize, nmax: usize, buf: &mut Vec<String>
             let j = i + n;
             buf.push(padded[i..j].to_string()); //FIXME (perf): allocations
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{for_each_word_ngram, for_each_word_token_ascii, word_tokens, word_tokens_ascii};
+
+    fn collect_ngrams(tokens: &[&str], nmin: usize, nmax: usize) -> Vec<String> {
+        let mut ngrams = Vec::new();
+        for_each_word_ngram(tokens, nmin, nmax, |ngram| {
+            ngrams.push(ngram.to_owned());
+        });
+        ngrams
+    }
+
+    #[test]
+    fn default_word_pattern_drops_single_character_tokens() {
+        let mut tokens = Vec::new();
+        word_tokens("a fox 42 _ x_y café", &mut tokens);
+        assert_eq!(tokens, vec!["fox", "42", "x_y", "café"]);
+    }
+
+    #[test]
+    fn ascii_fast_path_matches_generic_tokenizer() {
+        for text in [
+            "",
+            "a fox 42 _ x_y cafe",
+            " punctuation!around,tokens ",
+            "UPPER lower MiXeD123",
+            "one\ttwo\nthree\r\nfour",
+        ] {
+            let mut generic = Vec::new();
+            word_tokens(text, &mut generic);
+
+            let mut buffered = Vec::new();
+            word_tokens_ascii(text, &mut buffered);
+            assert_eq!(buffered, generic);
+
+            let mut visited = Vec::new();
+            for_each_word_token_ascii(text, |token| visited.push(token));
+            assert_eq!(visited, generic);
+        }
+    }
+
+    #[test]
+    fn ascii_fast_path_matches_generic_tokenizer_on_random_documents() {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let alphabet = b"abcdeXYZ0129_ \t.,!?-";
+        let mut rng = StdRng::seed_from_u64(0x05EE_D1DF);
+
+        for _ in 0..3000 {
+            let length = rng.random_range(0..24);
+            let document: String = (0..length)
+                .map(|_| alphabet[rng.random_range(0..alphabet.len())] as char)
+                .collect();
+
+            let mut expected = Vec::new();
+            word_tokens(&document, &mut expected);
+
+            let mut buffered = Vec::new();
+            word_tokens_ascii(&document, &mut buffered);
+            assert_eq!(buffered, expected, "document {document:?}");
+
+            let mut visited = Vec::new();
+            for_each_word_token_ascii(&document, |token| visited.push(token));
+            assert_eq!(visited, expected, "document {document:?}");
+        }
+    }
+
+    #[test]
+    fn empty_tokens_ignore_unbounded_nmax() {
+        assert!(collect_ngrams(&[], 1, usize::MAX).is_empty());
+    }
+
+    #[test]
+    fn one_token_ignores_unbounded_nmax() {
+        assert_eq!(collect_ngrams(&["token"], 1, usize::MAX), vec!["token"]);
+    }
+
+    #[test]
+    fn nmin_above_token_count_produces_no_ngrams() {
+        assert!(collect_ngrams(&["one", "two"], 3, usize::MAX).is_empty());
+    }
+
+    #[test]
+    fn ordinary_word_ngram_ranges_are_unchanged() {
+        let tokens = ["one", "two", "three"];
+        assert_eq!(collect_ngrams(&tokens, 1, 1), vec!["one", "two", "three"]);
+        assert_eq!(
+            collect_ngrams(&tokens, 1, 2),
+            vec!["one", "two", "three", "one two", "two three"]
+        );
+        assert_eq!(
+            collect_ngrams(&tokens, 2, 3),
+            vec!["one two", "two three", "one two three"]
+        );
     }
 }

--- a/stratum/_rust_backend.py
+++ b/stratum/_rust_backend.py
@@ -50,16 +50,28 @@ def print_timing(msg, start_time):
         print(f"[python] {msg}: {(end_time - start_time):8.3f}s")
 
 
-# pandas or polars series -> list (best-effort, minimal overhead)
+# Container -> list (best-effort, minimal overhead).
+# Prefer pandas/NumPy ``.tolist()`` and Polars ``.to_list()`` over generic
+# iteration, which is much slower for large containers.
 def _to_list(col):
-    try:
-        return col.tolist()
-    except Exception:
-        pass
-    try:
-        return col.to_list()
-    except Exception:
-        pass
+    if isinstance(col, list):
+        return list(col)
+    tolist = getattr(col, "tolist", None)
+    if callable(tolist):
+        try:
+            materialized = tolist()
+            if isinstance(materialized, list):
+                return materialized
+        except Exception:
+            pass
+    to_list = getattr(col, "to_list", None)
+    if callable(to_list):
+        try:
+            materialized = to_list()
+            if isinstance(materialized, list):
+                return materialized
+        except Exception:
+            pass
     return list(col)
 
 #---------------------------------------------
@@ -67,6 +79,7 @@ def _to_list(col):
 # Re-export compiled rust functions
 hashing_tfidf_fit = getattr(native, "hashing_tfidf_csr", None) if native else None
 hashing_tfidf_transform = getattr(native, "hashing_tfidf_csr_with_idf", None) if native else None
+hashing_vectorizer_transform = getattr(native, "hashing_vectorizer_transform", None) if native else None
 tfidf_fit = getattr(native, "tfidf_fit_csr", None) if native else None
 tfidf_transform = getattr(native, "tfidf_transform_csr", None) if native else None
 fd_fit= getattr(native, "fd_fit_from_csr", None) if native else None

--- a/stratum/adapters/hashing_vectorizer.py
+++ b/stratum/adapters/hashing_vectorizer.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import logging
+import operator
+from numbers import Integral
+
+import numpy as np
+import scipy.sparse as sp
+
+from sklearn.feature_extraction.text import HashingVectorizer as _HV
+
+from .. import _rust_backend as rb
+from .._config import get_config
+
+logger = logging.getLogger(__name__)
+
+# The one token pattern we replicate exactly in Rust (sklearn's default).
+_DEFAULT_TOKEN_PATTERN = r"(?u)\b\w\w+\b"
+
+_MAX_SKLEARN_FEATURES = np.iinfo(np.int32).max
+_MAX_RUST_USIZE = np.iinfo(np.uintp).max
+_SKLEARN_FALLBACK = object()
+
+
+def _supported_integral(value) -> bool:
+    return isinstance(value, Integral) and not isinstance(value, (bool, np.bool_))
+
+
+def _rust_supported_subset(enc: _HV) -> tuple[bool, str]:
+    """Gate: only route to Rust for the parameter subset the kernel replicates
+    bit-for-bit. Anything else falls back to sklearn."""
+    if getattr(enc, "analyzer", "word") != "word":
+        return False, "analyzer != 'word'"
+    if getattr(enc, "token_pattern", _DEFAULT_TOKEN_PATTERN) != _DEFAULT_TOKEN_PATTERN:
+        return False, "non-default token_pattern"
+    if getattr(enc, "stop_words", None) is not None:
+        return False, "stop_words not supported"
+    if getattr(enc, "preprocessor", None) is not None:
+        return False, "custom preprocessor not supported"
+    if getattr(enc, "tokenizer", None) is not None:
+        return False, "custom tokenizer not supported"
+    if getattr(enc, "strip_accents", None) is not None:
+        return False, "strip_accents not supported"
+    if getattr(enc, "input", "content") != "content":
+        return False, "input != 'content'"
+    if getattr(enc, "norm", "l2") not in (None, "l1", "l2"):
+        return False, "norm not in {None, 'l1', 'l2'}"
+    try:
+        dtype = np.dtype(getattr(enc, "dtype", np.float64))
+    except (TypeError, ValueError):
+        return False, "invalid dtype"
+    if dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+        return False, "dtype is not float32 or float64"
+    if not isinstance(getattr(enc, "lowercase", True), bool):
+        return False, "non-bool lowercase"
+    if not isinstance(getattr(enc, "binary", False), bool):
+        return False, "non-bool binary"
+    if not isinstance(getattr(enc, "alternate_sign", True), bool):
+        return False, "non-bool alternate_sign"
+    n_features = getattr(enc, "n_features", 2**20)
+    if not _supported_integral(n_features):
+        return False, "non-integral n_features"
+    n_features = operator.index(n_features)
+    if not 1 <= n_features <= _MAX_SKLEARN_FEATURES:
+        return False, "n_features outside sklearn's supported range"
+    ngr = getattr(enc, "ngram_range", (1, 1))
+    if not (
+        isinstance(ngr, tuple)
+        and len(ngr) == 2
+        and all(_supported_integral(value) for value in ngr)
+    ):
+        return False, f"invalid ngram_range {ngr!r}"
+    ngram_min, ngram_max = map(operator.index, ngr)
+    if not 1 <= ngram_min <= ngram_max:
+        return False, f"invalid ngram_range {ngr!r}"
+    if ngram_max > _MAX_RUST_USIZE:
+        return False, "ngram_range exceeds Rust's supported integer range"
+    return True, ""
+
+
+def _materialize_documents(raw_documents):
+    """Materialize containers using their optimized conversion methods.
+
+    Plain lists are returned unchanged so the all-string hot path creates no
+    second Python list.
+    """
+    if isinstance(raw_documents, list):
+        return raw_documents
+    return rb._to_list(raw_documents)
+
+
+def _to_docs(raw_documents, encoding="utf-8", decode_error="strict"):
+    """Decode bytes while avoiding a copy for ``list[str]``.
+
+    Callers must route unsupported document types to sklearn before using this
+    helper. The explicit error prevents accidental semantic coercion if that
+    invariant is broken later.
+    """
+    documents = _materialize_documents(raw_documents)
+    converted = None
+
+    for index, value in enumerate(documents):
+        if isinstance(value, str):
+            if converted is not None:
+                converted.append(value)
+            continue
+
+        if isinstance(value, bytes):
+            replacement = value.decode(encoding, errors=decode_error)
+        else:
+            raise TypeError("documents must contain only str or bytes values")
+
+        if converted is None:
+            converted = list(documents[:index])
+        converted.append(replacement)
+
+    return documents if converted is None else converted
+
+
+class RustyHashingVectorizer(_HV):
+    """Drop-in sklearn ``HashingVectorizer`` that prefers a Rust fast path for the
+    default word-analyzer configuration and falls back to sklearn otherwise."""
+
+    def _rust_enabled(self) -> bool:
+        rc = get_config()
+        return bool(
+            rc["allow_patch"]
+            and rc["rust_backend"]
+            and rb.HAVE_RUST
+            and rb.hashing_vectorizer_transform is not None
+        )
+
+    def _rust_transform(self, X):
+        """Return a Rust CSR matrix or the private pre-materialization sentinel."""
+        ok, reason = _rust_supported_subset(self)
+        if not ok:
+            logger.debug("HashingVectorizer Rust fallback: %s", reason)
+            return _SKLEARN_FALLBACK
+        if not self._rust_enabled():
+            return _SKLEARN_FALLBACK
+        if isinstance(X, (str, bytes)):
+            # Let sklearn raise its standard "iterable over raw text" error.
+            return _SKLEARN_FALLBACK
+
+        t_mat = rb.start_timing()
+        documents = _materialize_documents(X)
+        if not documents or any(
+            not isinstance(document, (str, bytes)) for document in documents
+        ):
+            return super().transform(documents)
+
+        docs = _to_docs(documents, self.encoding, self.decode_error)
+        rb.print_timing("hv py_materialize", t_mat)
+        t_ascii = rb.start_timing()
+        non_ascii = any(not document.isascii() for document in docs)
+        rb.print_timing("hv ascii_prescan", t_ascii)
+        if non_ascii:
+            return super().transform(docs)
+
+        t_prep = rb.start_timing()
+        n_features = operator.index(self.n_features)
+        ngram_min, ngram_max = map(operator.index, self.ngram_range)
+        norm = "none" if self.norm is None else self.norm
+        output_dtype = np.dtype(self.dtype)
+        rb.print_timing("hv prep", t_prep)
+        try:
+            data, indices, indptr, n_rows, n_cols = rb.hashing_vectorizer_transform(
+                docs,
+                n_features,
+                ngram_min,
+                ngram_max,
+                self.binary,
+                self.alternate_sign,
+                self.lowercase,
+                norm,
+            )
+        except MemoryError:
+            raise
+        except Exception:
+            logger.warning(
+                "Rust hashing_vectorizer_transform failed; falling back to sklearn",
+                exc_info=True,
+            )
+            # ``docs`` also preserves values from one-shot iterators that were
+            # consumed during materialization.
+            return super().transform(docs)
+
+        # Kernel always emits float64; cast at the boundary for float32.
+        t_csr = rb.start_timing()
+        X_out = sp.csr_matrix(
+            (np.asarray(data, dtype=output_dtype), indices, indptr),
+            shape=(n_rows, n_cols),
+            dtype=output_dtype,
+        )
+        rb.print_timing("hv csr_wrap", t_csr)
+        return X_out
+
+    # HashingVectorizer is stateless: fit() only validates and transform()
+    # does the work. We route transform (and thus fit_transform) through Rust.
+    def transform(self, X):
+        t_total = rb.start_timing()
+        out = self._rust_transform(X)
+        if out is not _SKLEARN_FALLBACK:
+            rb.print_timing("hv transform", t_total)
+            return out
+        return super().transform(X)
+
+    def fit_transform(self, X, y=None):
+        return self.fit(X, y).transform(X)

--- a/stratum/patching/_patching.py
+++ b/stratum/patching/_patching.py
@@ -3,6 +3,10 @@
 Rust estimator implementations are registered with the physical operator
 registry. They are no longer installed by replacing upstream skrub or sklearn
 classes at import time.
+
+HashingVectorizer is an exception: it is a sklearn class used directly by
+skrub (e.g. StringEncoder) and by user pipelines, so we still swap in the
+Rusty adapter at import time.
 """
 from __future__ import annotations
 
@@ -11,6 +15,7 @@ import threading
 from types import ModuleType
 from typing import Dict, Tuple, List
 
+from stratum.adapters.hashing_vectorizer import RustyHashingVectorizer
 from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSearch
 
 # ------------------------
@@ -18,6 +23,7 @@ from stratum.patching._gridsearch import make_grid_search as StratumMakeGridSear
 # ------------------------
 # Definition: (module, symbol) -> adapter
 _DEFINITION_REPLACEMENTS: Dict[Tuple[str, str], object] = {
+    ("sklearn.feature_extraction.text", "HashingVectorizer"): RustyHashingVectorizer,
 }
 
 # Method-level replacements (for methods on classes)
@@ -29,11 +35,13 @@ _METHOD_REPLACEMENTS: Dict[Tuple[str, str, str], object] = {
 # Replace/override names in these upstream usage modules if present.
 # Keep this list manually maintained. Add to it if skrub adds new direct imports.
 _USAGE_MODULES: List[str] = [
+    "skrub._string_encoder",  # imports HashingVectorizer directly
 ]
 
 # Symbol-level overrides for usage modules and top-level exposure on `skrub`
 # (symbol name) -> adapter
 _SYMBOL_OVERRIDES: Dict[str, object] = {
+    "HashingVectorizer": RustyHashingVectorizer,
 }
 
 # Idempotence sentinel + lock
@@ -62,12 +70,6 @@ def _set_symbol(mod: ModuleType, name: str, value: object) -> None:
 
 def _patch_definitions() -> None:
     for (modname, symbol), adapter in _DEFINITION_REPLACEMENTS.items():
-        # Ensure sklearn is imported if we are patching it
-        if modname.startswith("sklearn"):
-            # skrub already imports sklearn modules internally, but it's safer
-            # to ensure it's loaded before trying to patch.
-            _import_module("sklearn.preprocessing")
-
         mod = _import_module(modname)
         _set_symbol(mod, symbol, adapter)
 

--- a/stratum/tests/adapters/test_hashing_vectorizer.py
+++ b/stratum/tests/adapters/test_hashing_vectorizer.py
@@ -1,0 +1,755 @@
+import os
+
+os.environ.setdefault("SKRUB_RUST", "1")  # opt-in fastpath before any imports
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import stratum  # noqa: F401  (ensures patching + config side effects)
+from stratum import _rust_backend as rb
+from stratum.adapters.hashing_vectorizer import (
+    _HV as OriginalHashingVectorizer,
+    RustyHashingVectorizer,
+    _materialize_documents,
+    _rust_supported_subset,
+    _to_docs,
+)
+
+pytestmark = pytest.mark.skipif(not rb.HAVE_RUST, reason="Rust backend not built")
+
+_DOCS = [
+    "The quick brown fox jumps over the lazy dog",
+    "the Lazy dog, the CAT!!!",
+    "",
+    "foo a b cc dd foo foo",           # repeated tokens + single-char tokens dropped
+    "Hello, WORLD! hello.",
+    "ünïcodé café tëst café",          # non-ASCII word chars
+    "a",                                # single char only -> empty row
+    "123 45 6 seven_eight under_score",
+]
+_ASCII_DOCS = [document for document in _DOCS if document.isascii()]
+
+
+def _rust_csr(docs, **params):
+    enc = RustyHashingVectorizer(**params)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        X = enc.transform(docs)
+    assert sp.issparse(X)
+    return X.tocsr()
+
+
+def _sklearn_csr(docs, **params):
+    return OriginalHashingVectorizer(**params).transform(docs).tocsr()
+
+
+def _assert_csr_equal(got, ref, *, atol=1e-12):
+    got = got.tocsr()
+    ref = ref.tocsr()
+    assert got.shape == ref.shape
+    assert got.dtype == ref.dtype
+    assert got.indptr.dtype == ref.indptr.dtype
+    assert got.indices.dtype == ref.indices.dtype
+    np.testing.assert_array_equal(got.indptr, ref.indptr)
+    np.testing.assert_array_equal(got.indices, ref.indices)
+    np.testing.assert_allclose(got.data, ref.data, rtol=0, atol=atol)
+
+
+def _assert_matches_sklearn_behavior(
+    documents_factory, *, method="transform", params=None, atol=1e-12
+):
+    params = {} if params is None else params
+
+    try:
+        reference = getattr(OriginalHashingVectorizer(**params), method)(
+            documents_factory()
+        )
+    except Exception as exc:
+        reference_error = exc
+    else:
+        reference_error = None
+
+    try:
+        with stratum.config(rust_backend=True, allow_patch=True):
+            actual = getattr(RustyHashingVectorizer(**params), method)(
+                documents_factory()
+            )
+    except Exception as exc:
+        actual_error = exc
+    else:
+        actual_error = None
+
+    if reference_error is not None or actual_error is not None:
+        assert reference_error is not None, "sklearn succeeded but the adapter raised"
+        assert actual_error is not None, "sklearn raised but the adapter succeeded"
+        assert type(actual_error) is type(reference_error)
+        return
+
+    _assert_csr_equal(actual, reference, atol=atol)
+
+
+def _assert_close(docs, atol=1e-12, **params):
+    got = _rust_csr(docs, **params)
+    ref = _sklearn_csr(docs, **params)
+    _assert_csr_equal(got, ref, atol=atol)
+
+
+def test_rust_config_controls_native_dispatch(monkeypatch):
+    native_transform = rb.hashing_vectorizer_transform
+    native_calls = 0
+
+    def counted_transform(*args, **kwargs):
+        nonlocal native_calls
+        native_calls += 1
+        return native_transform(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", counted_transform)
+    vectorizer = RustyHashingVectorizer()
+
+    with stratum.config(rust_backend=True, allow_patch=True):
+        actual = vectorizer.transform(["plain ascii text"])
+    assert native_calls == 1
+    reference = OriginalHashingVectorizer().transform(["plain ascii text"])
+    _assert_csr_equal(actual, reference)
+
+    with stratum.config(rust_backend=False, allow_patch=True):
+        vectorizer.transform(["plain ascii text"])
+    assert native_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("dtype", "norm"),
+    [
+        (np.float64, "l2"),
+        (np.float64, "l1"),
+        (np.float32, "l2"),
+        (np.float32, "l1"),
+        (np.float32, None),
+        (np.int64, "l2"),
+        (np.int64, None),
+        (np.bool_, "l2"),
+        (np.float16, "l2"),
+        (np.longdouble, "l2"),
+        (np.complex128, "l2"),
+        (object, "l2"),
+    ],
+)
+def test_dtype_behavior_matches_sklearn(dtype, norm):
+    _assert_matches_sklearn_behavior(
+        lambda: ["alpha beta"],
+        params={"dtype": dtype, "norm": norm, "n_features": 2**10},
+        atol=1e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float16,
+        np.longdouble,
+        np.int64,
+        np.bool_,
+        np.complex128,
+        object,
+    ],
+)
+def test_unverified_dtypes_are_rejected_by_native_gate(dtype):
+    # On Windows and macOS, longdouble is an alias of float64, so the native
+    # path correctly accepts it as float64.
+    try:
+        if np.dtype(dtype) in (np.dtype(np.float32), np.dtype(np.float64)):
+            pytest.skip(f"{dtype!r} normalizes to a supported float dtype")
+    except (TypeError, ValueError):
+        pass
+    supported, _ = _rust_supported_subset(RustyHashingVectorizer(dtype=dtype))
+    assert not supported
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_float_dtypes_are_supported_by_native_gate(dtype):
+    supported, reason = _rust_supported_subset(
+        RustyHashingVectorizer(dtype=dtype)
+    )
+    assert supported, reason
+
+
+@pytest.mark.parametrize("norm", [None, "l1", "l2"])
+def test_norm_options_are_supported_by_native_gate(norm):
+    supported, reason = _rust_supported_subset(
+        RustyHashingVectorizer(norm=norm, n_features=2**10)
+    )
+    assert supported, reason
+
+
+def test_unsupported_norm_is_rejected_by_native_gate():
+    # sklearn's normalize also accepts 'max'; the Rust kernel only does l1/l2.
+    supported, reason = _rust_supported_subset(
+        RustyHashingVectorizer(norm="max", n_features=2**10)
+    )
+    assert not supported
+    assert reason == "norm not in {None, 'l1', 'l2'}"
+
+@pytest.mark.parametrize(
+    "documents_factory",
+    [
+        lambda: [],
+        lambda: [None],
+        lambda: [np.nan],
+        lambda: ["valid", None],
+        lambda: ["valid", 42],
+        lambda: [bytearray(b"text")],
+        lambda: [object()],
+    ],
+    ids=[
+        "empty",
+        "none",
+        "nan",
+        "mixed-none",
+        "mixed-int",
+        "bytearray",
+        "object",
+    ],
+)
+def test_invalid_document_behavior_matches_sklearn(documents_factory):
+    _assert_matches_sklearn_behavior(documents_factory)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [None],
+        [np.nan],
+        ["valid", None],
+        ["valid", 42],
+        [bytearray(b"text")],
+        [object()],
+    ],
+    ids=["none", "nan", "mixed-none", "mixed-int", "bytearray", "object"],
+)
+def test_invalid_generator_behavior_matches_sklearn(values):
+    _assert_matches_sklearn_behavior(lambda: (value for value in values))
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "plain ascii text",
+        "café déjà vu",
+        "שָׁלוֹם עולם",
+        "بِسْمِ الله",
+        "A\u0345B",
+        "中文 混合 English",
+    ],
+)
+@pytest.mark.parametrize("lowercase", [True, False])
+@pytest.mark.parametrize("ngram_range", [(1, 1), (1, 2)])
+def test_unicode_behavior_matches_sklearn(document, lowercase, ngram_range):
+    _assert_matches_sklearn_behavior(
+        lambda: [document],
+        params={
+            "lowercase": lowercase,
+            "ngram_range": ngram_range,
+            "n_features": 2**18,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "café déjà vu",
+        "שָׁלוֹם עולם",
+        "بِسْمِ الله",
+        "A\u0345B",
+        "中文 混合 English",
+    ],
+)
+def test_non_ascii_uses_sklearn_fallback(document, monkeypatch):
+    def unexpected_native_call(*args, **kwargs):
+        raise AssertionError("non-ASCII input was sent to Rust")
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", unexpected_native_call)
+    _assert_matches_sklearn_behavior(lambda: [document])
+
+
+def test_native_boundary_rejects_non_ascii_input():
+    with pytest.raises(ValueError, match="non-ASCII"):
+        rb.hashing_vectorizer_transform(
+            ["plain ascii", "café"],
+            2**18,
+            1,
+            1,
+            False,
+            True,
+            True,
+            "l2",
+        )
+
+
+def test_native_boundary_accepts_max_i32_feature_count():
+    docs = ["plain ascii"]
+    n_features = 2**31 - 1
+    supported, reason = _rust_supported_subset(
+        RustyHashingVectorizer(n_features=n_features)
+    )
+    assert supported, reason
+
+    data, indices, indptr, n_rows, n_cols = rb.hashing_vectorizer_transform(
+        docs,
+        n_features,
+        1,
+        1,
+        False,
+        True,
+        True,
+        "l2",
+    )
+    actual = sp.csr_matrix(
+        (data, indices, indptr),
+        shape=(n_rows, n_cols),
+        dtype=np.float64,
+    )
+    expected = OriginalHashingVectorizer(n_features=n_features).transform(docs)
+    _assert_csr_equal(actual, expected)
+
+
+def test_native_boundary_rejects_feature_count_above_i32_range():
+    with pytest.raises(ValueError, match="at most 2147483647"):
+        rb.hashing_vectorizer_transform(
+            ["plain ascii"],
+            2**31,
+            1,
+            1,
+            False,
+            True,
+            True,
+            "l2",
+        )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"n_features": 8.9},
+        {"n_features": "8"},
+        {"n_features": 0},
+        {"n_features": 2**31},
+        {"binary": 1},
+        {"alternate_sign": 1},
+        {"ngram_range": (1.0, 2.0)},
+        {"ngram_range": (2, 1)},
+        {"ngram_range": (1, 2**100)},
+    ],
+)
+def test_fit_transform_parameter_validation_matches_sklearn(params):
+    _assert_matches_sklearn_behavior(
+        lambda: ["hello world"], method="fit_transform", params=params
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"n_features": 8.9},
+        {"n_features": "8"},
+        {"n_features": 2**31},
+        {"binary": 1},
+        {"alternate_sign": 1},
+        {"ngram_range": (1.0, 2.0)},
+        {"ngram_range": (2, 1)},
+        {"ngram_range": (1, 2**100)},
+    ],
+)
+def test_transform_parameter_behavior_matches_sklearn(params):
+    _assert_matches_sklearn_behavior(lambda: ["hello world"], params=params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"n_features": 0},
+        {"n_features": 2**31},
+        {"n_features": 8.9},
+        {"n_features": "8"},
+        {"binary": 1},
+        {"alternate_sign": 1},
+        {"lowercase": 1},
+        {"ngram_range": (1.0, 2.0)},
+        {"ngram_range": (2, 1)},
+        {"ngram_range": (1, 2**100)},
+    ],
+)
+def test_invalid_native_parameters_are_rejected_by_gate(params):
+    supported, _ = _rust_supported_subset(RustyHashingVectorizer(**params))
+    assert not supported
+
+
+def test_invalid_dtype_is_rejected_by_gate():
+    # Mutate after init so the gate's np.dtype(...) exception path is hit.
+    vectorizer = RustyHashingVectorizer()
+    vectorizer.dtype = "not_a_real_dtype_xyz"
+    supported, reason = _rust_supported_subset(vectorizer)
+    assert not supported
+    assert reason == "invalid dtype"
+
+
+def test_transform_rejects_y_argument():
+    vectorizer = RustyHashingVectorizer()
+    with pytest.raises(TypeError):
+        vectorizer.transform(["hello world"], None)
+
+
+@pytest.mark.parametrize("binary", [False, True])
+@pytest.mark.parametrize("alternate_sign", [False, True])
+@pytest.mark.parametrize("norm", [None, "l1", "l2"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_matches_sklearn_param_grid(binary, alternate_sign, norm, dtype):
+    atol = 1e-6 if dtype == np.float32 else 1e-12
+    _assert_close(
+        _ASCII_DOCS,
+        atol=atol,
+        n_features=2**18,
+        binary=binary,
+        alternate_sign=alternate_sign,
+        norm=norm,
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize("ngram_range", [(1, 1), (1, 2), (2, 3), (1, 3)])
+def test_matches_sklearn_ngram_ranges(ngram_range):
+    _assert_close(_ASCII_DOCS, n_features=2**18, ngram_range=ngram_range)
+
+
+def test_huge_ngram_upper_bound_matches_sklearn(monkeypatch):
+    native_transform = rb.hashing_vectorizer_transform
+    native_calls = 0
+
+    def counted_transform(*args, **kwargs):
+        nonlocal native_calls
+        native_calls += 1
+        return native_transform(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", counted_transform)
+    _assert_matches_sklearn_behavior(
+        lambda: ["one token"],
+        params={"n_features": 2**10, "ngram_range": (1, 1_000_000_000)},
+    )
+    assert native_calls == 1
+
+
+def test_default_config_matches_sklearn():
+    # Full defaults, incl. n_features=2**20 and norm="l2".
+    _assert_close(_ASCII_DOCS)
+
+
+@pytest.mark.parametrize("n_features", [1, 2, 4, 8])
+def test_hash_collisions_match_sklearn(n_features):
+    docs = [
+        "alpha beta gamma delta epsilon zeta eta theta iota kappa alpha beta",
+        "collision heavy repeated repeated one two three four five six seven",
+    ]
+    _assert_close(
+        docs,
+        n_features=n_features,
+        binary=True,
+        alternate_sign=True,
+    )
+
+
+def test_lowercase_false_matches_sklearn():
+    _assert_close(_ASCII_DOCS, n_features=2**16, lowercase=False)
+
+
+def test_rows_are_l2_normalized():
+    X = _rust_csr(_ASCII_DOCS, n_features=2**18)
+    row_norms = np.sqrt(np.asarray(X.multiply(X).sum(axis=1)).ravel())
+    # Empty rows have norm 0; non-empty rows must be unit norm.
+    nnz_per_row = np.diff(X.indptr)
+    for norm, nnz in zip(row_norms, nnz_per_row):
+        if nnz > 0:
+            assert abs(norm - 1.0) < 1e-6
+
+
+def test_rows_are_l1_normalized():
+    X = _rust_csr(_ASCII_DOCS, n_features=2**18, norm="l1")
+    row_norms = np.asarray(np.abs(X).sum(axis=1)).ravel()
+    nnz_per_row = np.diff(X.indptr)
+    for norm, nnz in zip(row_norms, nnz_per_row):
+        if nnz > 0:
+            assert abs(norm - 1.0) < 1e-6
+
+
+def test_float32_output_dtype_uses_native_path(monkeypatch):
+    native_transform = rb.hashing_vectorizer_transform
+    native_calls = 0
+
+    def counted_transform(*args, **kwargs):
+        nonlocal native_calls
+        native_calls += 1
+        return native_transform(*args, **kwargs)
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", counted_transform)
+    X = _rust_csr(_ASCII_DOCS, n_features=2**12, dtype=np.float32, norm="l1")
+    assert native_calls == 1
+    assert X.dtype == np.float32
+    _assert_csr_equal(X, _sklearn_csr(_ASCII_DOCS, n_features=2**12, dtype=np.float32, norm="l1"), atol=1e-6)
+
+def test_empty_rows():
+    for docs in ([""], ["", ""], ["a", "b"]):
+        X = _rust_csr(docs, n_features=2**15)
+        assert X.shape[0] == len(docs)
+        assert X.nnz == X.indptr[-1]
+
+
+@pytest.mark.parametrize("method", ["fit_transform", "transform"])
+def test_zero_dimensional_numpy_input_matches_sklearn_exception(method):
+    raw_documents = np.array("hello world")
+    reference = OriginalHashingVectorizer()
+    vectorizer = RustyHashingVectorizer()
+
+    with pytest.raises(Exception) as expected_error:
+        getattr(reference, method)(raw_documents)
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(Exception) as actual_error:
+            getattr(vectorizer, method)(raw_documents)
+
+    assert type(actual_error.value) is type(expected_error.value)
+    assert str(actual_error.value) == str(expected_error.value)
+
+
+@pytest.mark.parametrize("binary", [False, True])
+@pytest.mark.parametrize("alternate_sign", [False, True])
+def test_long_ngram_row_sparse_accumulator_matches_sklearn(
+    binary, alternate_sign
+):
+    # More than COMPACT_FEATURE_LIMIT generated n-grams forces the Rust
+    # accumulator onto its bounded sparse path.
+    document = " ".join(f"token{index}" for index in range(300))
+    _assert_close(
+        [document],
+        n_features=2**12,
+        ngram_range=(1, 3),
+        norm=None,
+        binary=binary,
+        alternate_sign=alternate_sign,
+    )
+
+
+def test_all_string_list_is_not_copied():
+    docs = ["hello", "world"]
+    assert _materialize_documents(docs) is docs
+    assert _to_docs(docs) is docs
+
+
+def test_materializes_common_containers():
+    assert _materialize_documents(("hello", "world")) == ["hello", "world"]
+    assert _materialize_documents(doc for doc in ("hello", "world")) == [
+        "hello",
+        "world",
+    ]
+    assert _materialize_documents(np.array(["hello", "world"])) == ["hello", "world"]
+
+    pl = pytest.importorskip("polars")
+    assert _materialize_documents(pl.Series(["hello", "world"])) == ["hello", "world"]
+
+
+def test_to_docs_decodes_bytes_without_coercing_other_values():
+    docs = ["hello", b"world"]
+    converted = _to_docs(docs)
+    assert converted == ["hello", "world"]
+    assert converted is not docs
+
+    for value in (None, np.nan, 42, object()):
+        with pytest.raises(TypeError, match="only str or bytes"):
+            _to_docs(["hello", value])
+
+
+def test_bytes_and_encoding_match_sklearn():
+    _assert_close([b"Hello WORLD", "hello world", b"caf\xc3\xa9 caf\xc3\xa9"])
+    _assert_close([b"caf\xe9 plain", "café plain"], encoding="latin-1")
+
+
+@pytest.mark.parametrize("decode_error", ["strict", "ignore", "replace"])
+def test_bytes_decode_error_matches_sklearn(decode_error):
+    _assert_matches_sklearn_behavior(
+        lambda: [b"invalid \xff bytes"],
+        params={"encoding": "utf-8", "decode_error": decode_error},
+    )
+
+
+def test_pandas_series_matches_sklearn():
+    pd = pytest.importorskip("pandas")
+    docs = pd.Series(_DOCS)
+    _assert_close(docs, n_features=2**18)
+
+
+def test_polars_series_matches_sklearn():
+    pl = pytest.importorskip("polars")
+    docs = pl.Series(_ASCII_DOCS)
+    _assert_close(docs, n_features=2**18)
+
+
+def test_generator_matches_sklearn():
+    got = _rust_csr((doc for doc in _DOCS), n_features=2**18)
+    ref = _sklearn_csr((doc for doc in _DOCS), n_features=2**18)
+    diff = abs(got - ref)
+    assert (diff.max() if diff.nnz else 0.0) <= 1e-6
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_error"),
+    [
+        (["valid ascii text", "another document"], None),
+        (["café déjà vu", "another document"], None),
+        (["valid ascii text", None], AttributeError),
+    ],
+    ids=["native", "unicode-fallback", "invalid-fallback"],
+)
+def test_one_shot_iterable_is_consumed_once(values, expected_error):
+    class OneShotDocuments:
+        def __init__(self, documents):
+            self.documents = documents
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            if self.iterations > 1:
+                raise AssertionError("documents were consumed more than once")
+            return iter(self.documents)
+
+    documents = OneShotDocuments(values)
+    vectorizer = RustyHashingVectorizer()
+    with stratum.config(rust_backend=True, allow_patch=True):
+        if expected_error is None:
+            vectorizer.transform(documents)
+        else:
+            with pytest.raises(expected_error):
+                vectorizer.transform(documents)
+    assert documents.iterations == 1
+
+
+def test_native_failure_is_logged_and_falls_back(
+    monkeypatch, caplog, capsys
+):
+    def failing_transform(*args, **kwargs):
+        raise RuntimeError("native test failure")
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", failing_transform)
+    vectorizer = RustyHashingVectorizer(n_features=2**10)
+    with (
+        caplog.at_level("WARNING"),
+        stratum.config(rust_backend=True, allow_patch=True),
+    ):
+        actual = vectorizer.transform(["plain ascii text"])
+
+    reference = OriginalHashingVectorizer(n_features=2**10).transform(
+        ["plain ascii text"]
+    )
+    _assert_csr_equal(actual, reference)
+    assert "falling back to sklearn" in caplog.text
+    assert "native test failure" in caplog.text
+    assert "WARNING" not in capsys.readouterr().out
+
+
+def test_native_memory_error_is_not_retried(monkeypatch):
+    def failing_transform(*args, **kwargs):
+        raise MemoryError("native allocation failed")
+
+    monkeypatch.setattr(rb, "hashing_vectorizer_transform", failing_transform)
+    vectorizer = RustyHashingVectorizer()
+    with (
+        stratum.config(rust_backend=True, allow_patch=True),
+        pytest.raises(MemoryError, match="native allocation failed"),
+    ):
+        vectorizer.transform(["plain ascii text"])
+
+
+def test_raw_string_uses_sklearn_validation():
+    enc = RustyHashingVectorizer()
+    with stratum.config(rust_backend=True, allow_patch=True):
+        with pytest.raises(ValueError, match="Iterable over raw text documents"):
+            enc.transform("not a corpus")
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"analyzer": "char"},
+        {"stop_words": "english"},
+        {"token_pattern": r"(?u)\b\w+\b"},
+        {"preprocessor": str.strip},
+        {"tokenizer": str.split},
+        {"strip_accents": "unicode"},
+        {"norm": "max"},
+        {"dtype": np.float16},
+    ],
+)
+def test_unsupported_configuration_falls_back(params):
+    params = {**params, "n_features": 2**16}
+    supported, reason = _rust_supported_subset(RustyHashingVectorizer(**params))
+    assert not supported, reason
+
+    _assert_matches_sklearn_behavior(
+        lambda: _ASCII_DOCS,
+        params=params,
+        atol=1e-6,
+    )
+
+
+def test_filename_input_falls_back_and_matches_sklearn(tmp_path):
+    paths = []
+    for index, document in enumerate(_ASCII_DOCS):
+        path = tmp_path / f"document-{index}.txt"
+        path.write_text(document)
+        paths.append(str(path))
+
+    supported, reason = _rust_supported_subset(
+        RustyHashingVectorizer(input="filename", n_features=2**12)
+    )
+    assert not supported
+    assert "input" in reason
+
+    _assert_matches_sklearn_behavior(
+        lambda: paths,
+        params={"input": "filename", "n_features": 2**12},
+    )
+
+
+def test_unsupported_gate_is_logged(caplog):
+    vectorizer = RustyHashingVectorizer(analyzer="char", n_features=2**10)
+    with (
+        caplog.at_level("DEBUG", logger="stratum.adapters.hashing_vectorizer"),
+        stratum.config(rust_backend=True, allow_patch=True),
+    ):
+        vectorizer.transform(["alpha beta"])
+    assert "HashingVectorizer Rust fallback" in caplog.text
+    assert "analyzer" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"encoding": None},
+        {"encoding": 123},
+        {"decode_error": None},
+        {"decode_error": 123},
+        {"decode_error": "bogus"},
+    ],
+)
+def test_invalid_encoding_parameters_match_sklearn(params):
+    _assert_matches_sklearn_behavior(
+        lambda: ["hello world"],
+        params=params,
+    )
+
+
+def test_patched_symbol_is_adapter():
+    import sklearn.feature_extraction.text as text_mod
+    import skrub
+    import skrub._string_encoder as string_encoder
+
+    assert text_mod.HashingVectorizer is RustyHashingVectorizer
+    assert skrub.HashingVectorizer is RustyHashingVectorizer
+    assert string_encoder.HashingVectorizer is RustyHashingVectorizer
+    assert stratum.HashingVectorizer is RustyHashingVectorizer

--- a/stratum/tests/adapters/test_rust_backend.py
+++ b/stratum/tests/adapters/test_rust_backend.py
@@ -346,3 +346,51 @@ class TestToList:
         result = _rust_backend._to_list(series)
         assert result == [1, 2, 3, 4, 5]
 
+    def test_to_list_falls_back_when_tolist_raises(self):
+        """Prefer to_list when tolist exists but fails."""
+        from stratum import _rust_backend
+
+        class TolistFails:
+            def tolist(self):
+                raise RuntimeError("tolist failed")
+
+            def to_list(self):
+                return ["via", "to_list"]
+
+            def __iter__(self):
+                raise AssertionError("list() iteration should not run")
+
+        assert _rust_backend._to_list(TolistFails()) == ["via", "to_list"]
+
+    def test_to_list_ignores_non_list_helper_results(self):
+        """Invalid scalar helper results preserve normal iteration errors."""
+        from stratum import _rust_backend
+
+        class ScalarTolist:
+            def tolist(self):
+                return "not a materialized document collection"
+
+            def to_list(self):
+                return 42
+
+            def __iter__(self):
+                raise TypeError("source is not iterable")
+
+        with pytest.raises(TypeError, match="source is not iterable"):
+            _rust_backend._to_list(ScalarTolist())
+
+    def test_to_list_falls_back_to_list_when_both_helpers_raise(self):
+        """Fall through to list() when tolist and to_list both fail."""
+        from stratum import _rust_backend
+
+        class BothFail:
+            def tolist(self):
+                raise RuntimeError("tolist failed")
+
+            def to_list(self):
+                raise RuntimeError("to_list failed")
+
+            def __iter__(self):
+                return iter(("a", "b"))
+
+        assert _rust_backend._to_list(BothFail()) == ["a", "b"]


### PR DESCRIPTION
  - Reimplement sklearn's HashingVectorizer in Rust: MurmurHash3 feature hashing, word tokenization / n-grams, parallel CSR assembly, binary features, alternate signing, lowercasing, and L1/L2 normalization.
  - Wire it through RustyHashingVectorizer with a narrow supported subset (default token pattern, ASCII content, float32/float64) and keep sklearn for everything else - Unicode, custom analyzers, stop words, accent stripping, and non-content input.
  - Patch the sklearn and skrub symbols; cover parity and fallbacks on both sides.

## Supported params (Rust Kernel)
  Requires defaults for `input="content"`, `analyzer="word"`, `token_pattern`, and `stop_words` / `preprocessor` / `tokenizer` / `strip_accents` all `None`. Documents must be 
  ASCII `str`/`bytes` (`encoding` / `decode_error` used for bytes).
  Supported: `lowercase`, `ngram_range`, `min_df`, `max_df`, `max_features` (TF tie on the cutoff → sklearn fallback; NumPy sort order is unstable), `vocabulary` (learned or 
  fixed string terms), `binary`, `dtype` in `{float32, float64}`, `norm` in `{None, "l1", "l2"}`, `use_idf`, `smooth_idf`, `sublinear_tf` (bool flags must be plain `bool`).
  ## Sklearn fallbacks
  `input` in `{filename, file}`, non-default analyzer/token pattern, stop words / custom hooks / accent stripping, Unicode docs, non-float dtypes, ambiguous `max_features`, 
  mutated fitted state, pickle.