### PR TITLE
Initial commits for default and greedy operator implementation selectors

### DIFF
--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -20,13 +20,28 @@ def _env_int(name, default=0):
     return int(v) if v is not None else int(default)
 
 
-#: IR levels the optimizer can print a linear plan for, in pipeline order:
+#: IR levels the optimizer can print a linear plan for:
 #: ``logical`` (after logical rewrites), ``physical`` (after lowering) and
-#: ``physical_impl`` (after implementation selection -- the executable plan).
+#: ``physical_impl`` (after implementation selection, i.e.,  the executable plan).
 EXPLAIN_LEVELS = ("logical", "physical", "physical_impl")
+IMPLEMENTATION_SELECTOR_MODES = ("default",)
 
 
-def _normalize_explain(value) -> tuple[str, ...]:
+def _read_implementation_selector(value: str) -> str:
+    """Read and validate the configured implementation-selector mode."""
+    if not isinstance(value, str):
+        raise ValueError(
+            "implementation_selector must be one of "
+            f"{list(IMPLEMENTATION_SELECTOR_MODES)}, got {value!r}.")
+    mode = value.strip().lower()
+    if mode not in IMPLEMENTATION_SELECTOR_MODES:
+        raise ValueError(
+            "Invalid implementation_selector "
+            f"{value!r}; valid modes are {list(IMPLEMENTATION_SELECTOR_MODES)}.")
+    return mode
+
+
+def _read_explain_levels(value) -> tuple[str, ...]:
     """Coerce the ``explain`` config into a tuple of IR levels to print.
 
     ``None``/``False`` -> off; ``True`` -> the executable plan only
@@ -44,6 +59,7 @@ def _normalize_explain(value) -> tuple[str, ...]:
     return levels
 
 
+# FIXME: Not all flags need environment variables, only the ones that are shared across backends
 @dataclass
 class _Flags:
     rust_backend: bool = _env_bool("SKRUB_RUST", False)
@@ -59,6 +75,8 @@ class _Flags:
     cse: bool = True
     DEBUG: bool = False
     force_polars: bool = _env_bool("STRATUM_FORCE_POLARS", False)
+    implementation_selector: str = _read_implementation_selector(
+        os.getenv("STRATUM_IMPLEMENTATION_SELECTOR", "default"))
     pandas_query: bool = _env_bool("STRATUM_PANDAS_QUERY", False)
     fast_dataops_convert: bool = True
     validate_dag: bool = True
@@ -90,7 +108,8 @@ def set_config(rust_backend: bool | None = None,
     make_map_op: bool = True,
     make_column_projection: bool = True,
     rechunk: bool = True,
-buffer_pool_memory_budget: int = 0
+    buffer_pool_memory_budget: int = 0,
+    implementation_selector: str = "default",
                ) -> None:
     """Runtime toggles (synced env for Rust to read).
 
@@ -134,13 +153,20 @@ buffer_pool_memory_budget: int = 0
             Enable/disable debug mode.
 
         force_polars: bool, default false
-            Force use of Polars instead of Pandas for dataframe operations.
+            Legacy frame-backend flag. It does not override the configured
+            implementation selector.
+
+        implementation_selector: str, default "default"
+            Implementation-selection policy. Only ``"default"`` is available
+            until additional selector strategies are implemented.
 
         pandas_query: bool, default false
             Evaluate MASK selections on the pandas backend via ``DataFrame.query()``
             when the predicate is expressible as a query string (no OperandLeaf / str
             accessor); otherwise fall back to boolean-mask indexing.
     """
+    implementation_selector = _read_implementation_selector(implementation_selector)
+
     if rust_backend is not None:
         FLAGS.rust_backend = bool(rust_backend)
         os.environ["SKRUB_RUST"] = "1" if FLAGS.rust_backend else "0"
@@ -164,10 +190,11 @@ buffer_pool_memory_budget: int = 0
     if DEBUG is not None:
         FLAGS.DEBUG = bool(DEBUG)
         os.environ["STRATUM_DEBUG"] = "1" if FLAGS.DEBUG else "0"
-    #FIXME: This is a temporary flag. Remove once we have the operator selector.
     if force_polars is not None:
         FLAGS.force_polars = bool(force_polars)
         os.environ["STRATUM_FORCE_POLARS"] = "1" if FLAGS.force_polars else "0"
+    FLAGS.implementation_selector = implementation_selector
+    os.environ["STRATUM_IMPLEMENTATION_SELECTOR"] = implementation_selector
     FLAGS.pandas_query = bool(pandas_query)
     os.environ["STRATUM_PANDAS_QUERY"] = "1" if FLAGS.pandas_query else "0"
     # TODO: Select between multiple schedulers in the future.
@@ -176,7 +203,7 @@ buffer_pool_memory_budget: int = 0
     FLAGS.debug_graph = bool(debug_graph)
     FLAGS.open_graph = bool(open_graph)
     FLAGS.buffer_pool_memory_budget = int(buffer_pool_memory_budget)
-    FLAGS.explain = _normalize_explain(explain)
+    FLAGS.explain = _read_explain_levels(explain)
     FLAGS.make_selection_op = bool(make_selection_op)
     FLAGS.make_map_op = bool(make_map_op)
     FLAGS.make_column_projection = bool(make_column_projection)

--- a/stratum/_config.py
+++ b/stratum/_config.py
@@ -24,7 +24,7 @@ def _env_int(name, default=0):
 #: ``logical`` (after logical rewrites), ``physical`` (after lowering) and
 #: ``physical_impl`` (after implementation selection, i.e.,  the executable plan).
 EXPLAIN_LEVELS = ("logical", "physical", "physical_impl")
-IMPLEMENTATION_SELECTOR_MODES = ("default",)
+IMPLEMENTATION_SELECTOR_MODES = ("default", "greedy")
 
 
 def _read_implementation_selector(value: str) -> str:
@@ -157,8 +157,9 @@ def set_config(rust_backend: bool | None = None,
             implementation selector.
 
         implementation_selector: str, default "default"
-            Implementation-selection policy. Only ``"default"`` is available
-            until additional selector strategies are implemented.
+            Implementation-selection policy. ``"default"`` prefers pandas/
+            sklearn-skrub; ``"greedy"`` prefers efficient backends
+            (rust/polars) first.
 
         pandas_query: bool, default false
             Evaluate MASK selections on the pandas backend via ``DataFrame.query()``

--- a/stratum/optimizer/_input_removal_planning.py
+++ b/stratum/optimizer/_input_removal_planning.py
@@ -1,14 +1,15 @@
 """Input removal planning for the linearized Op DAG.
 
-After linearization, each op produces an intermediate buffer stored in the
-BufferPool.  Removal planning decides *when* each buffer can be freed so
-that peak memory stays low while correctness is preserved.
+Removal planning marks the last use of each intermediate in the DAG. The list of
+intermediates to be removed is materialized in each op's ``op.remove_after`` attribute.
+Skrub/stratum's execution plan does not include control flow, so we can mark the last
+use of each intermediate in the compile time.
 
 How it works:
 - Each op starts with a consumer count equal to ``len(op.outputs)`` (min 1).
 - Walking the linearized order, every time an op appears as an input of
   another op, its remaining count is decremented.
-- When the count hits zero the buffer is scheduled for removal right after
+- When the count hits zero, the intermediate is scheduled for removal right after
   the current op finishes (set via ``op.remove_after``).
 - Pinned ops (pre-split ops that feed post-split / re-executed ops) are
   never removed by the schedule; they persist across CV folds.
@@ -29,7 +30,7 @@ def compute_pinned_ops(
     split_pos: int | None,
     recompute_ops: list[Op],
 ) -> set[Op]:
-    """Return pre-split ops whose buffers must persist across CV folds."""
+    """Return pre-split ops that must persist across CV folds."""
     start = start_time()
     if split_pos is None:
         return set()

--- a/stratum/optimizer/_optimize.py
+++ b/stratum/optimizer/_optimize.py
@@ -13,8 +13,8 @@ from ._linearization import linearize_dag
 from ._input_removal_planning import compute_pinned_ops, plan_input_removals
 from .physical._plan_context import PlanContext
 from .physical._lowering import lower_to_physical
-from .physical._impl_selection import select_implementations
-# Importing the physical exec modules registers their lowering rules.
+from .physical._impl_selection import (ImplementationSelector, get_implementation_selector, select_implementations)
+# Importing the physical exec modules and their lowering rules.
 from .physical import _source_execs  # noqa: F401
 from .physical import _transform_execs  # noqa: F401
 from stratum.utils._skrub_graph import build_graph
@@ -97,15 +97,15 @@ def optimize(dag_root: DataOp, config: OptConfig = None, env: dict = None):
     """Entry point for the optimizer. Runs the three planning phases and returns
     the linearized physical plan ``(linearized_dag, split_pos, flagged_ops)``.
 
-    The phases are:
+    The steps are:
 
-    1. :func:`logical_optimize` -- convert the Skrub DataOp DAG to the logical
+    1. :func:`logical_optimize` -- compile the Skrub DataOp DAG to the logical
        IR and run all backend-agnostic rewrites (extraction, CSE, choice
        unrolling, algebraic rewrites).
     2. :func:`~stratum.optimizer.physical._lowering.lower_to_physical` -- lower
        logical ops to physical ops (one logical op may become several).
     3. :func:`physical_optimize` -- select a concrete implementation per
-       physical op, then linearize and plan buffer removals as the final step.
+       physical op, then linearize and plan intermediate last use as the final step.
 
     ``env`` (variable name -> value), when supplied, lets the converter resolve
     variables to compile-time constants (ValueOps) instead of VariableOps."""
@@ -113,21 +113,22 @@ def optimize(dag_root: DataOp, config: OptConfig = None, env: dict = None):
     if config is None:
         config = OptConfig()
 
-    # Phase 1: logical optimization (backend-agnostic).
+    # Step 1: Convert the Skrub DataOp DAG to the logical IR and apply rewrites.
     root = logical_optimize(dag_root, config, env)
     _debug_explain_dag("logical", root)
 
-    # Phases 2 & 3 read the config that drives operator selection once, here, so
+    # Steps 2 & 3 read the config that drives operator selection once, here, so
     # execution carries no operator-selection control flow.
     ctx = PlanContext.from_flags()
 
-    # Phase 2: lower logical ops to physical ops.
+    # Step 2: lower logical ops to physical ops.
     root = lower_to_physical(root, ctx)
     _debug_validate_dag(root)  # operand refs after lowering
     _debug_show_graph(root, "lowered")
     _debug_explain_dag("physical", root)
 
-    # Phase 3: physical optimization (implementation selection + linearization).
+    # Step 3: physical optimization (implementation selection + linearization).
+    # TODO: May need physical-level rewrites before or after operator selection
     result = physical_optimize(root, ctx)
 
     log_time("Optimization took in total", start)
@@ -135,10 +136,10 @@ def optimize(dag_root: DataOp, config: OptConfig = None, env: dict = None):
 
 
 def logical_optimize(dag_root: DataOp, config: OptConfig, env: dict = None) -> Op:
-    """Phase 1: build the logical IR and run all backend-agnostic rewrites.
-
+    """Step 1: build the logical IR and run all backend-agnostic rewrites.
     Returns the logical DAG root, ready to be lowered to physical ops."""
-    # Convert to Op DAG
+
+    # Convert to logical operator DAG
     root = convert_to_ops(dag_root, env)
 
     # Add splitting op
@@ -171,20 +172,23 @@ def logical_optimize(dag_root: DataOp, config: OptConfig, env: dict = None) -> O
     return root
 
 
-def physical_optimize(root: Op, ctx: PlanContext, registry=None):
-    """Phase 3: select concrete implementations, then linearize and plan removals.
-
+def physical_optimize(root: Op, ctx: PlanContext, registry=None,
+                      selector: ImplementationSelector | None = None):
+    """Step 3: select concrete implementations, then linearize and plan removals.
     Implementation selection resolves each op with registered candidates to a
     concrete implementation (consulting the default PhysicalRegistry unless one
     is injected). Linearization and buffer-removal planning run last, as the
     final step of the whole pipeline."""
 
-    # add physical rewrites here (or afterwards)
-    root = select_implementations(root, ctx, registry=registry)
+    # TODO: add physical rewrites here (or afterwards)
+    if selector is None:
+        selector = get_implementation_selector(ctx.implementation_selector)
+    root = select_implementations(root, ctx, registry=registry, selector=selector)
     _debug_validate_dag(root)
     _debug_show_graph(root, "physical")
     # similarly we can do the things like parallelization planning here
 
+    # Linearize and mark last used intermediates for removal
     linearized_dag, split_pos, flagged_ops = linearize_dag(root)
     pinned_ops = compute_pinned_ops(linearized_dag, split_pos, flagged_ops)
     plan_input_removals(linearized_dag, pinned_ops)

--- a/stratum/optimizer/physical/__init__.py
+++ b/stratum/optimizer/physical/__init__.py
@@ -17,6 +17,7 @@ from ._lowering import lower_to_physical, lowering_rule
 from ._impl_selection import (
     DefaultImplementationSelector,
     FlagBasedSelector,
+    GreedyImplementationSelector,
     ImplementationSelector,
     get_implementation_selector,
     select_implementations,
@@ -25,6 +26,7 @@ from ._impl_selection import (
 __all__ = [
     "DefaultImplementationSelector",
     "FlagBasedSelector",
+    "GreedyImplementationSelector",
     "ImplementationSelector",
     "get_implementation_selector",
     "PhysicalImpl",

--- a/stratum/optimizer/physical/__init__.py
+++ b/stratum/optimizer/physical/__init__.py
@@ -1,8 +1,4 @@
 from ._registry import (
-    CURRENT_BACKENDS,
-    CURRENT_LOGICAL_OPERATOR_TYPES,
-    BackendSpec,
-    OperatorFamily,
     PhysicalImpl,
     PhysicalRegistry,
     RustPhysicalImpl,
@@ -19,18 +15,18 @@ from ._physical_ops import PhysicalOp, RustPhysicalOp
 from ._plan_context import PlanContext
 from ._lowering import lower_to_physical, lowering_rule
 from ._impl_selection import (
+    DefaultImplementationSelector,
     FlagBasedSelector,
     ImplementationSelector,
+    get_implementation_selector,
     select_implementations,
 )
 
 __all__ = [
-    "CURRENT_BACKENDS",
-    "CURRENT_LOGICAL_OPERATOR_TYPES",
-    "BackendSpec",
+    "DefaultImplementationSelector",
     "FlagBasedSelector",
     "ImplementationSelector",
-    "OperatorFamily",
+    "get_implementation_selector",
     "PhysicalImpl",
     "PhysicalOp",
     "PhysicalRegistry",

--- a/stratum/optimizer/physical/_impl_selection.py
+++ b/stratum/optimizer/physical/_impl_selection.py
@@ -1,5 +1,6 @@
-"""Implementation-selection pass (the third phase).
+"""Implementation-selection pass.
 
+# TODO: Rewrite all comments
 Lowering fixes the *shape* of the physical plan; this pass fixes the *impl* of
 each op: which concrete backend-specific implementation actually runs. For every
 op in the DAG it asks the :class:`~stratum.optimizer.physical._registry.PhysicalRegistry`
@@ -20,10 +21,6 @@ left**.
 Ops with no candidates (un-migrated logical families, ValueOp, ChoiceOp, ...)
 pass through and keep executing their own ``process``.
 
-Today's :class:`FlagBasedSelector` reproduces the legacy flag semantics from the
-plan context. This is the seam where a cost/memory-based selector plugs in later
-without touching lowering or the registry: candidates already expose ``cost`` and
-``exec_mem``, so a future selector only changes *which* candidate wins.
 """
 from __future__ import annotations
 
@@ -49,6 +46,49 @@ class ImplementationSelector:
     def choose(self, op: IRNode, candidates: list[PhysicalImpl],
                ctx: PlanContext) -> PhysicalImpl | None:
         raise NotImplementedError
+
+
+class DefaultImplementationSelector(ImplementationSelector):
+    """Choose implementations using the stable default backend preference.
+
+    The selector is intentionally local to one operator.  Candidates have
+    already been filtered through ``supports(op, ctx)`` by :func:`bind_op`, so
+    this policy only ranks the supported implementations and falls back to
+    registration order when none of the preferred backends is available.
+    """
+
+    _PREFERRED_BACKENDS = ("pandas", "sklearn-skrub", "numpy")
+
+    # FIXME: PandasInMemoryFrame may fail if the in-memory dataframe is Polars
+    def choose(self, op: IRNode, candidates: list[PhysicalImpl],
+               ctx: PlanContext) -> PhysicalImpl | None:
+        if not candidates:
+            return None
+        for backend_name in self._PREFERRED_BACKENDS:
+            for impl in candidates:
+                if impl.backend_name == backend_name:
+                    return impl
+        return candidates[0]
+
+
+_IMPLEMENTATION_SELECTOR_FACTORIES: dict[str, type[ImplementationSelector]] = {
+    "default": DefaultImplementationSelector,
+}
+
+
+def get_implementation_selector(mode: str) -> ImplementationSelector:
+    """Get the configured implementation-selection policy.
+
+    Keeping construction in one place makes adding a future selector a small,
+    explicit change while preserving selector injection for focused tests.
+    """
+    try:
+        selector_type = _IMPLEMENTATION_SELECTOR_FACTORIES[mode]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown implementation selector {mode!r}; available selectors "
+            f"are {sorted(_IMPLEMENTATION_SELECTOR_FACTORIES)}.") from exc
+    return selector_type()
 
 
 class FlagBasedSelector(ImplementationSelector):
@@ -97,7 +137,7 @@ def bind_op(op: IRNode, ctx: PlanContext,
     if registry is None:
         registry = get_default_physical_registry()
     if selector is None:
-        selector = FlagBasedSelector()
+        selector = get_implementation_selector(ctx.implementation_selector)
 
     candidates = [c for c in registry.candidates_for(type(op)) if c.supports(op, ctx)]
     impl = selector.choose(op, candidates, ctx)
@@ -105,7 +145,7 @@ def bind_op(op: IRNode, ctx: PlanContext,
         return op
     logger.debug(f"Selected {impl.backend_name} implementation for {op}")
     if impl.impl_class is not None and impl.impl_class is not type(op):
-        op.__class__ = impl.impl_class
+        op.__class__ = impl.impl_class #late-binding
     if isinstance(op, PhysicalOp):
         op.on_impl_selected(ctx)
     return op
@@ -124,7 +164,7 @@ def select_implementations(root: IRNode, ctx: PlanContext,
     if registry is None:
         registry = get_default_physical_registry()
     if selector is None:
-        selector = FlagBasedSelector()
+        selector = get_implementation_selector(ctx.implementation_selector)
 
     for op in topological_iterator(root):
         bind_op(op, ctx, registry=registry, selector=selector)

--- a/stratum/optimizer/physical/_impl_selection.py
+++ b/stratum/optimizer/physical/_impl_selection.py
@@ -71,8 +71,32 @@ class DefaultImplementationSelector(ImplementationSelector):
         return candidates[0]
 
 
+class GreedyImplementationSelector(ImplementationSelector):
+    """Choose implementations using an efficient-backend-first preference.
+
+    Like DefaultImplementationSelector, this policy only ranks the
+    already ``supports``-filtered candidates for one operator at a time. It
+    does not call :meth:`PhysicalImpl.cost` (still a placeholder) and does not
+    look at neighboring operators, formats, conversion costs, or plan-wide
+    costs. This is a baseline.
+    """
+
+    _PREFERRED_BACKENDS = ("rust", "polars", "numpy", "sklearn-skrub", "pandas")
+
+    def choose(self, op: IRNode, candidates: list[PhysicalImpl],
+               ctx: PlanContext) -> PhysicalImpl | None:
+        if not candidates:
+            return None
+        for backend_name in self._PREFERRED_BACKENDS:
+            for impl in candidates:
+                if impl.backend_name == backend_name:
+                    return impl
+        return candidates[0]
+
+
 _IMPLEMENTATION_SELECTOR_FACTORIES: dict[str, type[ImplementationSelector]] = {
     "default": DefaultImplementationSelector,
+    "greedy": GreedyImplementationSelector,
 }
 
 
@@ -145,7 +169,7 @@ def bind_op(op: IRNode, ctx: PlanContext,
         return op
     logger.debug(f"Selected {impl.backend_name} implementation for {op}")
     if impl.impl_class is not None and impl.impl_class is not type(op):
-        op.__class__ = impl.impl_class #late-binding
+        op.__class__ = impl.impl_class # late-binding
     if isinstance(op, PhysicalOp):
         op.on_impl_selected(ctx)
     return op

--- a/stratum/optimizer/physical/_physical_ops.py
+++ b/stratum/optimizer/physical/_physical_ops.py
@@ -96,6 +96,7 @@ class PhysicalOp(IRNode):
             f"cloning happens in the logical phase, before lowering.")
 
 
+# FIXME: Why do we need this class?
 class RustPhysicalOp(PhysicalOp):
     """Base for native Rust physical ops.
 

--- a/stratum/optimizer/physical/_plan_context.py
+++ b/stratum/optimizer/physical/_plan_context.py
@@ -41,6 +41,9 @@ class PlanContext:
         Legacy soft kill-switch for non-sklearn backends; gates Rust selection
         together with ``rust_backend`` to preserve the pre-registry semantics
         (``allow_patch and rust_backend``).
+    implementation_selector:
+        Name of the implementation-selection policy to use during physical
+        planning.
     """
 
     backend: str
@@ -49,6 +52,7 @@ class PlanContext:
     parallelism: int
     rust_backend: bool
     allow_patch: bool
+    implementation_selector: str = "default"
 
     @property
     def is_polars(self) -> bool:
@@ -68,4 +72,5 @@ class PlanContext:
             parallelism=os.cpu_count(),
             rust_backend=bool(FLAGS.rust_backend),
             allow_patch=bool(FLAGS.allow_patch),
+            implementation_selector=FLAGS.implementation_selector,
         )

--- a/stratum/optimizer/physical/_plan_context.py
+++ b/stratum/optimizer/physical/_plan_context.py
@@ -43,7 +43,8 @@ class PlanContext:
         (``allow_patch and rust_backend``).
     implementation_selector:
         Name of the implementation-selection policy to use during physical
-        planning.
+        planning: ``"default"`` (pandas/sklearn-skrub-first) or ``"greedy"``
+        (rust/polars-first).
     """
 
     backend: str

--- a/stratum/optimizer/physical/_registry.py
+++ b/stratum/optimizer/physical/_registry.py
@@ -3,51 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
 
-from stratum.optimizer.ir._aggregation_ops import AggregateOp, GroupedDataframeOp
 from stratum.optimizer.ir._base import IRNode
-from stratum.optimizer.ir._dataframe_ops import (
-    ApplyUDFOp,
-    AssignMapOp,
-    AssignOp,
-    ColumnProjectionOp,
-    ColumnSelectorOp,
-    ConcatOp,
-    DatetimeConversionOp,
-    DropOp,
-    GetAttrProjectionOp,
-    MapOp,
-    MetadataOp,
-    ProjectionOp,
-    SelectionOp,
-    SplitOp,
-    SplitOutput,
-    StringMethodOp,
-)
-from stratum.optimizer.ir._join_ops import JoinOp
-from stratum.optimizer.ir._numeric_ops import NumericOp
-from stratum.optimizer.ir._ops import (
-    BaseEstimatorOp,
-    BinOp,
-    CallOp,
-    ChoiceOp,
-    GetAttrOp,
-    GetItemOp,
-    ImplOp,
-    MethodCallOp,
-    Op,
-    SearchEvalOp,
-    ValueOp,
-    VariableOp,
-    PredictorOp,
-    TransformerOp,
-)
 BackendName = str
 
 
 """Descriptor for one physical implementation of a plannable operator.
 
 ``op_type`` is the type the implementation is registered under: an *abstract
-physical* op type for families already migrated to the physical layer (e.g.
+physical* op type for families already compiled to the physical layer (e.g.
 ``ReadCSV``), or a *logical* op type for families that still pass through
 lowering unchanged (e.g. ``TransformerOp``). ``supports``/``cost``/``exec_mem``
 form the fixed selector-facing API; ``impl_class`` names the concrete
@@ -55,9 +18,8 @@ form the fixed selector-facing API; ``impl_class`` names the concrete
 after which its ``on_impl_selected`` folds in any plan-time state.
 
 This is the shared, backend-agnostic schema. A backend that carries extra
-scheduling metadata *subclasses* this (see :class:`RustPhysicalImpl`) instead of
-widening the base, so the common schema stays small as more backends grow their
-own fields."""
+scheduling metadata *subclasses* this (e.g., :class:`RustPhysicalImpl`) instead of
+widening the base, so the common schema stays small."""
 @dataclass(frozen=True, slots=True)
 class PhysicalImpl:
     op_type: type[IRNode]
@@ -89,148 +51,54 @@ class RustPhysicalImpl(PhysicalImpl):
     data_parallel: bool = False
 
 
-"""Operator family used to keep the registry extensible."""
-@dataclass(frozen=True, slots=True)
-class OperatorFamily:
-    name: str
-    op_types: tuple[type[IRNode], ...]
-    default_backends: tuple[BackendName, ...] = ()
-    notes: str = ""
-
-
-"""A physical execution backend understood by the registry."""
-@dataclass(frozen=True, slots=True)
-class BackendSpec:
-    name: str
-    notes: str = ""
-
-
-# FIXME: Only list the stratum's logical operators after compilation from skrub IR
-# these will be replaced by the general physical operators (once they are here), and
-# will be lowered to specific physical op implementations. Types leave this list as
-# their family migrates to the physical layer (sources already have: DataSourceOp is
-# lowered away and its physical types live in the "sources" family instead).
-CURRENT_LOGICAL_OPERATOR_TYPES: tuple[type[Op], ...] = (
-    AggregateOp,
-    ApplyUDFOp,
-    AssignMapOp,
-    AssignOp,
-    BaseEstimatorOp,
-    BinOp,
-    CallOp,
-    ChoiceOp,
-    ColumnProjectionOp,
-    ColumnSelectorOp,
-    ConcatOp,
-    DatetimeConversionOp,
-    DropOp,
-    PredictorOp,
-    GetAttrOp,
-    GetAttrProjectionOp,
-    GetItemOp,
-    GroupedDataframeOp,
-    ImplOp,
-    JoinOp,
-    MapOp,
-    MetadataOp,
-    MethodCallOp,
-    NumericOp,
-    ProjectionOp,
-    SearchEvalOp,
-    SelectionOp,
-    SplitOp,
-    SplitOutput,
-    StringMethodOp,
-    TransformerOp,
-    ValueOp,
-    VariableOp,
-)
-
-
-CURRENT_BACKENDS: tuple[BackendSpec, ...] = (
-    BackendSpec("pandas", "Pandas dataframe implementation."),
-    BackendSpec("polars", "Polars dataframe implementation."),
-    BackendSpec("numpy", "NumPy array implementation."),
-    BackendSpec("sklearn-skrub", "Existing sklearn/skrub implementation."),
-    BackendSpec("rust", "Native Rust implementation selected like any other backend."),
-)
-
-
-CURRENT_OPERATOR_FAMILIES: tuple[OperatorFamily, ...] = (
-    OperatorFamily(
-        name="logical",
-        op_types=CURRENT_LOGICAL_OPERATOR_TYPES,
-        default_backends=tuple(backend.name for backend in CURRENT_BACKENDS),
-        notes="Current logical IR surface; backends are attached later by the planner.",
-    ),
-)
-
-
-def _unsupported_supports(op: Op, ctx: Any) -> bool:
+def _unsupported_supports(op: IRNode, ctx: Any) -> bool:
     return False
 
 
-def _unsupported_cost(op: Op, stats: Any) -> float:
+def _unsupported_cost(op: IRNode, stats: Any) -> float:
     raise NotImplementedError("No physical cost model has been registered for this operator yet.")
 
 
-def _unsupported_exec_mem(op: Op, stats: Any) -> int:
+def _unsupported_exec_mem(op: IRNode, stats: Any) -> int:
     raise NotImplementedError("No execution-memory model has been registered for this operator yet.")
 
 
-def _unsupported_execute(op: Op, mode: str, inputs: list[Any]) -> Any:
+def _unsupported_execute(op: IRNode, mode: str, inputs: list[Any]) -> Any:
     raise NotImplementedError("No physical implementation has been registered for this operator yet.")
 
 
-def _current_process_execute(op: Op, mode: str, inputs: list[Any]) -> Any:
+def _current_process_execute(op: IRNode, mode: str, inputs: list[Any]) -> Any:
     return op.process(mode, inputs)
 
 
-def _placeholder_cost(op: Op, stats: Any) -> float:
+def _placeholder_cost(op: IRNode, stats: Any) -> float:
     return 1.0
 
 
-def _placeholder_exec_mem(op: Op, stats: Any) -> int:
+def _placeholder_exec_mem(op: IRNode, stats: Any) -> int:
     return 0
 
 
-"""Container for physical implementations and their operator families."""
+"""Dictionary for physical implementations keyed by operator type.
+Extensibile to support new backends. """
 class PhysicalRegistry:
     def __init__(
         self,
-        families: Iterable[OperatorFamily] = (),
         implementations: Iterable[PhysicalImpl] = (),
     ) -> None:
-        self._families: list[OperatorFamily] = list(families)
         self._implementations: dict[type[IRNode], list[PhysicalImpl]] = {}
         self._implementations_by_backend: dict[BackendName, list[PhysicalImpl]] = {}
         for impl in implementations:
             self.register(impl)
-
-    def register_family(self, family: OperatorFamily) -> None:
-        self._families.append(family)
 
     def register(self, impl: PhysicalImpl) -> PhysicalImpl:
         self._implementations.setdefault(impl.op_type, []).append(impl)
         self._implementations_by_backend.setdefault(impl.backend_name, []).append(impl)
         return impl
 
-    def families(self) -> tuple[OperatorFamily, ...]:
-        return tuple(self._families)
-
     def op_types(self) -> tuple[type[IRNode], ...]:
-        types: list[type[IRNode]] = []
-        seen: set[type[IRNode]] = set()
-        for family in self._families:
-            for op_type in family.op_types:
-                if op_type not in seen:
-                    seen.add(op_type)
-                    types.append(op_type)
-        for op_type in self._implementations:
-            if op_type not in seen:
-                seen.add(op_type)
-                types.append(op_type)
-        return tuple(types)
+        """Return operator types with at least one registered implementation."""
+        return tuple(self._implementations)
 
     def candidates_for(
         self,
@@ -243,7 +111,6 @@ class PhysicalRegistry:
             candidates = [impl for impl in candidates if impl.backend_name == backend_name]
         return tuple(candidates)
 
-    """Return the physical implementations available for a given operator."""
     def candidates_for_op(
         self,
         op: IRNode,
@@ -351,6 +218,11 @@ sklearn_skrub_impl = _backend_impl("sklearn-skrub")
 
 
 def _register_current_estimator_impls(registry: PhysicalRegistry) -> None:
+    # These are transitional registrations for estimator families that do not
+    # have abstract physical operators yet. Once those lowerings land, their
+    # implementations should be keyed by the corresponding physical type.
+    from stratum.optimizer.ir._ops import PredictorOp, TransformerOp
+
     for op_type in (TransformerOp, PredictorOp):
         registry.register(
             PhysicalImpl(
@@ -368,12 +240,15 @@ def _register_current_estimator_impls(registry: PhysicalRegistry) -> None:
 
 """Create the default registry with every known implementation registered."""
 def build_default_physical_registry() -> PhysicalRegistry:
-    registry = PhysicalRegistry(families=CURRENT_OPERATOR_FAMILIES)
+    registry = PhysicalRegistry()
 
     # Imported lazily: the exec modules import back into this module (the
     # decorator / PhysicalImpl), so pulling them in at module level would cycle.
-    # Importing each exec module triggers its @physical_impl registrations
-    # (including the Rust kernels, now class-based @rust_impl impls).
+    # Importing each exec module triggers its lowering rules and
+    # @physical_impl/@rust_impl registrations. Keep this list complete so a
+    # standalone registry construction does not depend on optimizer imports.
+    from stratum.optimizer.physical import _source_execs  # noqa: F401
+    from stratum.optimizer.physical import _transform_execs  # noqa: F401
     from stratum.optimizer.physical import _concat_execs  # noqa: F401
     from stratum.optimizer.physical import _join_execs  # noqa: F401
     from stratum.optimizer.physical import _aggregation_execs  # noqa: F401
@@ -391,10 +266,9 @@ def build_default_physical_registry() -> PhysicalRegistry:
 _default_registry: PhysicalRegistry | None = None
 
 
+"""Shared default registry, built once on first use."""
 def get_default_physical_registry() -> PhysicalRegistry:
-    """Shared default registry, built once on first use.
-
-    The implementation-selection pass consults this unless a registry is
+    """The implementation-selection pass consults this unless a registry is
     injected explicitly (tests, custom planners)."""
     global _default_registry
     if _default_registry is None:

--- a/stratum/optimizer/physical/_source_execs.py
+++ b/stratum/optimizer/physical/_source_execs.py
@@ -19,7 +19,7 @@ from stratum.optimizer.ir._base import (OperandRef, OutputType, _resolve_args,
 from stratum.optimizer.ir._source_ops import DataSourceOp
 from stratum.optimizer.physical._physical_ops import PhysicalOp
 from stratum.optimizer.physical._lowering import lowering_rule
-from stratum.optimizer.physical._registry import OperatorFamily, physical_impl
+from stratum.optimizer.physical._registry import physical_impl
 
 
 def rechunk_pl_frame(df, rows_per_chunk=128_000):
@@ -114,8 +114,8 @@ class NumpyLoad(FileReadOp):
         return np.load(file_path, *read_args, **read_kwargs)
 
 
-# Registered as its own implementation so the catalog lists it; selection is a
-# no-op (the class is already concrete and backend-agnostic).
+# Registered as its own implementation so the default registry includes it;
+# selection is a no-op (the class is already concrete and backend-agnostic).
 physical_impl(of=NumpyLoad, backend="numpy", input_format="value",
               output_format="matrix")(NumpyLoad)
 

--- a/stratum/optimizer/physical/_transform_execs.py
+++ b/stratum/optimizer/physical/_transform_execs.py
@@ -2,13 +2,12 @@
 
 Lowering turns a logical :class:`~stratum.optimizer.ir._ops.TransformerOp`
 wrapping a supported estimator into an *abstract* physical transformer op -- one
-per estimator kind -- mirroring how a ``DataSourceOp`` lowers to
-``ReadCSV``/``ReadParquet``/... (one logical op, many concrete shapes).
+per estimator kind.
 Implementation selection then swaps the abstract op to a concrete backend impl:
 the sklearn/skrub reference (``@physical_impl``) or the native Rust kernel
 (``@rust_impl``).
 
-Migration is incremental. Only estimators with a branch in
+Lowering is incremental. Only estimators with a branch in
 :func:`lower_transformer` move to a dedicated physical op; every other
 ``TransformerOp`` returns ``None`` from the rule, passes through lowering
 unchanged, and keeps running via the ``sklearn-skrub`` impl registered on
@@ -28,8 +27,7 @@ from stratum.adapters.string_encoder import (RustyStringEncoder,
 from stratum.optimizer.ir._ops import TransformerOp
 from stratum.optimizer.physical._lowering import lowering_rule
 from stratum.optimizer.physical._physical_ops import PhysicalOp, RustPhysicalOp
-from stratum.optimizer.physical._registry import (OperatorFamily, rust_impl,
-                                                 sklearn_skrub_impl)
+from stratum.optimizer.physical._registry import (rust_impl, sklearn_skrub_impl)
 
 
 class StringEncoderOp(TransformerOp, PhysicalOp):

--- a/stratum/tests/application/test_default_selector_pipeline.py
+++ b/stratum/tests/application/test_default_selector_pipeline.py
@@ -1,0 +1,103 @@
+import io
+import numpy as np
+import pandas as pd
+from contextlib import redirect_stdout
+from skrub import StringEncoder
+from sklearn.linear_model import Ridge
+from sklearn.model_selection import KFold
+
+import stratum as st
+from stratum.optimizer._optimize import OptConfig, optimize
+from stratum.optimizer.physical._concat_execs import PandasConcatOp
+from stratum.optimizer.physical._map_execs import PandasAssignMapOp
+from stratum.optimizer.physical._projection_execs import (
+    PandasColumnProjectionOp,
+    PandasColumnSelectorOp,
+)
+from stratum.optimizer.physical._source_execs import PandasReadCSV
+from stratum.optimizer.physical._transform_execs import SkrubStringEncoder
+from stratum.tests._helpers import csv_file
+
+# TODO: Add tests to match results with vanilla skrub
+
+def make_small_table(n: int = 24) -> pd.DataFrame:
+    rng = np.random.RandomState(7)
+    amount = rng.uniform(5.0, 50.0, size=n).round(2)
+    quantity = rng.randint(1, 6, size=n)
+    category = rng.choice(["books", "games", "home"], size=n)
+    target = (amount * quantity + (category == "games") * 4.0).round(2)
+    return pd.DataFrame({
+        "when": pd.date_range("2024-01-01", periods=n, freq="D").astype(str),
+        "amount": amount,
+        "quantity": quantity,
+        "category": category,
+        "target": target,
+    })
+
+
+def build_pipeline(file_path):
+    """Build a small recorded pipeline using several registered physical ops."""
+    data = st.as_data_op(file_path).skb.apply_func(pd.read_csv)
+
+    y = data["target"].skb.mark_as_y()
+    X = data.drop(columns=["target"]).skb.mark_as_X(
+        cv=KFold(n_splits=2, shuffle=True, random_state=0),
+        split_kwargs={})
+
+    date = X["when"].skb.apply_func(pd.to_datetime)
+    X = X.assign(
+        month=date.dt.month,
+        total=X["amount"] * X["quantity"],
+    )
+    X = X[["amount", "quantity", "total", "category"]]
+
+    numeric = X.skb.select(st.selectors.numeric())
+    categorical = X.skb.select(st.selectors.string())
+    encoded = categorical.skb.apply(StringEncoder())
+    features = numeric.skb.concat([encoded], axis=1)
+    return features.skb.apply(Ridge(alpha=1.0), y=y)
+
+
+def test_default_selector_compiles_registered_pipeline():
+    with csv_file(make_small_table()) as path:
+        with st.config(implementation_selector="default", rust_backend=True):
+            ops, *_ = optimize(
+                build_pipeline(path),
+                OptConfig(dataframe_ops=True),
+            )
+
+    # The source and every migrated frame/transformer family is bound to the
+    # default pandas/skrub implementations, even when the legacy Rust flag is on.
+    assert any(isinstance(op, PandasReadCSV) for op in ops)
+    assert any(isinstance(op, PandasAssignMapOp) for op in ops)
+    assert any(isinstance(op, PandasColumnProjectionOp) for op in ops)
+    assert any(isinstance(op, PandasColumnSelectorOp) for op in ops)
+    assert any(isinstance(op, PandasConcatOp) for op in ops)
+    assert any(isinstance(op, SkrubStringEncoder) for op in ops)
+
+
+def test_default_selector_pipeline_scores_end_to_end():
+    with csv_file(make_small_table()) as path:
+        predictions = build_pipeline(path)
+        
+        # Capture explain output using redirect_stdout
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            # Enable scheduler mode to trigger optimizer and get explain output
+            with st.config(implementation_selector="default", scheduler=True, explain=("physical_impl")):
+                search = predictions.skb.make_grid_search(
+                    n_jobs=1,
+                    fitted=True,
+                    refit=False,
+                    scoring="r2",
+                )
+
+    # Print the captured explain output
+    output_str = captured_output.getvalue()
+    if output_str:
+        print(output_str)
+
+    assert search.results_ is not None
+    # SequentialScheduler returns a Polars DataFrame with columns ['id', 'scores']
+    # instead of pandas DataFrame with 'mean_test_score'
+    assert "scores" in search.results_.columns or "mean_test_score" in search.results_.columns

--- a/stratum/tests/application/test_frame_ops_pipeline.py
+++ b/stratum/tests/application/test_frame_ops_pipeline.py
@@ -3,7 +3,7 @@ compiling pass, exercised through one realistic supervised pipeline.
 
 A single e-commerce pipeline -- read a CSV, engineer features, encode the
 categoricals, fit a model -- chains everything the recent optimizer work
-introduced, over both frame backends:
+introduced into one default-selector pipeline:
 
 * a source **read** ``pd.read_csv`` lowered to a source op;
 * a **mask selection** ``df[predicate]`` that folds a boolean expression tree
@@ -14,18 +14,17 @@ introduced, over both frame backends:
 * a literal **column projection** ``df[[...]]`` -> :class:`ColumnProjectionOp`
   and two selector-driven ``skb.select(...)`` splits -> :class:`ColumnSelectorOp`
   (``stratum.optimizer.ir._projection_ops``);
-* a **transformer** (:class:`TransformerOp`) with *multiple* registered physical
-  implementations -- the sklearn/skrub ``StringEncoder`` and its ``rust`` kernel
-  -- and an **estimator** (:class:`EstimatorOp`) that fits the model.
+* a **transformer** (:class:`TransformerOp`) with multiple registered physical
+  implementations, where the default chooses the sklearn/skrub implementation,
+  and an **estimator** (:class:`EstimatorOp`) that fits the model.
 
 The tests assert three things:
 
 1. each backend-agnostic *logical* abstraction is recognised;
 2. the *compiling* pass binds the frame abstractions to concrete
-   :class:`PhysicalOp` implementations, and binds the transformer to the
-   backend implementation chosen by the plan context (skrub vs. Rust);
-3. the compiled plan trains and scores end-to-end via ``make_grid_search`` on
-   both backends.
+   :class:`PhysicalOp` implementations, and binds the transformer according to
+   the configured implementation selector;
+3. the compiled plan trains and scores end-to-end via ``make_grid_search``.
 """
 import pytest
 import pandas as pd
@@ -35,8 +34,6 @@ from sklearn.linear_model import Ridge
 from sklearn.metrics import make_scorer, r2_score
 
 import stratum as st
-from stratum.adapters.string_encoder import (RustyStringEncoder,
-                                             supports_rust_string_encoder)
 from stratum.optimizer._optimize import OptConfig, optimize as optimize_
 from stratum.optimizer.ir._selection_ops import SelectionKind, SelectionOp
 from stratum.optimizer.ir._map_ops import AssignMapOp
@@ -101,8 +98,8 @@ def build_pipeline(file_path, model=None):
     X_num = X.skb.select(st.selectors.numeric())
     X_cat = X.skb.select(~st.selectors.numeric())
 
-    # (5) TRANSFORMER: encode the string columns. StringEncoder has both a
-    # sklearn/skrub and a Rust physical implementation; the plan context picks.
+    # (5) TRANSFORMER: encode the string columns. The default selector picks the
+    # sklearn/skrub physical implementation.
     X_cat_enc = X_cat.skb.apply(StringEncoder())
 
     # (6) CONCAT the numeric + encoded blocks, then (7) fit the ESTIMATOR.
@@ -144,16 +141,16 @@ def test_frame_ops_pipeline_plan(polars):
     assert any(isinstance(o, ConcatOp) for o in ops)
 
 
-def test_transformer_binds_selected_backend(polars):
-    """The *same* logical TransformerOp binds to different physical
-    implementations depending on the plan context: the sklearn/skrub encoder by
-    default, the Rust kernel when ``rust_backend`` is on."""
-    supported, reason = supports_rust_string_encoder(StringEncoder())
-    if not supported:
-        pytest.skip(f"Rust StringEncoder unavailable: {reason}")
+def test_transformer_binds_default_selector(polars):
+    """The configured default keeps the StringEncoder on the skrub backend.
+
+    The legacy ``rust_backend`` flag remains available to concrete adapters, but
+    it does not override the selected implementation policy.
+    """
 
     def encoder_estimator(rust):
-        with csv_file(make_orders()) as path, st.config(rust_backend=rust):
+        with csv_file(make_orders()) as path, st.config(
+                implementation_selector="default", rust_backend=rust):
             ops = _optimize(build_pipeline(path))
         transformers = [o for o in ops if isinstance(o, TransformerOp)]
         assert len(transformers) == 1
@@ -161,12 +158,11 @@ def test_transformer_binds_selected_backend(polars):
 
     # Default: the backend-agnostic sklearn/skrub implementation.
     default_est = encoder_estimator(rust=False)
-    assert not isinstance(default_est, RustyStringEncoder)
+    assert isinstance(default_est, StringEncoder)
 
-    # rust_backend on: the Rust kernel is bound in at plan time.
+    # The Rust flag does not override the configured default selector.
     rust_est = encoder_estimator(rust=True)
-    assert isinstance(rust_est, RustyStringEncoder)
-    assert rust_est._stratum_force_rust
+    assert type(rust_est) is type(default_est)
 
 
 def test_selection_binds_query_impl_under_flag():
@@ -211,8 +207,10 @@ def test_query_selection_trains_end_to_end():
 def test_frame_ops_pipeline_grid_search(polars):
     """The compiled plan trains and scores end-to-end through Stratum's
     scheduler, driven by ``make_grid_search`` -- the same entry point the other
-    application tests use. The pipeline carries a single candidate (no
-    ``choose_from``), which grid search handles as a one-pipeline search."""
+    application tests use. The legacy backend flag is varied by the fixture,
+    but the default selector still produces one pandas pipeline. The pipeline
+    carries a single candidate (no ``choose_from``), which grid search handles
+    as a one-pipeline search."""
     scorer = make_scorer(r2_score)
     with csv_file(make_orders()) as path:
         preds = build_pipeline(path)

--- a/stratum/tests/application/test_selector_pipeline.py
+++ b/stratum/tests/application/test_selector_pipeline.py
@@ -1,4 +1,5 @@
 import io
+import sys
 import numpy as np
 import pandas as pd
 from contextlib import redirect_stdout
@@ -7,18 +8,29 @@ from sklearn.linear_model import Ridge
 from sklearn.model_selection import KFold
 
 import stratum as st
+from stratum.adapters.string_encoder import supports_rust_string_encoder
 from stratum.optimizer._optimize import OptConfig, optimize
-from stratum.optimizer.physical._concat_execs import PandasConcatOp
-from stratum.optimizer.physical._map_execs import PandasAssignMapOp
+from stratum.optimizer.physical._concat_execs import PandasConcatOp, PolarsConcatOp
+from stratum.optimizer.physical._map_execs import PandasAssignMapOp, PolarsAssignMapOp
 from stratum.optimizer.physical._projection_execs import (
     PandasColumnProjectionOp,
     PandasColumnSelectorOp,
+    PolarsColumnProjectionOp,
+    PolarsColumnSelectorOp,
 )
-from stratum.optimizer.physical._source_execs import PandasReadCSV
-from stratum.optimizer.physical._transform_execs import SkrubStringEncoder
+from stratum.optimizer.physical._source_execs import PandasReadCSV, PolarsReadCSV
+from stratum.optimizer.physical._transform_execs import (RustStringEncoder,
+                                                          SkrubStringEncoder)
 from stratum.tests._helpers import csv_file
 
 # TODO: Add tests to match results with vanilla skrub
+
+
+def capture_std_out(capfd):
+    sys.stdout.flush()
+    sys.stderr.flush()
+    captured = capfd.readouterr()
+    return (captured.out or "") + (captured.err or "")
 
 def make_small_table(n: int = 24) -> pd.DataFrame:
     rng = np.random.RandomState(7)
@@ -76,7 +88,29 @@ def test_default_selector_compiles_registered_pipeline():
     assert any(isinstance(op, SkrubStringEncoder) for op in ops)
 
 
-def test_default_selector_pipeline_scores_end_to_end():
+def test_greedy_selector_compiles_registered_pipeline():
+    encoder = StringEncoder()
+    rust_supported, _ = supports_rust_string_encoder(encoder)
+
+    with csv_file(make_small_table()) as path:
+        with st.config(implementation_selector="greedy"):
+            ops, *_ = optimize(
+                build_pipeline(path),
+                OptConfig(dataframe_ops=True),
+            )
+
+    assert any(isinstance(op, PolarsReadCSV) for op in ops)
+    assert any(isinstance(op, PolarsAssignMapOp) for op in ops)
+    assert any(isinstance(op, PolarsColumnProjectionOp) for op in ops)
+    assert any(isinstance(op, PolarsColumnSelectorOp) for op in ops)
+    assert any(isinstance(op, PolarsConcatOp) for op in ops)
+    # The StringEncoder transformer binds Rust when the estimator supports it,
+    # and falls back to the skrub reference impl (there is no polars kernel)
+    encoder_impl = RustStringEncoder if rust_supported else SkrubStringEncoder
+    assert any(isinstance(op, encoder_impl) for op in ops)
+
+
+def test_default_selector_pipeline_scores_end_to_end(capfd):
     with csv_file(make_small_table()) as path:
         predictions = build_pipeline(path)
         
@@ -84,7 +118,8 @@ def test_default_selector_pipeline_scores_end_to_end():
         captured_output = io.StringIO()
         with redirect_stdout(captured_output):
             # Enable scheduler mode to trigger optimizer and get explain output
-            with st.config(implementation_selector="default", scheduler=True, explain=("physical_impl")):
+            with st.config(rust_backend=True, implementation_selector="default",
+                           scheduler=True, explain=("physical_impl"), debug_timing=True):
                 search = predictions.skb.make_grid_search(
                     n_jobs=1,
                     fitted=True,
@@ -101,3 +136,44 @@ def test_default_selector_pipeline_scores_end_to_end():
     # SequentialScheduler returns a Polars DataFrame with columns ['id', 'scores']
     # instead of pandas DataFrame with 'mean_test_score'
     assert "scores" in search.results_.columns or "mean_test_score" in search.results_.columns
+
+    # Verify the StringEncoder transformer did not execute on Rust
+    combined_output = capture_std_out(capfd)
+    assert "[rust]" not in combined_output
+
+
+def test_greedy_selector_pipeline_scores_end_to_end(capfd):
+    encoder = StringEncoder()
+    rust_supported, _ = supports_rust_string_encoder(encoder)
+
+    with csv_file(make_small_table()) as path:
+        predictions = build_pipeline(path)
+
+        # Capture explain output using redirect_stdout
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            with st.config(rust_backend=True, implementation_selector="greedy",
+                           scheduler=True, explain=("physical_impl"), debug_timing=True):
+                search = predictions.skb.make_grid_search(
+                    n_jobs=1,
+                    fitted=True,
+                    refit=False,
+                    scoring="r2",
+                )
+
+    # Print the captured explain output
+    output_str = captured_output.getvalue()
+    if output_str:
+        print(output_str)
+
+    assert search.results_ is not None
+    # SequentialScheduler returns a Polars DataFrame with columns ['id', 'scores']
+    # instead of pandas DataFrame with 'mean_test_score'
+    assert "scores" in search.results_.columns or "mean_test_score" in search.results_.columns
+
+    # Verify the StringEncoder transformer actually executed on the Rust
+    combined_output = capture_std_out(capfd)
+    if rust_supported:
+        assert "[rust]" in combined_output
+    else:
+        assert "[rust]" not in combined_output

--- a/stratum/tests/logical_optimizer/test_dataframe_ops.py
+++ b/stratum/tests/logical_optimizer/test_dataframe_ops.py
@@ -15,6 +15,7 @@ from stratum._config import FLAGS
 from stratum.optimizer._optimize import OptConfig, optimize as optimize_
 from stratum.optimizer.ir._dataframe_ops import ConcatOp
 from stratum.optimizer.ir._ops import OperandRef, OutputType, Op
+from stratum.optimizer.physical import FlagBasedSelector
 from stratum.optimizer.physical._impl_selection import bind_op
 from stratum.optimizer.physical._plan_context import PlanContext
 
@@ -46,7 +47,7 @@ def run_op(op, *values, mode="fit_transform"):
     each test having to construct the concrete class itself.
     """
     op.inputs = [_inp(v) for v in values]
-    bind_op(op, PlanContext.from_flags())
+    bind_op(op, PlanContext.from_flags(), selector=FlagBasedSelector())
     return op.process(mode, _inputs_for(op))
 
 

--- a/stratum/tests/logical_optimizer/test_map_ops.py
+++ b/stratum/tests/logical_optimizer/test_map_ops.py
@@ -419,9 +419,10 @@ def test_datetime_unsupported_kwargs_preserved(polars, values, kwargs, expected)
     assert expected == [pd.Timestamp(value) for value in result["parsed"]]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="TODO: DatetimeExpr.to_polars only supports string operands")
+# FIXME: Fix this test
+#@pytest.mark.xfail(
+#    strict=True,
+#    reason="TODO: DatetimeExpr.to_polars only supports string operands")
 def test_datetime_conversion_existing_datetime_polars():
     df = pd.DataFrame({"ts": pd.to_datetime(["2020-01-01", "2021-02-03"])})
     src = st.as_data_op(df)

--- a/stratum/tests/physical/test_impl_selection.py
+++ b/stratum/tests/physical/test_impl_selection.py
@@ -19,6 +19,7 @@ from stratum.optimizer.ir._ops import TransformerOp
 from stratum.optimizer.physical._impl_selection import (
     DefaultImplementationSelector,
     FlagBasedSelector,
+    GreedyImplementationSelector,
     get_implementation_selector,
     select_implementations,
 )
@@ -27,7 +28,11 @@ from stratum.optimizer.physical._plan_context import PlanContext
 from stratum.optimizer.physical._registry import (PhysicalImpl, PhysicalRegistry,
                                                   _current_process_execute,
                                                   _placeholder_cost,
-                                                  _placeholder_exec_mem)
+                                                  _placeholder_exec_mem,
+                                                  get_default_physical_registry)
+from stratum.optimizer.physical._source_execs import (InMemoryFrame,
+                                                       PandasInMemoryFrame,
+                                                       PolarsInMemoryFrame)
 from stratum.optimizer.physical._transform_execs import StringEncoderOp
 from stratum.optimizer.ir._ops import Op, ValueOp
 
@@ -109,6 +114,114 @@ class TestDefaultImplementationSelector(unittest.TestCase):
         self.assertIsNone(selector.choose(DummyOp(), [], _ctx()))
 
 
+class TestGreedyImplementationSelector(unittest.TestCase):
+    def test_greedy_selector_is_configurable_and_snapshotted(self):
+        with st.config(implementation_selector="greedy"):
+            self.assertEqual(
+                "greedy", PlanContext.from_flags().implementation_selector)
+            self.assertIsInstance(
+                get_implementation_selector("greedy"),
+                GreedyImplementationSelector)
+
+    def test_preference_order_is_independent_of_plan_backend(self):
+        selector = GreedyImplementationSelector()
+        pandas = _impl(DummyOp, "pandas")
+        polars = _impl(DummyOp, "polars")
+        sklearn = _impl(DummyOp, "sklearn-skrub")
+        numpy = _impl(DummyOp, "numpy")
+        rust = _impl(DummyOp, "rust")
+
+        self.assertIs(rust, selector.choose(
+            DummyOp(), [pandas, sklearn, numpy, polars, rust], _ctx("pandas")))
+        self.assertIs(polars, selector.choose(
+            DummyOp(), [pandas, sklearn, numpy, polars], _ctx()))
+        self.assertIs(numpy, selector.choose(
+            DummyOp(), [pandas, sklearn, numpy], _ctx()))
+        self.assertIs(sklearn, selector.choose(
+            DummyOp(), [pandas, sklearn], _ctx()))
+
+    def test_falls_back_to_first_supported_candidate(self):
+        selector = GreedyImplementationSelector()
+        other_a = _impl(DummyOp, "some-other-backend")
+        other_b = _impl(DummyOp, "yet-another-backend")
+        self.assertIs(other_a, selector.choose(DummyOp(), [other_a, other_b], _ctx()))
+        self.assertIsNone(selector.choose(DummyOp(), [], _ctx()))
+
+    def test_does_not_consult_impl_cost(self):
+        # The greedy ranking must stay a static backend preference: it must
+        # not call the placeholder PhysicalImpl.cost.
+        def _boom(op, stats):
+            raise AssertionError("greedy selector must not call cost()")
+
+        rust = PhysicalImpl(op_type=DummyOp, backend_name="rust",
+                            input_format="frame", output_format="frame",
+                            supports=lambda op, ctx: True, cost=_boom,
+                            exec_mem=_placeholder_exec_mem,
+                            execute=_current_process_execute)
+        selector = GreedyImplementationSelector()
+        self.assertIs(rust, selector.choose(DummyOp(), [rust], _ctx()))
+
+    def test_supports_filter_runs_before_either_policy(self):
+        # bind_op filters through supports() before the selector runs; a
+        # selector never sees an unsupported candidate.
+        rust = _impl(DummyOp, "rust", supports=lambda op, ctx: False)
+        pandas = _impl(DummyOp, "pandas")
+        registry = PhysicalRegistry()
+        registry.register(rust)
+        registry.register(pandas)
+        candidates = [c for c in registry.candidates_for(DummyOp)
+                     if c.supports(DummyOp(), _ctx())]
+        self.assertEqual([pandas], candidates)
+        self.assertIs(pandas, GreedyImplementationSelector().choose(
+            DummyOp(), candidates, _ctx()))
+
+    def test_greedy_selector_prefers_polars_for_dataframe_source(self):
+        registry = get_default_physical_registry()
+        candidates = list(registry.candidates_for(InMemoryFrame))
+        op = InMemoryFrame(data=None)
+        chosen = GreedyImplementationSelector().choose(op, candidates, _ctx())
+        self.assertIs(PolarsInMemoryFrame, chosen.impl_class)
+
+    def test_small_dag_binds_independent_backends_per_operator(self):
+        # No global backend or conversion optimization: two ops in one DAG
+        # each bind to a different backend under greedy selection, purely
+        # from their own candidate lists -- there is no plan-wide reasoning
+        # about mixing backends.
+        class UpstreamOp(DummyOp, PhysicalOp):
+            is_abstract = False
+            def on_impl_selected(self, ctx):
+                pass
+
+        class DownstreamOp(DummyOp, PhysicalOp):
+            is_abstract = False
+            def on_impl_selected(self, ctx):
+                pass
+
+        class PolarsUpstream(UpstreamOp):
+            pass
+
+        class SklearnDownstream(DownstreamOp):
+            pass
+
+        registry = PhysicalRegistry()
+        # Rust is registered but unsupported here (filtered before selection
+        # runs), so polars -- next in the greedy ranking -- wins for Upstream.
+        registry.register(_impl(UpstreamOp, "rust", supports=lambda op, ctx: False))
+        registry.register(_impl(UpstreamOp, "polars", impl_class=PolarsUpstream))
+        registry.register(_impl(DownstreamOp, "sklearn-skrub",
+                                impl_class=SklearnDownstream))
+
+        upstream = UpstreamOp(inputs=[])
+        downstream = DownstreamOp(inputs=[upstream])
+        upstream.add_output(downstream)
+
+        select_implementations(downstream, _ctx(), registry=registry,
+                               selector=GreedyImplementationSelector())
+
+        self.assertIsInstance(upstream, PolarsUpstream)
+        self.assertIsInstance(downstream, SklearnDownstream)
+
+
 class TestPlanTimeBinding(unittest.TestCase):
     def test_on_impl_selected_runs_at_plan_time(self):
         """Choosing an impl swaps the op to its class and runs on_impl_selected."""
@@ -174,6 +287,14 @@ class TestTransformerPlanTimeBinding(unittest.TestCase):
         self.assertIsInstance(op.estimator, RustyStringEncoder)
         self.assertIsInstance(op.original_estimator, RustyStringEncoder)
         self.assertTrue(op.original_estimator._stratum_force_rust)
+
+    def test_greedy_selector_binds_rust_for_supported_transformer(self):
+        # Greedy ranks rust first; unlike the default selector it does not
+        # need rust_backend/allow_patch enabled -- support already gates it.
+        op = StringEncoderOp(estimator=self.encoder, cols=["a"])
+        select_implementations(op, _ctx(), selector=GreedyImplementationSelector())
+        self.assertIsInstance(op.estimator, RustyStringEncoder)
+        self.assertIsInstance(op.original_estimator, RustyStringEncoder)
 
     def test_no_swap_when_rust_disabled(self):
         df = pd.DataFrame({"a": ["apple", "banana", "cherry", "orange"]})

--- a/stratum/tests/physical/test_impl_selection.py
+++ b/stratum/tests/physical/test_impl_selection.py
@@ -16,14 +16,19 @@ from stratum.adapters.string_encoder import (RustyStringEncoder,
                                              supports_rust_string_encoder)
 from stratum.optimizer._optimize import optimize
 from stratum.optimizer.ir._ops import TransformerOp
-from stratum.optimizer.physical._impl_selection import (FlagBasedSelector,
-                                                        select_implementations)
+from stratum.optimizer.physical._impl_selection import (
+    DefaultImplementationSelector,
+    FlagBasedSelector,
+    get_implementation_selector,
+    select_implementations,
+)
 from stratum.optimizer.physical._physical_ops import PhysicalOp
 from stratum.optimizer.physical._plan_context import PlanContext
 from stratum.optimizer.physical._registry import (PhysicalImpl, PhysicalRegistry,
                                                   _current_process_execute,
                                                   _placeholder_cost,
                                                   _placeholder_exec_mem)
+from stratum.optimizer.physical._transform_execs import StringEncoderOp
 from stratum.optimizer.ir._ops import Op, ValueOp
 
 
@@ -67,6 +72,43 @@ class TestFlagBasedSelector(unittest.TestCase):
         self.assertIsNone(FlagBasedSelector().choose(DummyOp(), [], _ctx()))
 
 
+class TestDefaultImplementationSelector(unittest.TestCase):
+    def test_default_selector_is_configurable_and_snapshotted(self):
+        with st.config(implementation_selector="default"):
+            self.assertEqual(
+                "default", PlanContext.from_flags().implementation_selector)
+            self.assertIsInstance(
+                get_implementation_selector("default"),
+                DefaultImplementationSelector)
+
+    def test_unknown_selector_mode_is_rejected(self):
+        with self.assertRaises(ValueError):
+            with st.config(implementation_selector="unknown"):
+                pass
+
+    def test_preference_order_is_independent_of_plan_backend(self):
+        selector = DefaultImplementationSelector()
+        pandas = _impl(DummyOp, "pandas")
+        polars = _impl(DummyOp, "polars")
+        sklearn = _impl(DummyOp, "sklearn-skrub")
+        numpy = _impl(DummyOp, "numpy")
+        rust = _impl(DummyOp, "rust")
+
+        self.assertIs(pandas, selector.choose(
+            DummyOp(), [rust, polars, numpy, sklearn, pandas], _ctx("polars")))
+        self.assertIs(sklearn, selector.choose(
+            DummyOp(), [rust, polars, numpy, sklearn], _ctx()))
+        self.assertIs(numpy, selector.choose(
+            DummyOp(), [rust, polars, numpy], _ctx()))
+
+    def test_falls_back_to_first_supported_candidate(self):
+        selector = DefaultImplementationSelector()
+        polars = _impl(DummyOp, "polars")
+        rust = _impl(DummyOp, "rust")
+        self.assertIs(polars, selector.choose(DummyOp(), [polars, rust], _ctx()))
+        self.assertIsNone(selector.choose(DummyOp(), [], _ctx()))
+
+
 class TestPlanTimeBinding(unittest.TestCase):
     def test_on_impl_selected_runs_at_plan_time(self):
         """Choosing an impl swaps the op to its class and runs on_impl_selected."""
@@ -101,9 +143,8 @@ class TestPlanTimeBinding(unittest.TestCase):
         self.assertNotIsInstance(op, FailDummyOp)
 
 
-class TestRustKernelPlanTimeBinding(unittest.TestCase):
-    """End-to-end: with rust enabled, a supported StringEncoder TransformerOp
-    carries the Rust adapter after planning, before anything executes."""
+class TestTransformerPlanTimeBinding(unittest.TestCase):
+    """Default selection stays on skrub; explicit legacy selection can bind Rust."""
 
     def setUp(self):
         encoder = StringEncoder(vectorizer="tfidf", analyzer="char", n_components=2)
@@ -112,7 +153,7 @@ class TestRustKernelPlanTimeBinding(unittest.TestCase):
             self.skipTest(f"Rust StringEncoder unavailable: {reason}")
         self.encoder = encoder
 
-    def test_estimators_swapped_at_plan_time(self):
+    def test_default_selector_prefers_skrub_over_rust(self):
         df = pd.DataFrame({"a": ["apple", "banana", "cherry", "orange"]})
         data = st.as_data_op(df).skb.apply(self.encoder, cols=["a"])
         with st.config(rust_backend=True):
@@ -120,6 +161,16 @@ class TestRustKernelPlanTimeBinding(unittest.TestCase):
         transformer_ops = [op for op in ops if isinstance(op, TransformerOp)]
         self.assertEqual(1, len(transformer_ops))
         op = transformer_ops[0]
+        self.assertNotIsInstance(op.estimator, RustyStringEncoder)
+        self.assertNotIsInstance(op.original_estimator, RustyStringEncoder)
+
+    def test_explicit_flag_selector_binds_rust_for_abstract_physical_op(self):
+        op = StringEncoderOp(estimator=self.encoder, cols=["a"])
+        select_implementations(
+            op,
+            _ctx(rust=True),
+            selector=FlagBasedSelector(),
+        )
         self.assertIsInstance(op.estimator, RustyStringEncoder)
         self.assertIsInstance(op.original_estimator, RustyStringEncoder)
         self.assertTrue(op.original_estimator._stratum_force_rust)

--- a/stratum/tests/physical/test_registry.py
+++ b/stratum/tests/physical/test_registry.py
@@ -2,13 +2,23 @@ from stratum.optimizer.ir._dataframe_ops import ConcatOp
 from stratum.optimizer.ir._numeric_ops import NumericOp
 from stratum.optimizer.ir._ops import PredictorOp, Op, TransformerOp
 from stratum.optimizer.physical import (
-    CURRENT_BACKENDS,
-    CURRENT_LOGICAL_OPERATOR_TYPES,
-    OperatorFamily,
     PhysicalImpl,
+    PhysicalOp,
     PhysicalRegistry,
     RustPhysicalImpl,
     build_default_physical_registry,
+)
+from stratum.optimizer.physical._source_execs import (
+    InMemoryFrame,
+    NumpyLoad,
+    ReadCSV,
+    ReadParquet,
+    PandasInMemoryFrame,
+    PandasReadCSV,
+    PandasReadParquet,
+    PolarsInMemoryFrame,
+    PolarsReadCSV,
+    PolarsReadParquet,
 )
 from stratum.optimizer.physical._transform_execs import (RustOneHotEncoder,
                                                         RustStringEncoder,
@@ -16,16 +26,24 @@ from stratum.optimizer.physical._transform_execs import (RustOneHotEncoder,
                                                         StringEncoderOp)
 
 
-def test_default_registry_has_logical_surface_and_adapter_candidates():
+def test_default_registry_discovers_registered_operator_types():
     registry = build_default_physical_registry()
 
     assert not registry.empty()
     assert registry.op_types()
-    assert ConcatOp in CURRENT_LOGICAL_OPERATOR_TYPES
-    assert NumericOp in CURRENT_LOGICAL_OPERATOR_TYPES
-    assert "rust" in {backend.name for backend in CURRENT_BACKENDS}
-    # StringEncoder migrated to its own physical op, so only OneHotEncoder's rust
-    # kernel is still keyed on the logical TransformerOp.
+    # The registry surface comes from registrations, not a catalog of every
+    # logical IR type. NumericOp has no implementation and must not appear.
+    assert ConcatOp in registry.op_types()
+    assert NumericOp not in registry.op_types()
+
+    # Standalone construction imports source and transformer modules, so the
+    # already-migrated abstract physical operators are discoverable directly.
+    for op_type in (ReadCSV, ReadParquet, InMemoryFrame, NumpyLoad,
+                    StringEncoderOp):
+        assert op_type in registry.op_types()
+
+    # StringEncoder migrated to its own physical op, so only OneHotEncoder's
+    # Rust kernel is still keyed on the logical TransformerOp.
     rust_candidates = registry.candidates_for(TransformerOp, backend_name="rust")
     sklearn_candidates = registry.candidates_for(TransformerOp, backend_name="sklearn-skrub")
     assert len(rust_candidates) == 1
@@ -35,6 +53,14 @@ def test_default_registry_has_logical_surface_and_adapter_candidates():
     # The migrated StringEncoder physical op carries both a skrub and a rust impl.
     assert len(registry.candidates_for(StringEncoderOp, backend_name="rust")) == 1
     assert len(registry.candidates_for(StringEncoderOp, backend_name="sklearn-skrub")) == 1
+
+    source_candidates = {
+        ReadCSV: {PandasReadCSV, PolarsReadCSV},
+        ReadParquet: {PandasReadParquet, PolarsReadParquet},
+        InMemoryFrame: {PandasInMemoryFrame, PolarsInMemoryFrame},
+    }
+    for op_type, impl_classes in source_candidates.items():
+        assert {candidate.impl_class for candidate in registry.candidates_for(op_type)} == impl_classes
 
 
 def test_rust_kernels_are_class_based_impls():
@@ -69,28 +95,28 @@ def test_rust_impl_is_its_own_dataclass_with_capability_hints():
     assert not hasattr(skrub, "releases_gil")
 
 
-def test_registry_registers_and_queries_impls_by_logical_type():
+def test_registry_registers_and_queries_impls_by_registered_type():
     registry = PhysicalRegistry()
 
-    class DummyOp(Op):
+    class DummyPhysicalOp(PhysicalOp):
         pass
 
     pandas_impl = PhysicalImpl(
-        op_type=DummyOp,
+        op_type=DummyPhysicalOp,
         backend_name="pandas",
         input_format="frame",
         output_format="frame",
-        supports=lambda op: isinstance(op, DummyOp),
+        supports=lambda op, ctx: isinstance(op, DummyPhysicalOp),
         cost=lambda op, stats: 1.0,
         exec_mem=lambda op, stats: 1,
         execute=lambda op, mode, inputs: ("concat", mode, len(inputs)),
     )
     rust_impl = PhysicalImpl(
-        op_type=DummyOp,
+        op_type=DummyPhysicalOp,
         backend_name="rust",
         input_format="frame",
         output_format="frame",
-        supports=lambda op: isinstance(op, DummyOp),
+        supports=lambda op, ctx: isinstance(op, DummyPhysicalOp),
         cost=lambda op, stats: 0.5,
         exec_mem=lambda op, stats: 1,
         execute=lambda op, mode, inputs: ("rust-concat", mode, len(inputs)),
@@ -99,23 +125,15 @@ def test_registry_registers_and_queries_impls_by_logical_type():
     registry.register(pandas_impl)
     registry.register(rust_impl)
 
-    assert registry.candidates_for(DummyOp) == (pandas_impl, rust_impl)
-    assert registry.candidates_for_op(DummyOp()) == (pandas_impl, rust_impl)
-    assert registry.candidates_for(DummyOp, backend_name="rust") == (rust_impl,)
-    assert registry.backends_for(DummyOp) == ("pandas", "rust")
+    assert registry.candidates_for(DummyPhysicalOp) == (pandas_impl, rust_impl)
+    assert registry.candidates_for_op(DummyPhysicalOp()) == (pandas_impl, rust_impl)
+    assert registry.candidates_for(DummyPhysicalOp, backend_name="rust") == (rust_impl,)
+    assert registry.backends_for(DummyPhysicalOp) == ("pandas", "rust")
     assert registry.candidates_by_backend("pandas") == (pandas_impl,)
     assert registry.candidates_by_backend("rust") == (rust_impl,)
 
+    class UnregisteredLogicalOp(Op):
+        pass
 
-def test_register_family_tracks_known_logical_types():
-    registry = PhysicalRegistry()
-
-    family = OperatorFamily(
-        name="custom",
-        op_types=(ConcatOp,),
-        default_backends=("pandas",),
-    )
-    registry.register_family(family)
-
-    assert registry.families() == (family,)
-    assert ConcatOp in registry.op_types()
+    assert DummyPhysicalOp in registry.op_types()
+    assert UnregisteredLogicalOp not in registry.op_types()

--- a/stratum/tests/physical/test_source_execs.py
+++ b/stratum/tests/physical/test_source_execs.py
@@ -54,30 +54,30 @@ class TestSourceImplSelection(unittest.TestCase):
     def _read_csv_ops(self):
         return csv_file(self.df)
 
-    def test_in_memory_frame_impls(self):
+    def test_default_selector_prefers_pandas_in_memory_frame(self):
         ops, *_ = optimize(st.as_data_op(self.df))
         self.assertIsInstance(ops[0], PandasInMemoryFrame)
         with force_polars(True):
             ops, *_ = optimize(st.as_data_op(self.df))
-        self.assertIsInstance(ops[0], PolarsInMemoryFrame)
+        self.assertIsInstance(ops[0], PandasInMemoryFrame)
 
-    def test_read_csv_impls(self):
+    def test_default_selector_prefers_pandas_read_csv(self):
         with self._read_csv_ops() as path:
             data = st.as_data_op(path).skb.apply_func(pd.read_csv)
             ops, *_ = optimize(data, OptConfig(dataframe_ops=True))
             self.assertIsInstance(ops[-1], PandasReadCSV)
             with force_polars(True):
                 ops, *_ = optimize(data, OptConfig(dataframe_ops=True))
-            self.assertIsInstance(ops[-1], PolarsReadCSV)
+            self.assertIsInstance(ops[-1], PandasReadCSV)
 
-    def test_read_parquet_impls(self):
+    def test_default_selector_prefers_pandas_read_parquet(self):
         with parquet_file(self.df) as path:
             data = st.as_data_op(path).skb.apply_func(pd.read_parquet)
             ops, *_ = optimize(data, OptConfig(dataframe_ops=True))
             self.assertIsInstance(ops[-1], PandasReadParquet)
             with force_polars(True):
                 ops, *_ = optimize(data, OptConfig(dataframe_ops=True))
-            self.assertIsInstance(ops[-1], PolarsReadParquet)
+            self.assertIsInstance(ops[-1], PandasReadParquet)
 
     def test_npy_is_single_impl(self):
         # np.load yields an ndarray; a single concrete impl serves both backends.
@@ -113,7 +113,7 @@ class TestSourcesInRegistry(unittest.TestCase):
             self.assertEqual({"pandas", "polars"},
                              {c.backend_name for c in candidates})
 
-    def test_numpy_load_is_catalogued(self):
+    def test_numpy_load_is_registered(self):
         candidates = self.registry.candidates_for(NumpyLoad)
         self.assertEqual(("numpy",), tuple(c.backend_name for c in candidates))
 
@@ -203,12 +203,12 @@ class TestExecutionIsBranchFree(unittest.TestCase):
             result = run_plan(ops)
         self.assertIsInstance(result, pd.DataFrame)
 
-    def test_in_memory_polars_plan_ignores_runtime_flag(self):
+    def test_default_in_memory_plan_ignores_backend_flag(self):
         with force_polars(True):
-            ops, *_ = optimize(st.as_data_op(self.df))  # planned as polars
-        with force_polars(False):                        # flag flipped back
+            ops, *_ = optimize(st.as_data_op(self.df))  # default still plans pandas
+        with force_polars(False):
             result = run_plan(ops)
-        self.assertIsInstance(result, pl.DataFrame)
+        self.assertIsInstance(result, pd.DataFrame)
 
     def test_read_csv_pandas_plan_ignores_runtime_flag(self):
         with csv_file(self.df) as path:
@@ -218,14 +218,14 @@ class TestExecutionIsBranchFree(unittest.TestCase):
                 result = run_plan(ops)
         self.assertIsInstance(result, pd.DataFrame)
 
-    def test_read_csv_polars_plan_ignores_runtime_flag(self):
+    def test_default_read_csv_plan_ignores_backend_flag(self):
         with csv_file(self.df) as path:
             data = st.as_data_op(path).skb.apply_func(pd.read_csv)
             with force_polars(True):
-                ops, *_ = optimize(data, OptConfig(dataframe_ops=True))  # polars plan
+                ops, *_ = optimize(data, OptConfig(dataframe_ops=True))
             with force_polars(False):
                 result = run_plan(ops)
-        self.assertIsInstance(result, pl.DataFrame)
+        self.assertIsInstance(result, pd.DataFrame)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These commits implements two baseline operator selection. The default selector selects popular (and slower) backends for the physical operators (e.g., Pandas, skrub/sklearn), and greedy selector selects efficient alternatives greedily (e.g., Polars, Rust). In addition to focused unit tests, an end-to-end test creates a DataOps pipeline with available physical operator to test the selectors.
This is just the initial commit. The next step is to conduct more testing with larger pipelines.