### PR TITLE
[Rewrite] add generalized x-op-x matcher and use it to fold x * x -> square(x)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -14,6 +14,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_any_mul_zero,
     eliminate_div_by_one,
     fold_log_plus_one,
+    fold_self_multiply,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -38,6 +39,7 @@ class AlgebraicRewritesConfig:
     any_mul_zero: bool = True
     div_by_one: bool = True
     log_plus_one: bool = True
+    self_multiply: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -55,6 +57,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
         root = eliminate_exp_log(root)
     if config.abs_abs:
         root = eliminate_abs_abs(root)
+    if config.self_multiply:
+        root = fold_self_multiply(root)
     if config.sqrt_square:
         root = eliminate_sqrt_square(root)
     if config.exp_minus_one:

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -143,14 +143,18 @@ def fold_to_one(op: Op, root: Op) -> Op:
     replace_op_in_outputs(op, one_op)
     return one_op if op is root else root
 
-def match_self_multiply(op):
-    """Match a multiply whose two operands are the same node (x * x)."""
-    return (op,) if (
-        isinstance(op, NumericOp)
-        and op.type is NumericOpType.MULTIPLY
-        and isinstance(op.opt_operand, OperandRef)
-        and op.inputs[op.opt_operand.k] is op.inputs[0]
-    ) else None
+def match_self_operation(op_cls, type1):
+    """Match a var-var operation whose two operands are the same node (x <op> x)."""
+    def match(op):
+        if (
+            isinstance(op, op_cls)
+            and op.type is type1
+            and isinstance(op.opt_operand, OperandRef)
+            and op.inputs[op.opt_operand.k] is op.inputs[0]
+        ):
+            return (op,)
+        return None
+    return match
 
 
 
@@ -252,4 +256,7 @@ eliminate_div_by_one = rewrite_pass(
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
 
-fold_self_multiply = rewrite_pass(match_self_multiply, fold_to_square)
+fold_self_multiply = rewrite_pass(
+    match_self_operation(NumericOp, NumericOpType.MULTIPLY),
+    fold_to_square,
+)

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,6 +1,6 @@
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
-from stratum.optimizer.ir._ops import Op, ValueOp
+from stratum.optimizer.ir._ops import Op, ValueOp, OperandRef
 
 
 def _is_scalar_const(value) -> bool:
@@ -143,6 +143,25 @@ def fold_to_one(op: Op, root: Op) -> Op:
     replace_op_in_outputs(op, one_op)
     return one_op if op is root else root
 
+def match_self_multiply(op):
+    """Match a multiply whose two operands are the same node (x * x)."""
+    return (op,) if (
+        isinstance(op, NumericOp)
+        and op.type is NumericOpType.MULTIPLY
+        and isinstance(op.opt_operand, OperandRef)
+        and op.inputs[op.opt_operand.k] is op.inputs[0]
+    ) else None
+
+
+
+def fold_to_square(op: Op, root: Op) -> Op:
+    """Rewrite a self-multiply into a square op, keeping its operand (x * x -> square(x))."""
+    x = op.inputs[0]
+    square_op = NumericOp(inputs=[], outputs=[], type=NumericOpType.SQUARE)
+    x.replace_output(op, square_op)
+    square_op.add_input(x)
+    replace_op_in_outputs(op, square_op)
+    return square_op if op is root else root
 
 match_exp_minus_one = match_two_op_chain(NumericOp, NumericOpType.EXP, NumericOpType.SUBTRACT,
     match2=lambda op: _matches_scalar_const(op, 1, reversed=False),
@@ -232,3 +251,5 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
+
+fold_self_multiply = rewrite_pass(match_self_multiply, fold_to_square)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -657,3 +657,78 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)
+
+    # x * x -> square(x)
+    def test_self_multiply_to_square(self):
+        """x * x  →  square(x)"""
+        df = st.as_data_op(5)
+        out, *_ = optimize(df * df)
+        self.assertEqual(len(out), 2)
+        self.assertIsInstance(out[1], NumericOp)
+        self.assertEqual(out[1].type, NumericOpType.SQUARE)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 25)
+
+    def test_self_multiply_negative_operand(self):
+        """(-5) * (-5)  →  square(-5) = 25."""
+        df = st.as_data_op(-5)
+        out, *_ = optimize(df * df)
+        self.assertEqual(out[1].type, NumericOpType.SQUARE)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 25)
+
+    def test_self_multiply_root_safe(self):
+        """x * x as the root DAG node must not break."""
+        value = st.as_data_op(7)
+        out, *_ = optimize(value * value)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].type, NumericOpType.SQUARE)
+
+    def test_self_multiply_disabled(self):
+        """self_multiply=False leaves x * x as a MULTIPLY."""
+        df = st.as_data_op(5)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(self_multiply=False),
+        )
+        out, *_ = optimize(df * df, config=config)
+        self.assertEqual(out[1].type, NumericOpType.MULTIPLY)
+
+    def test_no_rewrite_multiply_different_operands(self):
+        """x * y (different operands) must not become square."""
+        x = st.as_data_op(5)
+        y = st.as_data_op(3)
+        out, *_ = optimize(x * y)
+        self.assertFalse(any(isinstance(o, NumericOp) and o.type is NumericOpType.SQUARE for o in out))
+
+    def test_no_rewrite_multiply_by_constant(self):
+        """x * 3 (constant operand) must not become square."""
+        df = st.as_data_op(5)
+        out, *_ = optimize(df * 3)
+        self.assertFalse(any(isinstance(o, NumericOp) and o.type is NumericOpType.SQUARE for o in out))
+
+    def test_self_multiply_with_trailing_op(self):
+        """(x * x) + 3  →  square(x) + 3, keeping the trailing op."""
+        df = st.as_data_op(5)
+        out, *_ = optimize((df * df) + 3)
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[1].type, NumericOpType.SQUARE)
+        self.assertEqual(out[2].process("fit", [out[1].process("fit", [out[0].value])]), 28)
+
+    def test_self_multiply_then_sqrt_is_abs(self):
+        """sqrt(x * x) → sqrt(square(x)) → abs(x): composes with sqrt_square."""
+        df = st.as_data_op(-5)
+        out, *_ = optimize((df * df).skb.apply_func(np.sqrt))
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].type, NumericOpType.ABS)
+
+    def test_disable_self_multiply_does_not_affect_log_exp(self):
+        """Disabling self_multiply must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(self_multiply=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)


### PR DESCRIPTION
- Add a rewrite turning x * x into square(x). It generalizes the same-operand check into a reusable matcher match_self_operation(op_cls, type) (in the style of match_identity_operation) that matches any x <op> x, and reuses the existing rewiring functions to swap the multiply for a square op while keeping the operand.
- Wire it into AlgebraicRewritesConfig under self_multiply (default on), ordered before sqrt_square so sqrt(x * x) becomes abs(x).
- Add tests: fires with correct value, negative operand, root-safe, disabled flag, x * y and x * 3 not rewritten, trailing op, sqrt composition, and no suppression of other rewrites.