### PR TITLE
[Benchmark] adds minmaxscaler benchmarks

### DIFF
--- a/benchmarks/adapters/minmax_bench/minmax.py
+++ b/benchmarks/adapters/minmax_bench/minmax.py
@@ -1,0 +1,109 @@
+"""
+Benchmarks stratum's Rust-backed MinMaxScaler against scikit-learn's, for a
+single thread count, and appends the results to a CSV.
+
+The Rust thread pool is built once per process (see _rust/src/threads.rs),
+so sweeping across thread counts requires re-invoking this script once per
+--n-jobs value in a fresh process -- see run_macrobenchmark_minmax.sh.
+"""
+
+import argparse
+import time
+from pathlib import Path
+from statistics import median
+
+from sklearn.preprocessing import MinMaxScaler as SKMinMaxScaler
+from stratum import MinMaxScaler as RustyMinMaxScaler, set_config
+
+from minmax_benchmarkutils import warmup, get_synthetic_data
+
+N_REPS = 5
+N_COLS_LIST = [10, 50, 100]
+N_ROWS_LIST = [100_000, 1_000_000, 10_000_000]
+DEFAULT_OUT = Path(__file__).parent / "results" / "macrobenchmark_minmax.csv"
+
+
+def benchmark_rust(data, n_jobs):
+    set_config(rust_backend=True, num_threads=n_jobs)
+    scaler = RustyMinMaxScaler(n_jobs=n_jobs)
+
+    fit_times = []
+    for _ in range(N_REPS):
+        t0 = time.perf_counter()
+        scaler.fit(data)
+        fit_times.append((time.perf_counter() - t0) * 1000)
+    fit_ms = median(fit_times)
+
+    transform_times = []
+    for _ in range(N_REPS):
+        t0 = time.perf_counter()
+        scaler.transform(data)
+        transform_times.append((time.perf_counter() - t0) * 1000)
+    transform_ms = median(transform_times)
+
+    return fit_ms, transform_ms
+
+
+def benchmark_sklearn(data):
+    set_config(rust_backend=False)
+    scaler = SKMinMaxScaler()
+
+    fit_times = []
+    for _ in range(N_REPS):
+        t0 = time.perf_counter()
+        scaler.fit(data)
+        fit_times.append((time.perf_counter() - t0) * 1000)
+    fit_ms = median(fit_times)
+
+    transform_times = []
+    for _ in range(N_REPS):
+        t0 = time.perf_counter()
+        scaler.transform(data)
+        transform_times.append((time.perf_counter() - t0) * 1000)
+    transform_ms = median(transform_times)
+
+    return fit_ms, transform_ms
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        required=True,
+        help="Thread count for this run. The Rust thread pool is fixed for "
+        "the process lifetime, so run this script once per n_jobs value.",
+    )
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    warmup(args.n_jobs)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not args.out.exists()
+
+    with open(args.out, "a") as f:
+        if write_header:
+            f.write("n_jobs,n_cols,n_rows,version,fit_ms,transform_ms\n")
+
+        for n_cols in N_COLS_LIST:
+            for n_rows in N_ROWS_LIST:
+                data = get_synthetic_data(n_rows=n_rows, n_cols=n_cols)
+
+                # sklearn's timing doesn't depend on n_jobs; only run it once.
+                if args.n_jobs == 1:
+                    fit_ms, transform_ms = benchmark_sklearn(data)
+                    f.write(
+                        f"{args.n_jobs},{n_cols},{n_rows},sklearn,{fit_ms:.9f},{transform_ms:.9f}\n"
+                    )
+                    f.flush()
+
+                fit_ms, transform_ms = benchmark_rust(data, args.n_jobs)
+                f.write(
+                    f"{args.n_jobs},{n_cols},{n_rows},rust,{fit_ms:.9f},{transform_ms:.9f}\n"
+                )
+                f.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/adapters/minmax_bench/minmax_benchmarkutils.py
+++ b/benchmarks/adapters/minmax_bench/minmax_benchmarkutils.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the MinMaxScaler macrobenchmark."""
+import gc
+
+import numpy as np
+from sklearn.preprocessing import MinMaxScaler as SKMinMaxScaler
+from stratum import MinMaxScaler as RustyMinMaxScaler, set_config
+
+SEED = 67
+
+
+def get_synthetic_data(n_rows, n_cols, seed=SEED):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(size=(n_rows, n_cols), dtype=np.float32)
+
+
+def get_synthetic_data_64(n_rows, n_cols, seed=SEED):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal(size=(n_rows, n_cols), dtype=np.float64)
+
+
+def warmup(n_jobs: int) -> None:
+    """Touch both backends once so import/JIT overhead doesn't skew timings.
+
+    Also locks in the Rust thread pool at `n_jobs` threads: it is built once
+    per process (see _rust/src/threads.rs) from whatever SKRUB_RUST_THREADS
+    is set to on first use, so this must run before any timed rust call.
+    """
+    data = get_synthetic_data(2048, 4)
+
+    set_config(rust_backend=False)
+    SKMinMaxScaler().fit_transform(data)
+
+    set_config(rust_backend=True, num_threads=n_jobs)
+    RustyMinMaxScaler(n_jobs=n_jobs).fit_transform(data)
+
+    gc.collect()

--- a/benchmarks/adapters/minmax_bench/minmax_phases.py
+++ b/benchmarks/adapters/minmax_bench/minmax_phases.py
@@ -1,0 +1,118 @@
+import argparse
+import os
+import re
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from stratum import MinMaxScaler as RustyMinMaxScaler, set_config
+
+from minmax_benchmarkutils import warmup, get_synthetic_data
+
+N_REPS = 5
+N_COLS = 50
+N_ROWS_LIST = [100_0000, 10_000_000]
+DEFAULT_OUT = Path(__file__).parent / "results" / "minmax_phases.csv"
+
+
+@contextmanager
+def capture_rust_stderr():
+    """Redirect the OS-level stderr fd so Rust's `eprintln!` output (which
+    bypasses Python's sys.stderr) can be captured and parsed."""
+    saved_fd = os.dup(2)
+    tmp = tempfile.TemporaryFile(mode="w+b")
+    os.dup2(tmp.fileno(), 2)
+    box = {"text": ""}
+    try:
+        yield box
+    finally:
+        os.dup2(saved_fd, 2)
+        os.close(saved_fd)
+        tmp.seek(0)
+        box["text"] = tmp.read().decode("utf-8", errors="replace")
+        tmp.close()
+
+
+def parse_ms(text, label):
+    pattern = re.escape(f"[rust] {label}: ") + r"(\d+)ms"
+    return [int(m) for m in re.findall(pattern, text)]
+
+
+def median(values):
+    values = sorted(values)
+    mid = len(values) // 2
+    if len(values) % 2 == 0:
+        return (values[mid - 1] + values[mid]) / 2
+    return values[mid]
+
+
+def benchmark_phases(data, n_jobs):
+    set_config(rust_backend=True, allow_patch=True, debug_timing=True, num_threads=n_jobs)
+    scaler = RustyMinMaxScaler(n_jobs=n_jobs)
+
+    with capture_rust_stderr() as box:
+        t0 = time.perf_counter()
+        for _ in range(N_REPS):
+            scaler.fit(data)
+        fit_outer_ms = (time.perf_counter() - t0) * 1000 / N_REPS
+
+        t0 = time.perf_counter()
+        for _ in range(N_REPS):
+            scaler.transform(data)
+        transform_outer_ms = (time.perf_counter() - t0) * 1000 / N_REPS
+    text = box["text"]
+
+    fit_samples = parse_ms(text, "minmax scale fit")
+    transform_samples = parse_ms(text, "minmax scale transform")
+    if len(fit_samples) != N_REPS or len(transform_samples) != N_REPS:
+        raise RuntimeError(
+            f"Expected {N_REPS} '[rust] minmax scale fit/transform' timing "
+            f"samples each, got {len(fit_samples)}/{len(transform_samples)} -- "
+            "either the Rust fastpath didn't run at all (check "
+            "_supported_params eligibility and rust_backend/allow_patch "
+            "config), or it silently fell back to sklearn on a subset of "
+            "reps (see RustyMinMaxScaler.transform's try/except)."
+        )
+
+    fit_ms = median(fit_samples)
+    transform_ms = median(transform_samples)
+    outer_ms = fit_outer_ms + transform_outer_ms
+    ffi_ms = outer_ms - fit_ms - transform_ms
+
+    return ffi_ms, fit_ms, transform_ms
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        required=True,
+        help="Thread count for this run. The Rust thread pool is fixed for "
+        "the process lifetime, so run this script once per n_jobs value.",
+    )
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    warmup(args.n_jobs)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not args.out.exists()
+
+    with open(args.out, "a") as f:
+        if write_header:
+            f.write("n_jobs,n_rows,n_cols,ffi_ms,fit_ms,transform_ms\n")
+
+        for n_rows in N_ROWS_LIST:
+            data = get_synthetic_data(n_rows=n_rows, n_cols=N_COLS)
+
+            ffi_ms, fit_ms, transform_ms = benchmark_phases(data, args.n_jobs)
+            f.write(
+                f"{args.n_jobs},{n_rows},{N_COLS},{ffi_ms:.9f},{fit_ms:.9f},{transform_ms:.9f}\n"
+            )
+            f.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/adapters/minmax_bench/plot_minmax.py
+++ b/benchmarks/adapters/minmax_bench/plot_minmax.py
@@ -1,0 +1,173 @@
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.patches import Patch
+
+HERE = Path(__file__).parent
+
+df_all = pd.read_csv(HERE / "results" / "macrobenchmark_minmax.csv")
+df = df_all[df_all["version"] == "rust"]
+df_sklearn = df_all[df_all["version"] == "sklearn"]
+
+only_1m = "--1m" in sys.argv
+args = [a for a in sys.argv[1:] if a != "--1m"]
+out_suffix = args[0] if args else "all"
+
+UNIT = "ms"
+n_jobs_vals = sorted(df["n_jobs"].unique())
+col_vals = sorted(df["n_cols"].unique())
+row_vals = [1_000_000] if only_1m else [100_000, 1_000_000, 10_000_000]
+
+GRID_COLS = 1
+GRID_ROWS = len(row_vals)
+
+fig, axes = plt.subplots(
+    GRID_ROWS,
+    GRID_COLS,
+    figsize=(8, 3.4 * GRID_ROWS),
+    squeeze=False,
+)
+
+njobs_colors = {
+    1: "#C4C4C4",
+    2: "#525252",
+    4: "#f47e7e",
+    8: "#620000",
+    24: "#c1272d",
+}
+sklearn_color = "#444444"
+
+FIT_HATCH = "///"
+
+n_bars = len(n_jobs_vals) + 1
+total_width = 0.7
+bar_width = total_width / n_bars
+offsets = np.linspace(
+    -(total_width - bar_width) / 2, (total_width - bar_width) / 2, n_bars
+)
+
+for i, n_rows in enumerate(row_vals):
+    ax = axes[i][0]
+    sub = df[df["n_rows"] == n_rows]
+    sub_sklearn = df_sklearn[df_sklearn["n_rows"] == n_rows]
+    x = np.arange(len(col_vals))
+
+    sklearn_fit, sklearn_transform = [], []
+    for c in col_vals:
+        row = sub_sklearn[sub_sklearn.n_cols == c]
+        sklearn_fit.append(row.fit_ms.iloc[0] if not row.empty else float("nan"))
+        sklearn_transform.append(
+            row.transform_ms.iloc[0] if not row.empty else float("nan")
+        )
+    ax.bar(
+        x + offsets[0],
+        sklearn_fit,
+        bar_width,
+        color=sklearn_color,
+        hatch=FIT_HATCH,
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    ax.bar(
+        x + offsets[0],
+        sklearn_transform,
+        bar_width,
+        bottom=sklearn_fit,
+        color=sklearn_color,
+    )
+    sklearn_totals = [f + t for f, t in zip(sklearn_fit, sklearn_transform)]
+
+    for offset, n_jobs in zip(offsets[1:], n_jobs_vals):
+        fit_times, transform_times = [], []
+        for c in col_vals:
+            row = sub[(sub.n_cols == c) & (sub.n_jobs == n_jobs)]
+            fit_times.append(row.fit_ms.iloc[0] if not row.empty else float("nan"))
+            transform_times.append(
+                row.transform_ms.iloc[0] if not row.empty else float("nan")
+            )
+        color = njobs_colors[n_jobs]
+        ax.bar(
+            x + offset,
+            fit_times,
+            bar_width,
+            color=color,
+            hatch=FIT_HATCH,
+            edgecolor="black",
+            linewidth=0.4,
+        )
+        ax.bar(
+            x + offset,
+            transform_times,
+            bar_width,
+            bottom=fit_times,
+            color=color,
+        )
+        totals = [f + t for f, t in zip(fit_times, transform_times)]
+
+        if n_jobs in (1, n_jobs_vals[-1]):
+            origin_nudge = (-1 if n_jobs == 1 else 0) * 0.015
+            for xi_sklearn, xi_rust, tot, st in zip(
+                x + offsets[0], x + offset, totals, sklearn_totals
+            ):
+                origin_y = st * (1 + origin_nudge)
+                ax.annotate(
+                    "",
+                    xy=(xi_rust, tot),
+                    xytext=(xi_sklearn, origin_y),
+                    arrowprops=dict(
+                        arrowstyle="->",
+                        color="black",
+                        lw=0.8,
+                        connectionstyle="angle,angleA=0,angleB=90",
+                    ),
+                )
+                ax.annotate(
+                    f"{st / tot:.1f}×",
+                    xy=(xi_rust, (origin_y + tot) / 2),
+                    xytext=(4, 0),
+                    textcoords="offset points",
+                    ha="left",
+                    va="center",
+                    fontsize=7,
+                )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(col_vals)
+    if not only_1m:
+        ax.set_title(f"n_rows = {n_rows:,}")
+    ax.set_xlabel("n_cols")
+    ax.set_ylabel(f"time ({UNIT})")
+    ax.grid(True, axis="y", ls=":", alpha=0.5)
+
+legend_handles = [Patch(color=sklearn_color, label="sklearn")]
+legend_handles += [Patch(color=njobs_colors[j], label=str(j)) for j in n_jobs_vals]
+legend_handles.append(
+    Patch(
+        facecolor="white",
+        edgecolor="black",
+        hatch=FIT_HATCH,
+        label="fit (transform solid)",
+    )
+)
+if not only_1m:
+    addition = 0.05
+else:
+    addition = 0.12
+fig.legend(
+    handles=legend_handles,
+    title="rust (n_jobs)",
+    ncol=len(n_jobs_vals) + 2,
+    loc="upper center",
+    bbox_to_anchor=(0.5, 1 + addition),
+)
+fig.tight_layout()
+(HERE / "plots").mkdir(parents=True, exist_ok=True)
+fig.savefig(
+    HERE / "plots" / f"macrobenchmark_minmax_njobs_{out_suffix}.png",
+    dpi=150,
+    bbox_inches="tight",
+)
+plt.show()

--- a/benchmarks/adapters/minmax_bench/plot_minmax_phases.py
+++ b/benchmarks/adapters/minmax_bench/plot_minmax_phases.py
@@ -1,0 +1,114 @@
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.patches import Patch
+
+HERE = Path(__file__).parent
+
+df = pd.read_csv(HERE / "results" / "minmax_phases.csv")
+
+only_big = "--big" in sys.argv
+args = [a for a in sys.argv[1:] if a != "--big"]
+out_suffix = args[0] if args else "all"
+
+UNIT = "ms"
+n_jobs_vals = sorted(df["n_jobs"].unique())
+row_vals = [10_000_000] if only_big else sorted(df["n_rows"].unique())
+
+GRID_COLS = 1
+GRID_ROWS = len(row_vals)
+
+fig, axes = plt.subplots(
+    GRID_ROWS,
+    GRID_COLS,
+    figsize=(6, 3.4 * GRID_ROWS),
+    squeeze=False,
+)
+
+phase_colors = {
+    "FFI/materialize": "#C4C4C4",
+    "fit": "#f47e7e",
+    "transform": "#c1272d",
+}
+
+x = np.arange(len(n_jobs_vals))
+bar_width = 0.5
+
+for i, n_rows in enumerate(row_vals):
+    ax = axes[i][0]
+    sub = df[df["n_rows"] == n_rows]
+
+    ffi_times, fit_times, transform_times = [], [], []
+    for n_jobs in n_jobs_vals:
+        row = sub[sub.n_jobs == n_jobs]
+        ffi_times.append(row.ffi_ms.iloc[0] if not row.empty else float("nan"))
+        fit_times.append(row.fit_ms.iloc[0] if not row.empty else float("nan"))
+        transform_times.append(row.transform_ms.iloc[0] if not row.empty else float("nan"))
+
+    ax.bar(
+        x,
+        ffi_times,
+        bar_width,
+        color=phase_colors["FFI/materialize"],
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    ax.bar(
+        x,
+        fit_times,
+        bar_width,
+        bottom=ffi_times,
+        color=phase_colors["fit"],
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    transform_bottom = [f + m for f, m in zip(ffi_times, fit_times)]
+    ax.bar(
+        x,
+        transform_times,
+        bar_width,
+        bottom=transform_bottom,
+        color=phase_colors["transform"],
+        edgecolor="black",
+        linewidth=0.4,
+    )
+
+    totals = [f + m + r for f, m, r in zip(ffi_times, fit_times, transform_times)]
+    for xi, tot in zip(x, totals):
+        ax.annotate(
+            f"{tot:.0f}ms",
+            xy=(xi, tot),
+            xytext=(0, 3),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=7,
+        )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(n_jobs_vals)
+    if not only_big:
+        ax.set_title(f"n_rows = {n_rows:,}")
+    ax.set_xlabel("n_jobs")
+    ax.set_ylabel(f"time ({UNIT})")
+    ax.grid(True, axis="y", ls=":", alpha=0.5)
+
+legend_handles = [Patch(color=phase_colors[p], label=p) for p in ("FFI/materialize", "fit", "transform")]
+fig.legend(
+    handles=legend_handles,
+    title="phase",
+    ncol=3,
+    loc="upper center",
+    bbox_to_anchor=(0.5, 1.05),
+)
+fig.tight_layout()
+(HERE / "plots").mkdir(parents=True, exist_ok=True)
+fig.savefig(
+    HERE / "plots" / f"minmax_phases_{out_suffix}.png",
+    dpi=150,
+    bbox_inches="tight",
+)
+plt.show()

--- a/benchmarks/adapters/minmax_bench/run_minmax.sh
+++ b/benchmarks/adapters/minmax_bench/run_minmax.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${HERE}/results/macrobenchmark_minmax.csv"
+N_JOBS_LIST=(1 2 4 8)
+
+rm -f "${OUT}"
+
+for n_jobs in "${N_JOBS_LIST[@]}"; do
+    echo "=== n_jobs=${n_jobs} ==="
+    python3 "${HERE}/minmax.py" --n-jobs "${n_jobs}" --out "${OUT}"
+done
+
+python3 "${HERE}/plot_minmax.py"

--- a/benchmarks/adapters/minmax_bench/run_minmax_phases.sh
+++ b/benchmarks/adapters/minmax_bench/run_minmax_phases.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${HERE}/results/minmax_phases.csv"
+N_JOBS_LIST=(1 2 4 8)
+
+rm -f "${OUT}"
+
+for n_jobs in "${N_JOBS_LIST[@]}"; do
+    echo "=== n_jobs=${n_jobs} ==="
+    python3 "${HERE}/minmax_phases.py" --n-jobs "${n_jobs}" --out "${OUT}"
+done
+
+python3 "${HERE}/plot_minmax_phases.py"


### PR DESCRIPTION
Adds benchmarking for MinMaxScaler Rust Kernel. Since only 4 Performance cores are available on the benchmark laptop the parallelization gains stop after 4 jobs. On machines with more cores the results are expected differently as shown in the feature PR.

FFI/Materialize costs are measures when having a full data recast to f32 before actual kernel. If the data is already f32 the benchmarks shift to the second image.


<img width="883" height="1066" alt="minmax_phases_all" src="https://github.com/user-attachments/assets/a9de6e78-6a90-4273-b767-93f4d102d21e" />

<img width="883" height="1066" alt="minmax_phases_all" src="https://github.com/user-attachments/assets/e166c1c8-19c6-4708-a88f-51cb7284ee05" />
<img width="1183" height="1600" alt="macrobenchmark_minmax_njobs_all" src="https://github.com/user-attachments/assets/710fc663-c904-41f0-a894-fd0d29a7e5a6" />
