### PR TITLE
[Map] fold missing-value masks into MissingMaskOp / MissingMaskExpr

### DIFF
--- a/stratum/optimizer/ir/_column_expr.py
+++ b/stratum/optimizer/ir/_column_expr.py
@@ -247,6 +247,40 @@ class UnaryOpExpr(ColumnExpr):
         return UnaryOpExpr(self.op, self.operand.remap_operand_refs(mapping))
 
 
+class MissingMaskExpr(ColumnExpr):
+    """Missing-value-mask predicate applied to a frame-like object expression."""
+
+    __slots__ = ("operand", "positive")
+
+    def __init__(self, operand: ColumnExpr, positive: bool):
+        self.operand = operand
+        self.positive = positive
+
+    def _key(self):
+        return (self.operand, self.positive)
+
+    def __repr__(self):
+        name = "isnull" if self.positive else "notnull"
+        return f"{name}({self.operand!r})"
+
+    def to_pandas(self, ctx):
+        obj = self.operand.to_pandas(ctx)
+        return pd.isnull(obj) if self.positive else pd.notnull(obj)
+
+    def to_polars(self, ctx):
+        obj = self.operand.to_polars(ctx)
+        if isinstance(obj, pl.DataFrame):
+            return pl.all().is_null() if self.positive else pl.all().is_not_null()
+        return obj.is_null() if self.positive else obj.is_not_null()
+
+    def iter_operand_refs(self):
+        yield from self.operand.iter_operand_refs()
+
+    def remap_operand_refs(self, mapping):
+        return MissingMaskExpr(
+            self.operand.remap_operand_refs(mapping), self.positive)
+
+
 class StrExpr(ColumnExpr):
     """String accessor call (``.str.<method>()``)."""
     __slots__ = ("operand", "method", "args", "kwargs")
@@ -397,6 +431,9 @@ class _Folder:
 
     def _is_foldable(self, node: Op) -> bool:
         """Return whether ``node`` can be represented as a ``ColumnExpr``."""
+        # Local import avoids a cycle because _map_ops imports this module.
+        from stratum.optimizer.ir._map_ops import MissingMaskOp
+
         if isinstance(node, BinOp):
             return node.op in BINARY_SYMBOLS
         if isinstance(node, UnaryOp):
@@ -419,6 +456,8 @@ class _Folder:
             # Only the fused datetime accessor (.dt.<attr>); .str is already fused
             # into StringMethodOp during frame extraction.
             return len(node.attr_name) == 2 and node.attr_name[0] == "dt"
+        if isinstance(node, MissingMaskOp):
+            return len(node.inputs) == 1
         return False
 
     @staticmethod
@@ -429,6 +468,8 @@ class _Folder:
 
     def _producer_ops(self, node: Op) -> list[Op]:
         """Return foldable operand producers for ``node``."""
+        from stratum.optimizer.ir._map_ops import MissingMaskOp
+
         if isinstance(node, BinOp):
             return [node.inputs[r.k] for r in (node.left, node.right)
                     if isinstance(r, OperandRef)]
@@ -438,6 +479,8 @@ class _Folder:
             return []
         if isinstance(node, (StringMethodOp, DatetimeConversionOp,
                              GetAttrProjectionOp)):
+            return [node.inputs[0]]
+        if isinstance(node, MissingMaskOp):
             return [node.inputs[0]]
         return []
 
@@ -517,6 +560,8 @@ class _Folder:
 
     def _make_expr(self, node: Op, absorbable: set[int],
                    memo: dict[int, ColumnExpr]) -> ColumnExpr:
+        from stratum.optimizer.ir._map_ops import MissingMaskOp
+
         if isinstance(node, BinOp):
             return BinOpExpr(node.op,
                              self._operand(node.left, node, absorbable, memo),
@@ -539,6 +584,9 @@ class _Folder:
         if isinstance(node, GetAttrProjectionOp):
             operand = self._resolve(node.inputs[0], absorbable, memo)
             return DtExpr(operand, node.attr_name[1])
+        if isinstance(node, MissingMaskOp):
+            operand = self._resolve(node.inputs[0], absorbable, memo)
+            return MissingMaskExpr(operand, node.positive)
         raise AssertionError(f"unfoldable node reached _make_expr: {node!r}")
 
     def _operand(self, operand, parent: Op, absorbable: set[int],

--- a/stratum/optimizer/ir/_dataframe_ops.py
+++ b/stratum/optimizer/ir/_dataframe_ops.py
@@ -22,7 +22,9 @@ from stratum.optimizer.ir._projection_ops import (
     StringMethodOp, make_column_projection_op, make_column_selector_op,
     make_datetime_conversion_op, make_frame_get_attr, make_string_method_op,
     resolve_selector_columns)
-from stratum.optimizer.ir._map_ops import MapOp, AssignMapOp, make_assign_map_op
+from stratum.optimizer.ir._map_ops import (
+    MISSING_FUNCTIONS, MISSING_METHODS, AssignMapOp, MapOp, MissingMaskOp,
+    make_assign_map_op, make_missing_mask_op)
 from stratum.optimizer.ir._join_ops import (
     JoinOp, _MERGE_POSITIONAL, _JOIN_POSITIONAL, _JOIN_OP_FIELDS, make_join_op,
     _make_chained_join_op)
@@ -106,12 +108,16 @@ def extract_dataframe_op(op: Op, root: Op, selection_op = True, map_op = True,
     # input is frame-world data (a frame or a series): this is a dataframe op
     else:
         if isinstance(op, CallOp):
+            if map_op and op.func in MISSING_FUNCTIONS:
+                new_op = make_missing_mask_op(op)
             # Datetime conversion detection
-            if op.func is pd.to_datetime:
+            elif op.func is pd.to_datetime:
                 new_op = make_datetime_conversion_op(op)
 
         elif isinstance(op, MethodCallOp):
-            if isinstance(op.inputs[0], GetAttrProjectionOp) and op.inputs[0].attr_name == ["str"]:
+            if map_op and op.method_name in MISSING_METHODS:
+                new_op = make_missing_mask_op(op)
+            elif isinstance(op.inputs[0], GetAttrProjectionOp) and op.inputs[0].attr_name == ["str"]:
                 # `col.str.<method>(...)` -> fuse the .str accessor and the method
                 # call into a single StringMethodOp (a SERIES-typed projection). An
                 # enclosing `df[...]` then sees a mask and folds the chain into a
@@ -136,7 +142,7 @@ def extract_dataframe_op(op: Op, root: Op, selection_op = True, map_op = True,
                 # keep the input's kind (ProjectionOp defaults to FRAME).
                 new_op.output_type = op.inputs[0].output_type
                 op.replace_output_of_inputs(new_op)
-            elif op.method_name in ["assign"]:
+            elif op.method_name == "assign":
                 if map_op:
                     new_op = make_assign_map_op(op)
                 if new_op is None:

--- a/stratum/optimizer/ir/_map_ops.py
+++ b/stratum/optimizer/ir/_map_ops.py
@@ -7,8 +7,10 @@ restricted to natively-lazy computations (arithmetic, boolean logic,
 into one ``with_columns`` kernel. Anything outside the grammar stays in the
 graph and feeds the map through an ``OperandLeaf`` input.
 
-:class:`AssignMapOp` -- from ``df.assign(...)`` -- is the only map kind so far:
-named, series-valued entries, with input columns passing through.
+The concrete map kinds currently are:
+
+* :class:`AssignMapOp` for named, series-valued ``df.assign(...)`` entries.
+* :class:`MissingMaskOp` for pandas missing-value predicates.
 """
 from __future__ import annotations
 
@@ -17,7 +19,14 @@ import polars as pl
 
 from stratum.optimizer.ir._column_expr import (ColumnExpr, Const, EvalContext,
                                                _Folder)
-from stratum.optimizer.ir._ops import (MethodCallOp, Op, OperandRef, OutputType)
+from stratum.optimizer.ir._ops import (CallOp, MethodCallOp, Op, OperandRef,
+                                       OutputType)
+
+
+MISSING_METHODS = ("isna", "isnull", "notna", "notnull")
+POSITIVE_MISSING_METHODS = ("isna", "isnull")
+MISSING_FUNCTIONS = (pd.isna, pd.isnull, pd.notna, pd.notnull)
+POSITIVE_MISSING_FUNCTIONS = (pd.isna, pd.isnull)
 
 
 class MapOp(Op):
@@ -30,6 +39,20 @@ class MapOp(Op):
 
     def make_context(self, mode: str, inputs: list) -> EvalContext:
         return EvalContext(frame=inputs[0], inputs=inputs, mode=mode)
+
+
+class MissingMaskOp(MapOp):
+    """A missing-value predicate such as .isnull()/isna() on a frame or series."""
+
+    fields = ["positive"]
+
+    def __init__(self, positive: bool,
+                 inputs: list[Op] = None, outputs: list[Op] = None):
+        super().__init__(name="isnull" if positive else "notnull",
+                         inputs=inputs, outputs=outputs)
+        self.positive = positive
+        if inputs:
+            self.output_type = inputs[0].output_type
 
 
 class AssignMapOp(MapOp):
@@ -113,3 +136,54 @@ def make_assign_map_op(op: MethodCallOp) -> AssignMapOp | None:
                          inputs=[src, *folder.leaf_ops], outputs=list(op.outputs))
     _detach_absorbed_and_rewire(op, new_op, folder)
     return new_op
+
+
+def _make_method_missing_mask_op(op: MethodCallOp, positive: bool) -> MissingMaskOp | None:
+    """Build a mask from a bound call such as ``series.isna()``.
+
+    The object before the method is stored as the call's only input.
+    """
+    if op.args or op.kwargs or len(op.inputs) != 1:
+        return None
+
+    new_op = MissingMaskOp(positive=positive, inputs=[op.inputs[0]], outputs=list(op.outputs))
+    op.replace_output_of_inputs(new_op)
+    return new_op
+
+
+def _make_call_missing_mask_op(op: CallOp, positive: bool) -> MissingMaskOp | None:
+    """Build a missing mask from ``pd.isna(obj)`` or ``pd.isna(obj=obj)``."""
+    args = tuple(op.args or ())
+    kwargs = dict(op.kwargs or {})
+
+    if len(args) == 1 and not kwargs:
+        operand_ref = args[0]
+    elif not args and set(kwargs) == {"obj"}:
+        operand_ref = kwargs["obj"]
+    else:
+        return None
+
+    if not isinstance(operand_ref, OperandRef):
+        return None
+
+    new_op = MissingMaskOp(positive=positive, inputs=[op.inputs[operand_ref.k]], outputs=list(op.outputs))
+    op.replace_output_of_inputs(new_op)
+    return new_op
+
+
+def make_missing_mask_op(op: MethodCallOp | CallOp) -> MissingMaskOp | None:
+    """Extract bound-method and standalone pandas missing-value calls."""
+    if isinstance(op, MethodCallOp):
+        method_name = op.method_name
+        if method_name not in MISSING_METHODS:
+            return None
+        positive = method_name in POSITIVE_MISSING_METHODS
+        return _make_method_missing_mask_op(op, positive)
+
+    if isinstance(op, CallOp):
+        if op.func not in MISSING_FUNCTIONS:
+            return None
+        positive = op.func in POSITIVE_MISSING_FUNCTIONS
+        return _make_call_missing_mask_op(op, positive)
+
+    return None

--- a/stratum/optimizer/physical/_map_execs.py
+++ b/stratum/optimizer/physical/_map_execs.py
@@ -1,10 +1,7 @@
-"""Physical implementations of ``AssignMapOp`` (folded column-map).
+"""Physical implementations of folded column-map operators.
 
-Same-shape backend-variant family: the concrete impls subclass ``AssignMapOp``
-(+ :class:`PhysicalOp`) and carry the backend-specific kernel. On polars every
-folded entry runs in one ``with_columns`` call; on pandas they go through
-``assign``. The backend-agnostic ``ColumnExpr`` folding and ``make_context``
-stay on the logical side.
+The concrete implementations subclass their logical map operator together with
+:class:`PhysicalOp` and carry only the backend-specific kernel.
 """
 from __future__ import annotations
 
@@ -13,7 +10,7 @@ import logging
 import pandas as pd
 import polars as pl
 
-from stratum.optimizer.ir._map_ops import AssignMapOp
+from stratum.optimizer.ir._map_ops import AssignMapOp, MissingMaskOp
 from stratum.optimizer.physical._physical_ops import PhysicalOp
 from stratum.optimizer.physical._registry import physical_impl
 
@@ -47,3 +44,22 @@ class PolarsAssignMapOp(AssignMapOp, PhysicalOp):
         # The keyword API accepts expressions, series, arrays and scalars,
         # broadcasting the latter just like pandas.DataFrame.assign.
         return ctx.frame.with_columns(**columns)
+
+
+# Polars treats native NaN values separately from null values.
+@physical_impl(of=MissingMaskOp, backend="pandas")
+class PandasMissingMaskOp(MissingMaskOp, PhysicalOp):
+    def process(self, mode: str, inputs: list):
+        obj = inputs[0]
+        return pd.isnull(obj) if self.positive else pd.notnull(obj)
+
+
+@physical_impl(of=MissingMaskOp, backend="polars")
+class PolarsMissingMaskOp(MissingMaskOp, PhysicalOp):
+    def process(self, mode: str, inputs: list):
+        obj = inputs[0]
+        if isinstance(obj, pl.DataFrame):
+            predicate = (pl.all().is_null() if self.positive
+                         else pl.all().is_not_null())
+            return obj.select(predicate)
+        return obj.is_null() if self.positive else obj.is_not_null()

--- a/stratum/optimizer/physical/_registry.py
+++ b/stratum/optimizer/physical/_registry.py
@@ -3,7 +3,45 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 
+from stratum.optimizer.ir._aggregation_ops import AggregateOp, GroupedDataframeOp
 from stratum.optimizer.ir._base import IRNode
+from stratum.optimizer.ir._dataframe_ops import (
+    ApplyUDFOp,
+    AssignMapOp,
+    AssignOp,
+    ColumnProjectionOp,
+    ColumnSelectorOp,
+    ConcatOp,
+    DatetimeConversionOp,
+    DropOp,
+    GetAttrProjectionOp,
+    MapOp,
+    MetadataOp,
+    MissingMaskOp,
+    ProjectionOp,
+    SelectionOp,
+    SplitOp,
+    SplitOutput,
+    StringMethodOp,
+)
+from stratum.optimizer.ir._join_ops import JoinOp
+from stratum.optimizer.ir._numeric_ops import NumericOp
+from stratum.optimizer.ir._ops import (
+    BaseEstimatorOp,
+    BinOp,
+    CallOp,
+    ChoiceOp,
+    GetAttrOp,
+    GetItemOp,
+    ImplOp,
+    MethodCallOp,
+    Op,
+    PredictorOp,
+    SearchEvalOp,
+    TransformerOp,
+    ValueOp,
+    VariableOp,
+)
 BackendName = str
 
 
@@ -51,6 +89,84 @@ class RustPhysicalImpl(PhysicalImpl):
     data_parallel: bool = False
 
 
+"""Operator family used to keep the registry extensible."""
+@dataclass(frozen=True, slots=True)
+class OperatorFamily:
+    name: str
+    op_types: tuple[type[IRNode], ...]
+    default_backends: tuple[BackendName, ...] = ()
+    notes: str = ""
+
+
+"""A physical execution backend understood by the registry."""
+@dataclass(frozen=True, slots=True)
+class BackendSpec:
+    name: str
+    notes: str = ""
+
+
+# FIXME: Only list the stratum's logical operators after compilation from skrub IR
+# these will be replaced by the general physical operators (once they are here), and
+# will be lowered to specific physical op implementations. Types leave this list as
+# their family migrates to the physical layer (sources already have: DataSourceOp is
+# lowered away and its physical types live in the "sources" family instead).
+CURRENT_LOGICAL_OPERATOR_TYPES: tuple[type[Op], ...] = (
+    AggregateOp,
+    ApplyUDFOp,
+    AssignMapOp,
+    AssignOp,
+    BaseEstimatorOp,
+    BinOp,
+    CallOp,
+    ChoiceOp,
+    ColumnProjectionOp,
+    ColumnSelectorOp,
+    ConcatOp,
+    DatetimeConversionOp,
+    DropOp,
+    PredictorOp,
+    GetAttrOp,
+    GetAttrProjectionOp,
+    GetItemOp,
+    GroupedDataframeOp,
+    ImplOp,
+    JoinOp,
+    MapOp,
+    MetadataOp,
+    MethodCallOp,
+    MissingMaskOp,
+    NumericOp,
+    ProjectionOp,
+    SearchEvalOp,
+    SelectionOp,
+    SplitOp,
+    SplitOutput,
+    StringMethodOp,
+    TransformerOp,
+    ValueOp,
+    VariableOp,
+)
+
+
+CURRENT_BACKENDS: tuple[BackendSpec, ...] = (
+    BackendSpec("pandas", "Pandas dataframe implementation."),
+    BackendSpec("polars", "Polars dataframe implementation."),
+    BackendSpec("numpy", "NumPy array implementation."),
+    BackendSpec("sklearn-skrub", "Existing sklearn/skrub implementation."),
+    BackendSpec("rust", "Native Rust implementation selected like any other backend."),
+)
+
+
+CURRENT_OPERATOR_FAMILIES: tuple[OperatorFamily, ...] = (
+    OperatorFamily(
+        name="logical",
+        op_types=CURRENT_LOGICAL_OPERATOR_TYPES,
+        default_backends=tuple(backend.name for backend in CURRENT_BACKENDS),
+        notes="Current logical IR surface; backends are attached later by the planner.",
+    ),
+)
+
+
 def _unsupported_supports(op: IRNode, ctx: Any) -> bool:
     return False
 
@@ -79,26 +195,43 @@ def _placeholder_exec_mem(op: IRNode, stats: Any) -> int:
     return 0
 
 
-"""Dictionary for physical implementations keyed by operator type.
-Extensibile to support new backends. """
+"""Container for physical implementations and their operator families."""
 class PhysicalRegistry:
     def __init__(
         self,
+        families: Iterable[OperatorFamily] = (),
         implementations: Iterable[PhysicalImpl] = (),
     ) -> None:
+        self._families: list[OperatorFamily] = list(families)
         self._implementations: dict[type[IRNode], list[PhysicalImpl]] = {}
         self._implementations_by_backend: dict[BackendName, list[PhysicalImpl]] = {}
         for impl in implementations:
             self.register(impl)
+
+    def register_family(self, family: OperatorFamily) -> None:
+        self._families.append(family)
 
     def register(self, impl: PhysicalImpl) -> PhysicalImpl:
         self._implementations.setdefault(impl.op_type, []).append(impl)
         self._implementations_by_backend.setdefault(impl.backend_name, []).append(impl)
         return impl
 
+    def families(self) -> tuple[OperatorFamily, ...]:
+        return tuple(self._families)
+
     def op_types(self) -> tuple[type[IRNode], ...]:
-        """Return operator types with at least one registered implementation."""
-        return tuple(self._implementations)
+        types: list[type[IRNode]] = []
+        seen: set[type[IRNode]] = set()
+        for family in self._families:
+            for op_type in family.op_types:
+                if op_type not in seen:
+                    seen.add(op_type)
+                    types.append(op_type)
+        for op_type in self._implementations:
+            if op_type not in seen:
+                seen.add(op_type)
+                types.append(op_type)
+        return tuple(types)
 
     def candidates_for(
         self,
@@ -111,6 +244,7 @@ class PhysicalRegistry:
             candidates = [impl for impl in candidates if impl.backend_name == backend_name]
         return tuple(candidates)
 
+    """Return the physical implementations available for a given operator."""
     def candidates_for_op(
         self,
         op: IRNode,

--- a/stratum/tests/logical_optimizer/test_map_ops.py
+++ b/stratum/tests/logical_optimizer/test_map_ops.py
@@ -8,13 +8,16 @@ import polars as pl
 
 import stratum as st
 from stratum.optimizer._optimize import OptConfig
-from stratum.optimizer.ir._map_ops import AssignMapOp
+from stratum.optimizer.ir._map_ops import (
+    AssignMapOp, MissingMaskOp, make_missing_mask_op)
 from stratum.optimizer.ir._projection_ops import (
     AssignOp, DatetimeConversionOp, GetAttrProjectionOp)
+from stratum.optimizer.ir._selection_ops import SelectionOp
 from stratum.optimizer.ir._column_expr import (
-    BinOpExpr, Col, Const, DatetimeExpr, DtExpr, OperandLeaf, StrExpr, _Folder)
+    BinOpExpr, Col, Const, DatetimeExpr, DtExpr, EvalContext, MissingMaskExpr,
+    OperandLeaf, StrExpr, _Folder)
 from stratum.optimizer.ir._ops import (
-    BinOp, GetItemOp, Op, OperandRef, UnaryOp)
+    BinOp, CallOp, GetItemOp, MethodCallOp, Op, OperandRef, OutputType, UnaryOp)
 from stratum.tests.logical_optimizer.test_dataframe_ops import (
     optimize, run_op, force_polars, make_map_op)
 
@@ -132,6 +135,304 @@ class TestAssignMapFolding(unittest.TestCase):
         map_op = _one(self, ops, AssignMapOp)
         self.assertIsInstance(map_op.entries["parsed"], OperandLeaf)
         _one(self, ops, DatetimeConversionOp)
+
+
+class TestMissingMaskOp(unittest.TestCase):
+    def setUp(self):
+        self.df = pd.DataFrame({"a": [1.0, np.nan]})
+
+    def test_bound_method_extracts(self):
+        src = st.as_data_op(self.df)
+        ops = optimize(src["a"].isna(), OptConfig(dataframe_ops=True))
+        mask_op = _one(self, ops, MissingMaskOp)
+        self.assertTrue(mask_op.positive)
+        self.assertEqual(OutputType.SERIES, mask_op.output_type)
+
+    def test_standalone_function_extracts(self):
+        src = st.as_data_op(self.df)
+        out = src["a"].skb.apply_func(pd.notna)
+        mask_op = _one(
+            self, optimize(out, OptConfig(dataframe_ops=True)), MissingMaskOp)
+        self.assertFalse(mask_op.positive)
+
+    def test_standalone_function_accepts_obj_keyword(self):
+        src = Op()
+        src.output_type = OutputType.FRAME
+        call = CallOp(func=pd.isna, args=(), kwargs={"obj": OperandRef(0)})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        mask_op = make_missing_mask_op(call)
+
+        self.assertIsInstance(mask_op, MissingMaskOp)
+        self.assertTrue(mask_op.positive)
+        self.assertEqual([src], mask_op.inputs)
+
+    def test_missing_mask_folds_into_assign(self):
+        src = st.as_data_op(self.df)
+        out = src.assign(missing=src["a"].isnull())
+        ops = optimize(out, OptConfig(dataframe_ops=True))
+        map_op = _one(self, ops, AssignMapOp)
+        self.assertEqual(
+            MissingMaskExpr(Col("a"), True), map_op.entries["missing"])
+        self.assertEqual([], [op for op in ops if isinstance(op, MissingMaskOp)])
+
+    def test_missing_mask_folds_into_selection(self):
+        src = st.as_data_op(self.df)
+        ops = optimize(src[src["a"].isna()], OptConfig(dataframe_ops=True))
+        selection = _one(self, ops, SelectionOp)
+        self.assertEqual(
+            MissingMaskExpr(Col("a"), True), selection.predicate)
+        self.assertEqual([], [op for op in ops if isinstance(op, MissingMaskOp)])
+
+    def test_standalone_execution(self):
+        result = run_op(MissingMaskOp(True), self.df["a"])
+        self.assertEqual([False, True], result.tolist())
+
+    def test_series_execution_polars(self):
+        series = pl.Series("a", [1.0, None, 3.0])
+
+        # A standalone mask is executed by the physical MissingMaskOp.
+        with force_polars():
+            positive_result = run_op(MissingMaskOp(True), series)
+            negative_result = run_op(MissingMaskOp(False), series)
+
+        self.assertEqual(
+            [False, True, False], positive_result.to_list())
+        self.assertEqual(
+            [True, False, True], negative_result.to_list())
+
+    def test_dataframe_execution_polars(self):
+        frame = pl.DataFrame({
+            "a": [1.0, None],
+            "b": [None, "value"],
+        })
+
+        # DataFrame masks apply the predicate to every column.
+        with force_polars():
+            positive_result = run_op(MissingMaskOp(True), frame)
+            negative_result = run_op(MissingMaskOp(False), frame)
+
+        positive_expected = {
+            "a": [False, True],
+            "b": [True, False],
+        }
+        negative_expected = {
+            "a": [True, False],
+            "b": [False, True],
+        }
+        self.assertEqual(
+            positive_expected, positive_result.to_dict(as_series=False))
+        self.assertEqual(
+            negative_expected, negative_result.to_dict(as_series=False))
+
+    # --- make_missing_mask_op: rejection contract ---------------------------
+
+    def test_bound_method_rejects_positional_args(self):
+        src = Op()
+        call = MethodCallOp("isna", args=(1,), kwargs={})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_bound_method_rejects_kwargs(self):
+        src = Op()
+        call = MethodCallOp("isna", args=(), kwargs={"foo": 1})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_bound_method_rejects_multiple_inputs(self):
+        src, other = Op(), Op()
+        call = MethodCallOp("isna", args=(), kwargs={})
+        call.inputs = [src, other]
+        src.outputs = [call]
+        other.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_standalone_function_rejects_missing_obj(self):
+        src = Op()
+        call = CallOp(func=pd.isna, args=(), kwargs={})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_standalone_function_rejects_positional_and_keyword_obj(self):
+        src = Op()
+        call = CallOp(func=pd.isna, args=(OperandRef(0),),
+                      kwargs={"obj": OperandRef(0)})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_standalone_function_rejects_multiple_positional_args(self):
+        src, other = Op(), Op()
+        call = CallOp(func=pd.isna, args=(OperandRef(0), OperandRef(1)), kwargs={})
+        call.inputs = [src, other]
+        src.outputs = [call]
+        other.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_standalone_function_rejects_non_operand_ref(self):
+        src = Op()
+        call = CallOp(func=pd.isna, args=(42,), kwargs={})
+        call.inputs = [src]
+        src.outputs = [call]
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_unrelated_method_call_rejected(self):
+        call = MethodCallOp("sum", args=(), kwargs={})
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_unrelated_call_rejected(self):
+        call = CallOp(func=pd.to_datetime, args=(), kwargs={})
+
+        self.assertIsNone(make_missing_mask_op(call))
+
+    def test_plain_op_rejected(self):
+        self.assertIsNone(make_missing_mask_op(Op()))
+
+
+class TestMissingMaskExpr(unittest.TestCase):
+    def setUp(self):
+        self.pandas_series_frame = pd.DataFrame({
+            "a": [1.0, None, 3.0],
+        })
+        self.polars_series_frame = pl.DataFrame({
+            "a": [1.0, None, 3.0],
+        })
+        self.pandas_frame = pd.DataFrame({
+            "a": [1.0, None],
+            "b": [None, "value"],
+        })
+        self.polars_frame = pl.DataFrame({
+            "a": [1.0, None],
+            "b": [None, "value"],
+        })
+
+    def test_equality_and_hash(self):
+        first = MissingMaskExpr(Col("a"), True)
+        second = MissingMaskExpr(Col("a"), True)
+        different_positive = MissingMaskExpr(Col("a"), False)
+        different_operand = MissingMaskExpr(Col("b"), True)
+
+        self.assertEqual(first, second)
+        self.assertEqual(hash(first), hash(second))
+        self.assertNotEqual(first, different_positive)
+        self.assertNotEqual(first, different_operand)
+
+    def test_repr_contains_method_and_operand(self):
+        expression = MissingMaskExpr(Col("a"), True)
+
+        self.assertEqual("isnull(Col('a'))", repr(expression))
+
+    def test_iter_operand_refs(self):
+        leaf = OperandLeaf(OperandRef(2))
+        expression = MissingMaskExpr(leaf, True)
+
+        refs = list(expression.iter_operand_refs())
+
+        self.assertEqual([2], [ref.k for ref in refs])
+
+    def test_remap_operand_refs(self):
+        leaf = OperandLeaf(OperandRef(2))
+        expression = MissingMaskExpr(leaf, False)
+
+        remapped = expression.remap_operand_refs({2: 1})
+
+        expected = MissingMaskExpr(OperandLeaf(OperandRef(1)), False)
+        self.assertEqual(expected, remapped)
+        self.assertEqual([2], [ref.k for ref in expression.iter_operand_refs()])
+
+    def test_series_execution_pandas(self):
+        positive_expression = MissingMaskExpr(Col("a"), True)
+        negative_expression = MissingMaskExpr(Col("a"), False)
+        context = EvalContext(
+            frame=self.pandas_series_frame,
+            inputs=[self.pandas_series_frame],
+        )
+
+        positive_result = positive_expression.to_pandas(context)
+        negative_result = negative_expression.to_pandas(context)
+
+        self.assertEqual([False, True, False], positive_result.tolist())
+        self.assertEqual([True, False, True], negative_result.tolist())
+
+    def test_series_execution_polars(self):
+        positive_expression = MissingMaskExpr(Col("a"), True)
+        negative_expression = MissingMaskExpr(Col("a"), False)
+        context = EvalContext(
+            frame=self.polars_series_frame,
+            inputs=[self.polars_series_frame],
+        )
+
+        positive_result_expression = positive_expression.to_polars(context)
+        negative_result_expression = negative_expression.to_polars(context)
+        result = self.polars_series_frame.select(
+            positive_result_expression.alias("positive"),
+            negative_result_expression.alias("negative"),
+        )
+
+        self.assertEqual([False, True, False], result["positive"].to_list())
+        self.assertEqual([True, False, True], result["negative"].to_list())
+
+    def test_dataframe_execution_pandas(self):
+        leaf = OperandLeaf(OperandRef(0))
+        positive_expression = MissingMaskExpr(leaf, True)
+        negative_expression = MissingMaskExpr(leaf, False)
+        context = EvalContext(
+            frame=self.pandas_frame,
+            inputs=[self.pandas_frame],
+        )
+
+        positive_result = positive_expression.to_pandas(context)
+        negative_result = negative_expression.to_pandas(context)
+        positive_expected = pd.DataFrame({
+            "a": [False, True],
+            "b": [True, False],
+        })
+        negative_expected = pd.DataFrame({
+            "a": [True, False],
+            "b": [False, True],
+        })
+
+        pd.testing.assert_frame_equal(positive_expected, positive_result)
+        pd.testing.assert_frame_equal(negative_expected, negative_result)
+
+    def test_dataframe_execution_polars(self):
+        leaf = OperandLeaf(OperandRef(0))
+        positive_expression = MissingMaskExpr(leaf, True)
+        negative_expression = MissingMaskExpr(leaf, False)
+        context = EvalContext(
+            frame=self.polars_frame,
+            inputs=[self.polars_frame],
+        )
+
+        positive_result_expression = positive_expression.to_polars(context)
+        negative_result_expression = negative_expression.to_polars(context)
+        positive_result = self.polars_frame.select(positive_result_expression)
+        negative_result = self.polars_frame.select(negative_result_expression)
+        positive_expected = {
+            "a": [False, True],
+            "b": [True, False],
+        }
+        negative_expected = {
+            "a": [True, False],
+            "b": [False, True],
+        }
+
+        self.assertEqual(
+            positive_expected, positive_result.to_dict(as_series=False))
+        self.assertEqual(
+            negative_expected, negative_result.to_dict(as_series=False))
 
 
 class TestAssignMapProcess(unittest.TestCase):
@@ -308,6 +609,71 @@ class TestFolderEdgeCases(unittest.TestCase):
 def polars(request):
     with force_polars(request.param):
         yield request.param
+
+
+@pytest.mark.parametrize(
+    "method_name, expected",
+    [
+        ("isna", [False, True, False]),
+        ("isnull", [False, True, False]),
+        ("notna", [True, False, True]),
+        ("notnull", [True, False, True]),
+    ],
+)
+def test_missing_mask_pipeline_evaluates(polars, method_name, expected):
+    df = pd.DataFrame({"a": [1.0, None, 3.0]})
+    src = st.as_data_op(df)
+    column = src["a"]
+    missing_method = getattr(column, method_name)
+    out = src.assign(missing=missing_method())
+
+    ops = optimize(out, OptConfig(dataframe_ops=True))
+    map_op = _one(unittest.TestCase(), ops, AssignMapOp)
+    positive = method_name in ("isna", "isnull")
+    expected_expression = MissingMaskExpr(Col("a"), positive)
+    assert expected_expression == map_op.entries["missing"]
+    assert [] == [op for op in ops if isinstance(op, MissingMaskOp)]
+
+    result = st._api.evaluate(out)
+
+    assert expected == list(result["missing"])
+
+
+def test_nested_missing_mask_pipeline_evaluates(polars):
+    df = pd.DataFrame({
+        "a": [2.0, 4.0, 6.0],
+        "b": [1.0, None, 3.0],
+    })
+    src = st.as_data_op(df)
+    ratio = src["a"] / src["b"]
+    out = src.assign(missing=ratio.isnull())
+
+    ops = optimize(out, OptConfig(dataframe_ops=True))
+    map_op = _one(unittest.TestCase(), ops, AssignMapOp)
+    expected_expression = MissingMaskExpr(
+        BinOpExpr(operator.truediv, Col("a"), Col("b")),
+        True,
+    )
+    assert expected_expression == map_op.entries["missing"]
+
+    result = st._api.evaluate(out)
+
+    assert [False, True, False] == list(result["missing"])
+
+
+def test_missing_mask_selection_pipeline_evaluates(polars):
+    df = pd.DataFrame({"a": [1.0, None, 3.0]})
+    src = st.as_data_op(df)
+    out = src[src["a"].notnull()]
+
+    ops = optimize(out, OptConfig(dataframe_ops=True))
+    selection = _one(unittest.TestCase(), ops, SelectionOp)
+    expected_expression = MissingMaskExpr(Col("a"), False)
+    assert expected_expression == selection.predicate
+
+    result = st._api.evaluate(out)
+
+    assert [1.0, 3.0] == list(result["a"])
 
 
 def test_assign_pipeline_evaluates(polars):


### PR DESCRIPTION
## Summary

- Extract pandas `isna`/`isnull` and `notna`/`notnull` calls into a dedicated `MissingMaskOp`.
- Fold missing-value operations into backend-agnostic `MissingMaskExpr` column expressions.
- Execute standalone missing masks through dedicated Pandas and Polars physical operators.
- Support folded missing masks in assignments, selections, and nested column expressions.
- Add unit and end-to-end coverage for aliases, rejection paths, Series and DataFrame inputs, expression remapping, and both backends.

## Impact

Expressions such as `df["a"].isnull()`, `pd.notna(df["a"])`, nested missing masks, and masks used by `assign` or row selection can now be recognized and executed through the selected Pandas or Polars backend.

## Known limitations

- Polars distinguishes native `NaN` values from null values, so native Polars `NaN` does not yet match pandas `isnull()` semantics.
- Cloning a Series-valued `MissingMaskOp` does not yet preserve its `OutputType.SERIES` value.