### PR TITLE
[Rewrite] merge consecutive constant additions so (x + c1) + c2 -> x + (c1 + c2)

### DIFF
--- a/stratum/optimizer/_algebraic_rewrites.py
+++ b/stratum/optimizer/_algebraic_rewrites.py
@@ -14,6 +14,7 @@ from stratum.optimizer._numeric_rewrites import (
     eliminate_any_mul_zero,
     eliminate_div_by_one,
     fold_log_plus_one,
+    fold_add_chain,
 )
 from stratum.optimizer.ir._ops import Op
 from stratum.utils._utils import start_time, log_time
@@ -38,6 +39,7 @@ class AlgebraicRewritesConfig:
     any_mul_zero: bool = True
     div_by_one: bool = True
     log_plus_one: bool = True
+    add_chain: bool = True
 
 
 def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
@@ -45,6 +47,8 @@ def algebraic_rewrites(root: Op, config: AlgebraicRewritesConfig) -> Op:
     start = start_time()
     if config.identity_op:
         root = eliminate_identity_operation(root)
+    if config.add_chain:
+        root = fold_add_chain(root)
     if config.add_zero:
         root = eliminate_add_zero(root)
     if config.div_by_one:

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -145,6 +145,32 @@ def fold_to_one(op: Op, root: Op) -> Op:
     return one_op if op is root else root
 
 
+def match_const_chain(type1):
+    """Match (x <op> c1) <op> c2: two consecutive var-const ops of the same type."""
+    def match(op1):
+        if not (isinstance(op1, NumericOp) and op1.type is type1
+                and op1.opt_operand is None and _is_scalar_const(op1.constant)
+                and not op1.reversed and len(op1.outputs) == 1):
+            return None
+        op2 = op1.outputs[0]
+        if (isinstance(op2, NumericOp) and op2.type is type1
+                and op2.opt_operand is None and _is_scalar_const(op2.constant)
+                and not op2.reversed):
+            return (op1, op2)
+        return None
+    return match
+
+
+def make_merge_const_chain(combine):
+    """Action factory: fold op2's constant into op1 via combine, then drop op2."""
+    def action(op1, op2, root):
+        op1.constant = combine(op1.constant, op2.constant)
+        op1.outputs = [out for out in op1.outputs if out is not op2]
+        replace_op_in_outputs(op2, op1)
+        return op1 if op2 is root else root
+    return action
+
+
 match_exp_minus_one = match_two_op_chain(NumericOp, NumericOpType.EXP, NumericOpType.SUBTRACT,
     match2=lambda op: _matches_scalar_const(op, 1, reversed=False),
 )
@@ -233,33 +259,6 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
-
-
-def match_const_chain(type1):
-    """Match (x <op> c1) <op> c2: two consecutive var-const ops of the same type."""
-    def match(op1):
-        if not (isinstance(op1, NumericOp) and op1.type is type1
-                and op1.opt_operand is None and _is_scalar_const(op1.constant)
-                and not op1.reversed and len(op1.outputs) == 1):
-            return None
-        op2 = op1.outputs[0]
-        if (isinstance(op2, NumericOp) and op2.type is type1
-                and op2.opt_operand is None and _is_scalar_const(op2.constant)
-                and not op2.reversed):
-            return (op1, op2)
-        return None
-    return match
-
-
-def make_merge_const_chain(combine):
-    """Action factory: fold op2's constant into op1 via combine, then drop op2."""
-    def action(op1, op2, root):
-        op1.constant = combine(op1.constant, op2.constant)
-        op1.outputs = [out for out in op1.outputs if out is not op2]
-        replace_op_in_outputs(op2, op1)
-        return op1 if op2 is root else root
-    return action
-
 
 # Constant accumulation: (x + c1) + c2 rewritten as x + (c1 + c2)
 fold_add_chain = rewrite_pass(

--- a/stratum/optimizer/_numeric_rewrites.py
+++ b/stratum/optimizer/_numeric_rewrites.py
@@ -1,3 +1,4 @@
+import operator
 from stratum.optimizer.ir._numeric_ops import NumericOp, NumericOpType
 from stratum.optimizer._op_utils import rewrite_pass, replace_op_in_outputs
 from stratum.optimizer.ir._ops import Op, ValueOp
@@ -232,3 +233,36 @@ eliminate_div_by_one = rewrite_pass(
 )
 
 fold_log_plus_one = rewrite_pass(match_add_one_then_log, _replace_with_log1p)
+
+
+def match_const_chain(type1):
+    """Match (x <op> c1) <op> c2: two consecutive var-const ops of the same type."""
+    def match(op1):
+        if not (isinstance(op1, NumericOp) and op1.type is type1
+                and op1.opt_operand is None and _is_scalar_const(op1.constant)
+                and not op1.reversed and len(op1.outputs) == 1):
+            return None
+        op2 = op1.outputs[0]
+        if (isinstance(op2, NumericOp) and op2.type is type1
+                and op2.opt_operand is None and _is_scalar_const(op2.constant)
+                and not op2.reversed):
+            return (op1, op2)
+        return None
+    return match
+
+
+def make_merge_const_chain(combine):
+    """Action factory: fold op2's constant into op1 via combine, then drop op2."""
+    def action(op1, op2, root):
+        op1.constant = combine(op1.constant, op2.constant)
+        op1.outputs = [out for out in op1.outputs if out is not op2]
+        replace_op_in_outputs(op2, op1)
+        return op1 if op2 is root else root
+    return action
+
+
+# Constant accumulation: (x + c1) + c2 rewritten as x + (c1 + c2)
+fold_add_chain = rewrite_pass(
+    match_const_chain(NumericOpType.ADD),
+    make_merge_const_chain(operator.add),
+)

--- a/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
+++ b/stratum/tests/logical_optimizer/algebraic_rewrites/test_numeric.py
@@ -657,3 +657,75 @@ class TestCSE(unittest.TestCase):
         out, *_ = optimize(t2, config=config)
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0].value, 1)
+
+    # (x + c1) + c2 -> x + (c1 + c2)
+    def test_add_chain_fires(self):
+        """(x + 2) + 3  →  x + 5 ."""
+        df = st.as_data_op(10)
+        out, *_ = optimize((df + 2) + 3)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].type, NumericOpType.ADD)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 15)
+
+    def test_add_chain_negative_constant(self):
+        """(x + 5) + (-2)  →  x + 3."""
+        df = st.as_data_op(10)
+        out, *_ = optimize((df + 5) + (-2))
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[1].process("fit", [out[0].value]), 13)
+
+    def test_add_chain_then_add_zero_removes_op(self):
+        """(x + 2) + (-2)  →  x + 0  →  x: add_chain runs before add_zero."""
+        df = st.as_data_op(10)
+        out, *_ = optimize((df + 2) + (-2))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 10)
+
+    def test_add_chain_disabled(self):
+        """add_chain=False keeps both add ops."""
+        df = st.as_data_op(10)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(add_chain=False),
+        )
+        out, *_ = optimize((df + 2) + 3, config=config)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_single_add(self):
+        """A single x + 2 is left unchanged."""
+        df = st.as_data_op(10)
+        out, *_ = optimize(df + 2)
+        self.assertEqual(len(out), 2)
+
+    def test_no_rewrite_add_then_multiply(self):
+        """(x + 2) * 3 must not fuse (different op types)."""
+        df = st.as_data_op(10)
+        out, *_ = optimize((df + 2) * 3)
+        self.assertEqual(len(out), 3)
+
+    def test_no_rewrite_reversed_first_add(self):
+        """(2 + x) + 3 is not fused (reversed form)."""
+        df = st.as_data_op(10)
+        out, *_ = optimize((2 + df) + 3)
+        self.assertEqual(len(out), 3)
+
+    def test_add_chain_with_trailing_op(self):
+        """((x + 2) + 3) * 2  →  (x + 5) * 2, keeping the trailing multiply."""
+        df = st.as_data_op(10)
+        out, *_ = optimize(((df + 2) + 3) * 2)
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[1].type, NumericOpType.ADD)
+        self.assertEqual(out[2].process("fit", [out[1].process("fit", [out[0].value])]), 30)
+
+    def test_disable_add_chain_does_not_affect_log_exp(self):
+        """Disabling add_chain must not suppress other rewrites."""
+        df = st.as_data_op(1)
+        t1 = df.skb.apply_func(np.log)
+        t2 = t1.skb.apply_func(np.exp)
+        config = OptConfig(
+            algebraic_rewrites=True,
+            algebraic_rewrite_config=AlgebraicRewritesConfig(add_chain=False),
+        )
+        out, *_ = optimize(t2, config=config)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].value, 1)


### PR DESCRIPTION
- Add a rewrite that folds constant add-chains: (x + c1) + c2 → x + (c1 + c2). It uses a generalized matcher match_const_chain(type) that detects two consecutive var-const operations of the same type and a make_merge_const_chain(combine) action factory that merges the two constants into one node.
- Wire it into AlgebraicRewritesConfig under add_chain (default on), ordered before add_zero so that opposite constants like (x + 2) + (-2) first collapse to x + 0 and are then removed entirely.
- The matcher/action are factories over the op type and a combine function, so the same code also fuses (x * c1) * c2 → x * (c1 · c2) and the subtraction/division variants.
- Add tests: fires ((x+2)+3 → x+5), negative constant, the add_zero interaction ((x+2)+(-2) → x), disabled flag, single add untouched, (x+2)*3 not fused, reversed form not fused, trailing op, and no suppression of log/exp.